### PR TITLE
Align docs and CI with current entrypoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,42 @@ jobs:
         run: npm run build
         working-directory: web
 
+  system-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Install Dependencies
+        run: go mod download
+
+      - name: Start Postgres
+        run: docker compose up -d postgres
+
+      - name: Wait for Postgres
+        run: |
+          for i in {1..10}; do
+            if docker exec cloud-db pg_isready -U cloud -d thecloud; then
+              exit 0
+            fi
+            sleep 2
+          done
+          exit 1
+
+      - name: Build Binaries
+        run: make build
+
+      - name: Run System Tests
+        env:
+          DATABASE_URL: postgres://cloud:cloud@localhost:5433/thecloud?sslmode=disable
+        run: ./tests/system_test.sh
+
   build:
-    needs: [test, web]
+    needs: [test, web, system-tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,32 @@ jobs:
           DATABASE_URL: postgres://cloud:cloud@localhost:5433/thecloud?sslmode=disable
         run: go test -tags=integration -v ./internal/repositories/postgres/...
 
+  web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install Dependencies
+        run: npm ci
+        working-directory: web
+
+      - name: Lint
+        run: npm run lint
+        working-directory: web
+
+      - name: Build
+        run: npm run build
+        working-directory: web
+
   build:
-    needs: test
+    needs: [test, web]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing to The Cloud
+
+Thanks for taking the time to contribute! This guide keeps changes consistent and easy to review.
+
+## Quick Start
+- Fork and create a feature branch from `main`.
+- Keep changes scoped and focused.
+- Add or update tests when behavior changes.
+- Run checks before opening a PR:
+  - `go test ./...`
+  - `golangci-lint run` (or the CI lint job)
+  - `cd web && npm run lint && npm run build`
+
+## Pull Requests
+- Describe the problem and the approach.
+- Link related issues or docs.
+- Include screenshots or logs when relevant.
+- Avoid formatting-only changes unless necessary.
+
+## Code Style
+- Go: follow `gofmt` and project conventions.
+- Frontend: follow existing ESLint rules.
+- Keep configs and docs aligned with code changes.
+
+## Security
+If you find a security issue, please follow `SECURITY.md` instead of opening a public issue.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ migrate:
 	@echo "Running migrations..."
 	@docker compose up -d postgres
 	@sleep 2
-	@go run cmd/compute-api/main.go --migrate-only 2>/dev/null || echo "Migrations applied via server startup"
+	@go run cmd/api/main.go --migrate-only 2>/dev/null || echo "Migrations applied via server startup"
 
 migrate-status:
 	@echo "Checking migration status..."

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: run test test-coverage build migrate clean stop swagger
+.PHONY: run test test-coverage build migrate clean stop swagger lint web-lint web-build
 
 run: stop
 	docker compose up -d
@@ -22,6 +22,15 @@ build:
 	mkdir -p bin
 	go build -o bin/api cmd/api/main.go
 	go build -o bin/thecloud cmd/thecloud/*.go
+
+lint:
+	golangci-lint run
+
+web-lint:
+	cd web && npm run lint
+
+web-build:
+	cd web && npm run build
 
 install: build
 	mkdir -p $(HOME)/.local/bin

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ npm run dev
 | Doc | Description |
 |-----|-------------|
 | [Development Guide](docs/development.md) | Setup on Windows, Mac, or Linux |
+| [Testing Guide](docs/testing.md) | Unit, integration, and system test workflows |
 | [Roadmap](docs/roadmap.md) | Project phases and progress |
 | [Future Plans & Contributing](docs/future-plans.md) | How to contribute + feature backlog |
 | [Future Vision](docs/vision.md) | Long-term strategy and goals |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ To build the world's best open-source cloud platform that anyone can run, modify
 - **Storage**: S3-compatible object storage (Upload, Download, Delete)
 - **Block Storage**: Persistent volumes that survive instance termination
 - **Networking**: VPC with isolated Docker networks
-- **Networking**: VPC with isolated Docker networks
 - **Identity**: API Key authentication ([Guide](docs/guides/authentication.md))
 - **Observability**: Real-time CPU/Memory metrics and System Events
 - **Load Balancer**: Layer 7 HTTP traffic distribution
@@ -46,7 +45,7 @@ npm run dev
 ```
 
 ## 🏗️ Architecture
-- **Frontend**: Next.js 14, Tailwind CSS, GSAP
+- **Frontend**: Next.js 16, Tailwind CSS, GSAP
 - **Backend**: Go (Clean Architecture, Hexagonal)
 - **Database**: PostgreSQL (pgx)
 - **Infrastructure**: Docker Engine (Containers, Networks, Volumes)
@@ -62,6 +61,12 @@ npm run dev
 | [Roadmap](docs/roadmap.md) | Project phases and progress |
 | [Future Plans & Contributing](docs/future-plans.md) | How to contribute + feature backlog |
 | [Future Vision](docs/vision.md) | Long-term strategy and goals |
+
+### 🤝 Community
+| Doc | Description |
+|-----|-------------|
+| [Contributing Guide](CONTRIBUTING.md) | How to propose changes and run checks |
+| [Security Policy](SECURITY.md) | How to report vulnerabilities |
 
 ### 🏛️ Architecture & Services
 | Doc | Description |
@@ -79,7 +84,7 @@ npm run dev
 | [Networking](docs/guides/networking.md) | VPCs and Network isolation |
 | [Storage](docs/guides/storage.md) | Object and Block storage |
 
-## �📊 KPIs
+## 📊 KPIs
 - Time to Hello World: < 5 min
 - API Latency (P95): < 200ms
 - CLI Success Rate: > 95%

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+Please report security issues privately to maintainers instead of opening public issues.
+
+Email: security@thecloud.local
+
+Include:
+- A clear description of the issue
+- Steps to reproduce
+- Impact and affected versions (if known)
+
+We aim to acknowledge reports within 5 business days.

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -306,7 +306,7 @@ func main() {
 
 	// 7. Graceful Shutdown
 	go func() {
-		logger.Info("starting compute-api", "port", cfg.Port)
+		logger.Info("starting api", "port", cfg.Port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			logger.Error("failed to start server", "error", err)
 			os.Exit(1)

--- a/cmd/thecloud/auth.go
+++ b/cmd/thecloud/auth.go
@@ -25,12 +25,15 @@ var createDemoCmd = &cobra.Command{
 		key, err := client.CreateKey(name)
 
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[INFO] Generated Key: %s\n", key)
 		saveConfig(key)
+		if outputJSON {
+			printJSON(map[string]string{"api_key": key})
+			return
+		}
+		fmt.Printf("[INFO] Generated Key: %s\n", key)
 		fmt.Println("[SUCCESS] Key saved to configuration. You can now use 'cloud' commands without flags.")
 	},
 }
@@ -42,6 +45,10 @@ var loginCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		key := args[0]
 		saveConfig(key)
+		if outputJSON {
+			printJSON(map[string]string{"api_key": key})
+			return
+		}
 		fmt.Println("[SUCCESS] Key saved to configuration.")
 	},
 }

--- a/cmd/thecloud/autoscaling.go
+++ b/cmd/thecloud/autoscaling.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -46,13 +45,11 @@ var asgCreateCmd = &cobra.Command{
 
 		group, err := client.CreateScalingGroup(req)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			printError(err)
 		}
 
 		if outputJSON {
-			data, _ := json.MarshalIndent(group, "", "  ")
-			fmt.Println(string(data))
+			printJSON(group)
 			return
 		}
 
@@ -67,13 +64,11 @@ var asgListCmd = &cobra.Command{
 		client := getClient()
 		groups, err := client.ListScalingGroups()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			printError(err)
 		}
 
 		if outputJSON {
-			data, _ := json.MarshalIndent(groups, "", "  ")
-			fmt.Println(string(data))
+			printJSON(groups)
 			return
 		}
 
@@ -95,10 +90,9 @@ var asgRmCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		if err := client.DeleteScalingGroup(args[0]); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			printError(err)
 		}
-		fmt.Println("[SUCCESS] Scaling Group deleted")
+		printStatus("[SUCCESS] Scaling Group deleted")
 	},
 }
 
@@ -125,10 +119,9 @@ var asgPolicyAddCmd = &cobra.Command{
 		}
 
 		if err := client.CreateScalingPolicy(args[0], req); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			os.Exit(1)
+			printError(err)
 		}
-		fmt.Println("[SUCCESS] Policy added")
+		printStatus("[SUCCESS] Policy added")
 	},
 }
 

--- a/cmd/thecloud/cli_helpers.go
+++ b/cmd/thecloud/cli_helpers.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func printJSON(v any) {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(data))
+}
+
+func printError(err error) {
+	fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+	os.Exit(1)
+}
+
+func printStatus(message string) {
+	if outputJSON {
+		printJSON(map[string]string{
+			"status":  "ok",
+			"message": message,
+		})
+		return
+	}
+	fmt.Println(message)
+}
+
+func printDataOrStatus(data any, message string) {
+	if outputJSON {
+		printJSON(data)
+		return
+	}
+	if message != "" {
+		fmt.Println(message)
+	}
+}

--- a/cmd/thecloud/events.go
+++ b/cmd/thecloud/events.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"time"
@@ -22,13 +21,11 @@ var listEventsCmd = &cobra.Command{
 		client := getClient()
 		events, err := client.ListEvents()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
 		if outputJSON {
-			data, _ := json.MarshalIndent(events, "", "  ")
-			fmt.Println(string(data))
+			printJSON(events)
 			return
 		}
 

--- a/cmd/thecloud/loadbalancer.go
+++ b/cmd/thecloud/loadbalancer.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -21,13 +20,11 @@ var lbListCmd = &cobra.Command{
 		client := getClient()
 		lbs, err := client.ListLBs()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
 		if outputJSON {
-			data, _ := json.MarshalIndent(lbs, "", "  ")
-			fmt.Println(string(data))
+			printJSON(lbs)
 			return
 		}
 
@@ -60,13 +57,14 @@ var lbCreateCmd = &cobra.Command{
 		client := getClient()
 		lb, err := client.CreateLB(name, vpcID, port, algo)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] Load Balancer %s creation initiated!\n", lb.Name)
-		fmt.Printf("ID: %s\n", lb.ID)
-		fmt.Printf("Status: %s (It will be ACTIVE shortly)\n", lb.Status)
+		printDataOrStatus(lb, fmt.Sprintf("[SUCCESS] Load Balancer %s creation initiated!", lb.Name))
+		if !outputJSON {
+			fmt.Printf("ID: %s\n", lb.ID)
+			fmt.Printf("Status: %s (It will be ACTIVE shortly)\n", lb.Status)
+		}
 	},
 }
 
@@ -78,11 +76,10 @@ var lbRmCmd = &cobra.Command{
 		id := args[0]
 		client := getClient()
 		if err := client.DeleteLB(id); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] Load Balancer %s deletion initiated.\n", id)
+		printStatus(fmt.Sprintf("[SUCCESS] Load Balancer %s deletion initiated.", id))
 	},
 }
 
@@ -98,11 +95,10 @@ var lbAddTargetCmd = &cobra.Command{
 
 		client := getClient()
 		if err := client.AddLBTarget(lbID, instID, port, weight); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] Target %s added to LB %s.\n", instID, lbID)
+		printStatus(fmt.Sprintf("[SUCCESS] Target %s added to LB %s.", instID, lbID))
 	},
 }
 
@@ -115,11 +111,10 @@ var lbRemoveTargetCmd = &cobra.Command{
 		instID := args[1]
 		client := getClient()
 		if err := client.RemoveLBTarget(lbID, instID); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] Target %s removed from LB %s.\n", instID, lbID)
+		printStatus(fmt.Sprintf("[SUCCESS] Target %s removed from LB %s.", instID, lbID))
 	},
 }
 
@@ -153,13 +148,11 @@ var lbListTargetsCmd = &cobra.Command{
 		client := getClient()
 		targets, err := client.ListLBTargets(args[0])
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
 		if outputJSON {
-			data, _ := json.MarshalIndent(targets, "", "  ")
-			fmt.Println(string(data))
+			printJSON(targets)
 			return
 		}
 

--- a/cmd/thecloud/storage.go
+++ b/cmd/thecloud/storage.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -25,13 +24,11 @@ var storageListCmd = &cobra.Command{
 		client := getClient()
 		objects, err := client.ListObjects(bucket)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
 		if outputJSON {
-			data, _ := json.MarshalIndent(objects, "", "  ")
-			fmt.Println(string(data))
+			printJSON(objects)
 			return
 		}
 
@@ -71,11 +68,10 @@ var storageUploadCmd = &cobra.Command{
 
 		client := getClient()
 		if err := client.UploadObject(bucket, key, f); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] Uploaded %s to bucket %s\n", key, bucket)
+		printStatus(fmt.Sprintf("[SUCCESS] Uploaded %s to bucket %s", key, bucket))
 	},
 }
 
@@ -91,25 +87,22 @@ var storageDownloadCmd = &cobra.Command{
 		client := getClient()
 		body, err := client.DownloadObject(bucket, key)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 		defer body.Close()
 
 		out, err := os.Create(dest)
 		if err != nil {
-			fmt.Printf("Error creating destination file: %v\n", err)
-			return
+			printError(err)
 		}
 		defer out.Close()
 
 		_, err = io.Copy(out, body)
 		if err != nil {
-			fmt.Printf("Error writing file: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] Downloaded %s to %s\n", key, dest)
+		printStatus(fmt.Sprintf("[SUCCESS] Downloaded %s to %s", key, dest))
 	},
 }
 
@@ -123,11 +116,10 @@ var storageDeleteCmd = &cobra.Command{
 
 		client := getClient()
 		if err := client.DeleteObject(bucket, key); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] Deleted %s from bucket %s\n", key, bucket)
+		printStatus(fmt.Sprintf("[SUCCESS] Deleted %s from bucket %s", key, bucket))
 	},
 }
 

--- a/cmd/thecloud/volume.go
+++ b/cmd/thecloud/volume.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -21,13 +20,11 @@ var volumeListCmd = &cobra.Command{
 		client := getClient()
 		volumes, err := client.ListVolumes()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
 		if outputJSON {
-			data, _ := json.MarshalIndent(volumes, "", "  ")
-			fmt.Println(string(data))
+			printJSON(volumes)
 			return
 		}
 
@@ -65,13 +62,10 @@ var volumeCreateCmd = &cobra.Command{
 		client := getClient()
 		vol, err := client.CreateVolume(name, size)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] Volume created!\n")
-		data, _ := json.MarshalIndent(vol, "", "  ")
-		fmt.Println(string(data))
+		printDataOrStatus(vol, "[SUCCESS] Volume created!")
 	},
 }
 
@@ -83,10 +77,9 @@ var volumeDeleteCmd = &cobra.Command{
 		id := args[0]
 		client := getClient()
 		if err := client.DeleteVolume(id); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
-		fmt.Printf("[SUCCESS] Volume %s deleted.\n", id)
+		printStatus(fmt.Sprintf("[SUCCESS] Volume %s deleted.", id))
 	},
 }
 

--- a/cmd/thecloud/vpc.go
+++ b/cmd/thecloud/vpc.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -21,13 +20,11 @@ var vpcListCmd = &cobra.Command{
 		client := getClient()
 		vpcs, err := client.ListVPCs()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
 		if outputJSON {
-			data, _ := json.MarshalIndent(vpcs, "", "  ")
-			fmt.Println(string(data))
+			printJSON(vpcs)
 			return
 		}
 
@@ -55,13 +52,14 @@ var vpcCreateCmd = &cobra.Command{
 		client := getClient()
 		vpc, err := client.CreateVPC(name)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] VPC %s created successfully!\n", vpc.Name)
-		fmt.Printf("ID: %s\n", vpc.ID)
-		fmt.Printf("Network ID: %s\n", vpc.NetworkID)
+		printDataOrStatus(vpc, fmt.Sprintf("[SUCCESS] VPC %s created successfully!", vpc.Name))
+		if !outputJSON {
+			fmt.Printf("ID: %s\n", vpc.ID)
+			fmt.Printf("Network ID: %s\n", vpc.NetworkID)
+		}
 	},
 }
 
@@ -73,11 +71,10 @@ var vpcRmCmd = &cobra.Command{
 		id := args[0]
 		client := getClient()
 		if err := client.DeleteVPC(id); err != nil {
-			fmt.Printf("Error: %v\n", err)
-			return
+			printError(err)
 		}
 
-		fmt.Printf("[SUCCESS] VPC %s removed successfully.\n", id)
+		printStatus(fmt.Sprintf("[SUCCESS] VPC %s removed successfully.", id))
 	},
 }
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -42,7 +42,7 @@ Every function in the Service and Repository layers MUST accept `context.Context
 3.  **Implement Repository**: Add code to `internal/repositories/<adapter>/`.
 4.  **Implement Service**: Add business rules to `internal/core/services/`.
 5.  **Expose Handler**: Add Gin route in `internal/handlers/`.
-6.  **Wire up**: Update `cmd/compute-api/main.go`.
+6.  **Wire up**: Update `cmd/api/main.go`.
 
 ## Testing
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -108,7 +108,7 @@ CREATE TABLE metrics_history (
 - **Execution**: Migrations run automatically on API startup.
 - **CI/CD / Manual**: Use the `-migrate-only` flag to run migrations and exit:
   ```bash
-  go run cmd/compute-api/main.go -migrate-only
+  go run cmd/api/main.go -migrate-only
   ```
 
 ## Connection Details

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ Welcome to the **The Cloud** operational manual. This guide will help you set up
 2.  **Environment Variables**:
     Create a `.env` file in the root directory:
     ```bash
-    echo "DATABASE_URL=postgres://cloud:password@localhost:5432/thecloud" > .env
+    echo "DATABASE_URL=postgres://cloud:cloud@localhost:5433/thecloud" > .env
     ```
 
 ### 3. Running the Project
@@ -77,7 +77,7 @@ The `Makefile` works natively on macOS.
 2.  **Environment Variables**:
     Create a `.env` file manually or via PowerShell:
     ```powershell
-    Set-Content .env "DATABASE_URL=postgres://cloud:password@localhost:5432/thecloud"
+    Set-Content .env "DATABASE_URL=postgres://cloud:cloud@localhost:5433/thecloud"
     ```
 
 ### 3. Running the Project (Manual / PowerShell)

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,7 +11,7 @@ Welcome to the **The Cloud** operational manual. This guide will help you set up
   ```bash
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   ```
-- **Go (Golang)**: Version 1.25 or higher.
+- **Go (Golang)**: Version 1.24 or higher.
   ```bash
   brew install go
   ```
@@ -90,14 +90,13 @@ If you don't have `make`, run these commands:
 
 - **Run API**:
   ```powershell
-  go run cmd/compute-api/main.go
+  go run cmd/api/main.go
   ```
 
 - **Build CLI (PowerShell)**:
   ```powershell
   mkdir bin
-  go build -o bin/cloud.exe cmd/cloud-cli/main.go
-  go build -o bin/cloud2.exe cmd/cloud_cli/main.go
+  go build -o bin/thecloud.exe cmd/thecloud/*.go
   ```
 
 ### 🛑 Common Windows Issues

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -19,9 +19,12 @@ The "Compute" service acts as a hypervisor. Instead of launching VMs (KVM/QEMU),
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PORT` | API Server Port | `:8080` |
-| `DB_DSN` | Postgres Connection String | `host=localhost ...` |
-| `GODAEMON` | (Internal) Docker Socket | `/var/run/docker.sock` |
+| `PORT` | API Server Port | `8080` |
+| `DATABASE_URL` | Postgres Connection String | `postgres://cloud:cloud@localhost:5433/thecloud` |
+| `DB_USER` | Postgres Username | `cloud` |
+| `DB_PASSWORD` | Postgres Password | `cloud` |
+| `DB_NAME` | Postgres Database | `thecloud` |
+| `DOCKER_HOST` | Docker Socket | `unix:///var/run/docker.sock` |
 
 ## Deployment Strategy
 

--- a/docs/infrastructure.md
+++ b/docs/infrastructure.md
@@ -28,10 +28,10 @@ The "Compute" service acts as a hypervisor. Instead of launching VMs (KVM/QEMU),
 ### Docker Compose
 We use `docker-compose.yml` to orchestrate the control plane.
 - **Service**: `postgres` (State)
-- **Service**: `compute-api` (Logic)
+- **Service**: `api` (Logic)
 
 ### Mounting the Socket
-To let the `compute-api` container launch *sibling* containers, we mount the host Docker socket:
+To let the `api` container launch *sibling* containers, we mount the host Docker socket:
 ```yaml
 volumes:
   - /var/run/docker.sock:/var/run/docker.sock

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,42 @@
+# Testing Guide
+
+This document describes how to run tests locally and what each suite covers.
+
+## Unit Tests (Go)
+Run all unit tests:
+```bash
+go test ./...
+```
+
+## Integration Tests (Go)
+Some packages use the `integration` build tag.
+```bash
+go test -tags=integration -v ./internal/repositories/postgres/...
+```
+
+## System Tests (CLI + API)
+The system test runs the API and exercises the CLI against it.
+
+Prerequisites:
+- Docker running
+- PostgreSQL running locally via Docker Compose
+
+Steps:
+```bash
+docker compose up -d postgres
+make build
+DATABASE_URL=postgres://cloud:cloud@localhost:5433/thecloud ./tests/system_test.sh
+```
+
+## E2E Multi-Tenancy Test
+The E2E test expects a running API at `http://localhost:8080`.
+
+Steps:
+```bash
+docker compose up -d postgres
+go run cmd/api/main.go
+```
+Then, in another terminal:
+```bash
+go test -tags=e2e ./tests/...
+```

--- a/tests/system_test.sh
+++ b/tests/system_test.sh
@@ -10,7 +10,11 @@ echo -e "${BLUE}Starting System Test for The Cloud...${NC}"
 
 # 1. Start API in background
 echo "Restarting API..."
-fuser -k 8080/tcp || true
+if command -v fuser >/dev/null 2>&1; then
+  fuser -k 8080/tcp || true
+else
+  lsof -ti tcp:8080 | xargs -r kill || true
+fi
 nohup ./bin/api > test_api.log 2>&1 &
 API_PID=$!
 sleep 2

--- a/tests/system_test.sh
+++ b/tests/system_test.sh
@@ -11,7 +11,7 @@ echo -e "${BLUE}Starting System Test for The Cloud...${NC}"
 # 1. Start API in background
 echo "Restarting API..."
 fuser -k 8080/tcp || true
-nohup ./bin/compute-api > test_api.log 2>&1 &
+nohup ./bin/api > test_api.log 2>&1 &
 API_PID=$!
 sleep 2
 
@@ -31,12 +31,12 @@ echo "Using Test Name: $TEST_NAME, Port: $TEST_PORT"
 
 # 3. Launch Instance
 echo -e "${BLUE}Testing 'cloud compute launch'...${NC}"
-./bin/cloud compute launch --name $TEST_NAME --image nginx:alpine --port $TEST_PORT:80
+./bin/thecloud compute launch --name $TEST_NAME --image nginx:alpine --port $TEST_PORT:80
 sleep 2
 
 # 4. List Instances
 echo -e "${BLUE}Testing 'cloud compute list'...${NC}"
-./bin/cloud compute list | grep $TEST_NAME
+./bin/thecloud compute list | grep $TEST_NAME
 
 # 5. Check Connectivity (Integration check)
 echo -e "${BLUE}Testing Connectivity to Nginx...${NC}"
@@ -44,22 +44,22 @@ curl -s --retry 5 --retry-delay 1 localhost:$TEST_PORT | grep "Welcome to nginx"
 
 # 6. Show Details
 echo -e "${BLUE}Testing 'cloud compute show'...${NC}"
-./bin/cloud compute show $TEST_NAME | grep "Status:.*RUNNING"
+./bin/thecloud compute show $TEST_NAME | grep "Status:.*RUNNING"
 
 # 7. Get Logs
 echo -e "${BLUE}Testing 'cloud compute logs'...${NC}"
-./bin/cloud compute logs $TEST_NAME | head -n 20
+./bin/thecloud compute logs $TEST_NAME | head -n 20
 
 # 8. Stop Instance
 echo -e "${BLUE}Testing 'cloud compute stop'...${NC}"
-./bin/cloud compute stop $TEST_NAME
+./bin/thecloud compute stop $TEST_NAME
 sleep 1
-./bin/cloud compute list | grep $TEST_NAME | grep "STOPPED"
+./bin/thecloud compute list | grep $TEST_NAME | grep "STOPPED"
 
 # 9. Remove Instance
 echo -e "${BLUE}Testing 'cloud compute rm'...${NC}"
-./bin/cloud compute rm $TEST_NAME
+./bin/thecloud compute rm $TEST_NAME
 sleep 1
-! ./bin/cloud compute list | grep -q $TEST_NAME
+! ./bin/thecloud compute list | grep -q $TEST_NAME
 
 echo -e "${GREEN}[SUCCESS] System Test Passed!${NC}"


### PR DESCRIPTION
What’s changing

Align docs, scripts, and logging with current API/CLI entrypoints.
Add frontend CI job for lint/build.
Add CONTRIBUTING and SECURITY docs.
Tidy README duplication and KPI header.
Why

Reduce onboarding friction and doc/code drift.
Catch frontend regressions in CI.
Provide standard OSS contribution and security guidance.
