### PR TITLE
feat: implement security groups with full CLI, tracing, and auditing

### DIFF
--- a/.agent/workflows/vision.md
+++ b/.agent/workflows/vision.md
@@ -1,0 +1,185 @@
+---
+description: Strategic planning for cloud vision, architecture, and future feature ideation
+---
+# Cloud Vision & Architecture Brainstorming
+
+Use this workflow to think strategically about The Cloud's future direction, generate feature ideas, and explore architectural improvements.
+
+## Context
+- **Project Type**: Open-source cloud platform (potential startup or portfolio showcase)
+- **Goals**: Learn cloud engineering deeply, build production-grade infrastructure
+- **Philosophy**: Build > Consume. We implement ourselves before wrapping third-party services.
+
+---
+
+## Step 1: Review Current State
+
+Before ideating, understand where we are:
+
+```bash
+# View project stats
+wc -l $(find internal -name "*.go" | head -100) | tail -1
+```
+
+**Manual Review:**
+- [ ] What services do we have today?
+- [ ] What's our test coverage?
+- [ ] What's working well?
+- [ ] What's fragile or needs refactoring?
+
+---
+
+## Step 2: Competitive Analysis Questions
+
+Think about major cloud providers:
+
+| Provider | Notable Feature | Can We Learn From It? |
+|----------|-----------------|----------------------|
+| AWS | Lambda, S3, EC2 | Serverless, object storage |
+| GCP | BigQuery, GKE | Data analytics, K8s integration |
+| Azure | Active Directory | Identity federation |
+| DigitalOcean | Simplicity | Developer experience |
+| Vercel | Edge functions | CDN and instant deploys |
+
+**Ask yourself:**
+1. What's the simplest feature AWS has that we don't?
+2. What would make a developer choose TheCloud over AWS for a side project?
+3. What's the "10x better" experience we could offer?
+
+---
+
+## Step 3: Feature Categories to Explore
+
+### Compute Evolution
+- [ ] **Kubernetes Integration**: Deploy K8s clusters as a service
+- [ ] **GPU Instances**: ML workload support
+- [ ] **Spot/Preemptible Instances**: Cost-effective ephemeral compute
+- [ ] **Edge Computing**: Deploy containers to edge locations
+
+### Networking Advancement
+- [ ] **Service Mesh**: Istio-like traffic management
+- [ ] **Global Load Balancing**: Multi-region traffic routing
+- [ ] **Private Link**: Secure service-to-service connectivity
+- [ ] **DNS as a Service**: Managed DNS zones
+
+### Storage & Data
+- [ ] **Managed Kafka**: Event streaming
+- [ ] **Time-Series DB**: Infrastructure metrics storage
+- [ ] **Data Lake / Object Analytics**: S3 Select equivalent
+- [ ] **Backup & Disaster Recovery**: Cross-region replication
+
+### Developer Experience
+- [ ] **CLI Autocomplete**: Smart tab completion
+- [ ] **Terraform Provider**: Infrastructure as Code
+- [ ] **GitHub Integration**: Deploy on push
+- [ ] **Cost Calculator**: Estimate resource costs
+
+### Security & Compliance
+- [ ] **IAM Policies**: Fine-grained permission policies
+- [ ] **Audit Logs v2**: Searchable, exportable logs
+- [ ] **Compliance Dashboard**: SOC2/GDPR readiness
+- [ ] **Secret Rotation**: Automatic credential cycling
+
+### Observability
+- [ ] **Distributed Tracing**: Jaeger/Zipkin integration
+- [ ] **Log Aggregation**: Centralized log search
+- [ ] **Alerting Rules**: Threshold-based notifications
+- [ ] **SLO/SLI Tracking**: Reliability engineering
+
+---
+
+## Step 4: Prioritization Framework
+
+Score each idea (1-5) on these dimensions:
+
+| Dimension | Weight | Question |
+|-----------|--------|----------|
+| **Learning Value** | 5 | How much will we learn from building this? |
+| **User Impact** | 4 | How valuable is this to cloud users? |
+| **Differentiator** | 4 | Does this make us unique? |
+| **Feasibility** | 3 | Can we build this in 2-4 weeks? |
+| **Portfolio Value** | 3 | Does this impress potential employers/investors? |
+
+**Example Scoring:**
+```
+Feature: Kubernetes as a Service
+Learning: 5 (massive)
+User Impact: 5 (everyone wants K8s)
+Differentiator: 3 (others have it)
+Feasibility: 2 (complex)
+Portfolio: 5 (impressive)
+Total: 20 * weights = HIGH PRIORITY
+```
+
+---
+
+## Step 5: Architecture Decision Record (ADR)
+
+For any major feature, draft an ADR:
+
+```markdown
+# ADR-XXX: [Feature Name]
+
+## Status
+Proposed | Accepted | Deprecated
+
+## Context
+Why are we considering this?
+
+## Decision
+What will we build? High-level approach.
+
+## Consequences
+### Positive
+- Learning gains
+- User benefits
+
+### Negative
+- Complexity added
+- Maintenance burden
+
+### Risks
+- What could go wrong?
+```
+
+---
+
+## Step 6: Document Your Ideas
+
+After brainstorming, document in one of these locations:
+
+1. **docs/ROADMAP.md** - For features we'll definitely build
+2. **docs/adr/** - For architectural decisions
+3. **docs/vision.md** - For long-term strategy
+4. **GitHub Issues** - For trackable work items
+
+---
+
+## Recurring Reflection Questions
+
+Ask monthly:
+
+1. **What's the ONE feature that would 10x our user value?**
+2. **What part of our stack would break first at 1000 users?**
+3. **What would make a Fortune 500 company consider us?**
+4. **What would make a solo developer love us?**
+5. **What's the most educational thing we could build next?**
+
+---
+
+## Inspiration Sources
+
+- [AWS Whitepapers](https://aws.amazon.com/whitepapers/)
+- [Google SRE Book](https://sre.google/sre-book/table-of-contents/)
+- [CNCF Landscape](https://landscape.cncf.io/)
+- [Martin Fowler's Blog](https://martinfowler.com/)
+- [The Twelve-Factor App](https://12factor.net/)
+
+---
+
+## Output
+
+After running this workflow, you should have:
+- [ ] 3-5 prioritized feature ideas
+- [ ] At least 1 ADR draft
+- [ ] Updated ROADMAP.md with next quarter goals

--- a/cmd/cloud/cron.go
+++ b/cmd/cloud/cron.go
@@ -24,7 +24,7 @@ var createCronCmd = &cobra.Command{
 		client := getClient()
 		job, err := client.CreateCronJob(args[0], args[1], args[2], method, payload)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 
@@ -40,7 +40,7 @@ var listCronCmd = &cobra.Command{
 		client := getClient()
 		jobs, err := client.ListCronJobs()
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 
@@ -61,7 +61,7 @@ var pauseCronCmd = &cobra.Command{
 		client := getClient()
 		err := client.PauseCronJob(args[0])
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 		fmt.Println("[SUCCESS] Job paused")
@@ -76,7 +76,7 @@ var resumeCronCmd = &cobra.Command{
 		client := getClient()
 		err := client.ResumeCronJob(args[0])
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 		fmt.Println("[SUCCESS] Job resumed")
@@ -91,7 +91,7 @@ var deleteCronCmd = &cobra.Command{
 		client := getClient()
 		err := client.DeleteCronJob(args[0])
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 		fmt.Println("[SUCCESS] Job deleted")

--- a/cmd/cloud/instance_test.go
+++ b/cmd/cloud/instance_test.go
@@ -153,6 +153,8 @@ func TestInstanceCmdHasSubcommands(t *testing.T) {
 	}
 }
 
+const portMapping = "8080:80"
+
 func TestFormatAccessPorts(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -168,19 +170,19 @@ func TestFormatAccessPorts(t *testing.T) {
 		},
 		{
 			name:     "stopped instance",
-			ports:    "8080:80",
+			ports:    portMapping,
 			status:   "STOPPED",
 			expected: "-",
 		},
 		{
 			name:     "single port mapping",
-			ports:    "8080:80",
+			ports:    portMapping,
 			status:   "RUNNING",
 			expected: "localhost:8080->80",
 		},
 		{
 			name:     "multiple port mappings",
-			ports:    "8080:80,8443:443",
+			ports:    portMapping + ",8443:443",
 			status:   "RUNNING",
 			expected: "localhost:8080->80, localhost:8443->443",
 		},
@@ -246,7 +248,7 @@ func TestJSONMarshalIndent(t *testing.T) {
 		Name:   "test-instance",
 		Image:  "alpine",
 		Status: "RUNNING",
-		Ports:  "8080:80",
+		Ports:  portMapping,
 	}
 
 	data, err := json.MarshalIndent(inst, "", "  ")

--- a/cmd/cloud/sg.go
+++ b/cmd/cloud/sg.go
@@ -195,7 +195,7 @@ var sgGetCmd = &cobra.Command{
 				ports = fmt.Sprintf("%d", r.PortMin)
 			}
 			table.Append([]string{
-				r.ID[:8],
+				truncateID(r.ID, 8),
 				r.Direction,
 				r.Protocol,
 				ports,
@@ -236,4 +236,11 @@ func init() {
 
 	sgCmd.AddCommand(sgCreateCmd, sgListCmd, sgGetCmd, sgDeleteCmd, sgAddRuleCmd, sgRemoveRuleCmd, sgAttachCmd, sgDetachCmd)
 	rootCmd.AddCommand(sgCmd)
+}
+
+func truncateID(id string, n int) string {
+	if len(id) <= n {
+		return id
+	}
+	return id[:n]
 }

--- a/cmd/cloud/sg.go
+++ b/cmd/cloud/sg.go
@@ -139,6 +139,34 @@ func init() {
 	sgAddRuleCmd.Flags().String("cidr", "0.0.0.0/0", "CIDR block")
 	sgAddRuleCmd.Flags().Int("priority", 100, "Priority")
 
-	sgCmd.AddCommand(sgCreateCmd, sgListCmd, sgAddRuleCmd, sgAttachCmd)
+	sgCmd.AddCommand(sgCreateCmd, sgListCmd, sgAddRuleCmd, sgRemoveRuleCmd, sgAttachCmd, sgDetachCmd)
 	rootCmd.AddCommand(sgCmd)
+}
+
+var sgRemoveRuleCmd = &cobra.Command{
+	Use:   "remove-rule [rule-id]",
+	Short: "Remove a rule from a security group",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getClient()
+		if err := client.RemoveSecurityRule(args[0]); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+		fmt.Printf("[SUCCESS] Rule %s removed successfully.\n", args[0])
+	},
+}
+
+var sgDetachCmd = &cobra.Command{
+	Use:   "detach [instance-id] [sg-id]",
+	Short: "Detach a security group from an instance",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getClient()
+		if err := client.DetachSecurityGroup(args[0], args[1]); err != nil {
+			fmt.Printf("Error: %v\n", err)
+			return
+		}
+		fmt.Printf("[SUCCESS] Security Group %s detached from instance %s successfully.\n", args[1], args[0])
+	},
 }

--- a/cmd/cloud/sg_test.go
+++ b/cmd/cloud/sg_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestSGCommands(t *testing.T) {
+	if sgCmd == nil {
+		t.Fatal("sgCmd is nil")
+	}
+	if !sgCmd.HasSubCommands() {
+		t.Fatal("sgCmd should have subcommands")
+	}
+
+	subs := map[string][]string{
+		"create":      {"vpc-id", "description"},
+		"list":        {"vpc-id"},
+		"get":         {},
+		"delete":      {},
+		"add-rule":    {"direction", "protocol", "port-min", "port-max", "cidr", "priority"},
+		"remove-rule": {},
+		"attach":      {},
+		"detach":      {},
+	}
+
+	for cmdName, flags := range subs {
+		var sub *cobra.Command
+		for _, c := range sgCmd.Commands() {
+			if c.Name() == cmdName {
+				sub = c
+				break
+			}
+		}
+		if sub == nil {
+			t.Errorf("sgCmd should have subcommand %q", cmdName)
+			continue
+		}
+
+		for _, flag := range flags {
+			if sub.Flag(flag) == nil {
+				t.Errorf("subcommand %q should have flag %q", cmdName, flag)
+			}
+		}
+	}
+}

--- a/cmd/cloud/storage.go
+++ b/cmd/cloud/storage.go
@@ -25,7 +25,7 @@ var storageListCmd = &cobra.Command{
 		client := getClient()
 		objects, err := client.ListObjects(bucket)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 
@@ -91,7 +91,7 @@ var storageDownloadCmd = &cobra.Command{
 		client := getClient()
 		body, err := client.DownloadObject(bucket, key)
 		if err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 		defer func() { _ = body.Close() }()

--- a/cmd/cloud/storage.go
+++ b/cmd/cloud/storage.go
@@ -71,7 +71,7 @@ var storageUploadCmd = &cobra.Command{
 
 		client := getClient()
 		if err := client.UploadObject(bucket, key, f); err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 
@@ -123,7 +123,7 @@ var storageDeleteCmd = &cobra.Command{
 
 		client := getClient()
 		if err := client.DeleteObject(bucket, key); err != nil {
-			fmt.Printf("Error: %v\n", err)
+			fmt.Printf(errFmt, err)
 			return
 		}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,8 +53,8 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
-    # ports:
-    #   - "${PORT:-8080}:${PORT:-8080}" # Will be handled by LB or individual replicas
+    ports:
+      - "${PORT:-8080}:${PORT:-8080}"
     cap_add:
       - NET_ADMIN
       - NET_RAW

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -212,6 +212,66 @@ Delete a VPC.
 
 ---
 
+## Security Groups
+
+**Headers Required:** `X-API-Key: <your-api-key>`
+
+### GET /security-groups
+List all security groups.
+Query params: `?vpc_id=<vpc-uuid>` (required)
+
+### POST /security-groups
+Create a new security group.
+```json
+{
+  "vpc_id": "vpc-uuid",
+  "name": "web-tier",
+  "description": "Port 80 and 443 allowed"
+}
+```
+
+### GET /security-groups/:id
+Get details and rules for a security group.
+
+### DELETE /security-groups/:id
+Delete a security group.
+
+### POST /security-groups/:id/rules
+Add a firewall rule.
+```json
+{
+  "direction": "ingress",
+  "protocol": "tcp",
+  "port_min": 80,
+  "port_max": 80,
+  "cidr": "0.0.0.0/0",
+  "priority": 100
+}
+```
+
+### DELETE /security-groups/rules/:rule_id
+Remove a firewall rule.
+
+### POST /security-groups/attach
+Attach a security group to an instance.
+```json
+{
+  "instance_id": "inst-uuid",
+  "group_id": "sg-uuid"
+}
+```
+
+### POST /security-groups/detach
+Detach a security group from an instance.
+```json
+{
+  "instance_id": "inst-uuid",
+  "group_id": "sg-uuid"
+}
+```
+
+---
+
 ## Subnets
 
 **Headers Required:** `X-API-Key: <your-api-key>`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -379,12 +379,28 @@ List all security groups.
 cloud sg list --vpc my-network
 ```
 
+### `sg get [sg-id]`
+
+Get detailed information and rules for a security group.
+
+```bash
+cloud sg get my-sg
+```
+
 ### `sg create`
 
 Create a new security group.
 
 ```bash
 cloud sg create my-sg --vpc my-network --description "Web servers"
+```
+
+### `sg delete [sg-id]`
+
+Delete a security group.
+
+```bash
+cloud sg delete my-sg
 ```
 
 ### `sg add-rule <sg-id>`
@@ -396,6 +412,7 @@ cloud sg add-rule my-sg --protocol tcp --port-min 80 --port-max 80 --cidr 0.0.0.
 ```
 
 **Flags**:
+
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--direction` | `ingress` | Direction (ingress/egress) |

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -367,6 +367,70 @@ cloud subnet rm my-private-subnet --vpc my-network
 
 ---
 
+## Security Group Commands
+
+Manage network security groups (firewall rules).
+
+### `sg list`
+
+List all security groups.
+
+```bash
+cloud sg list --vpc my-network
+```
+
+### `sg create`
+
+Create a new security group.
+
+```bash
+cloud sg create my-sg --vpc my-network --description "Web servers"
+```
+
+### `sg add-rule <sg-id>`
+
+Add a rule to a security group.
+
+```bash
+cloud sg add-rule my-sg --protocol tcp --port-min 80 --port-max 80 --cidr 0.0.0.0/0
+```
+
+**Flags**:
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--direction` | `ingress` | Direction (ingress/egress) |
+| `--protocol` | `tcp` | Protocol (tcp/udp/icmp/all) |
+| `--port-min` | `0` | Minimum port |
+| `--port-max` | `0` | Maximum port |
+| `--cidr` | `0.0.0.0/0` | CIDR block |
+| `--priority` | `100` | Rule priority |
+
+### `sg remove-rule <rule-id>`
+
+Remove a rule from a security group.
+
+```bash
+cloud sg remove-rule rule-1234
+```
+
+### `sg attach <instance-id> <sg-id>`
+
+Attach a security group to an instance.
+
+```bash
+cloud sg attach my-server my-sg
+```
+
+### `sg detach <instance-id> <sg-id>`
+
+Detach a security group from an instance.
+
+```bash
+cloud sg detach my-server my-sg
+```
+
+---
+
 ## Load Balancer Commands
 
 Manage Layer 7 load balancers.

--- a/docs/guides/networking.md
+++ b/docs/guides/networking.md
@@ -35,5 +35,39 @@ You can map multiple ports by separating them with a comma (max 10):
 cloud compute launch --name dual --image my-app --port 8080:80,3000:3000
 ```
 
-## Internal Networking
-*Coming soon: VPCs, Subnets, and Security Groups.*
+## Virtual Private Cloud (VPC)
+VPCs provide logically isolated sections of The Cloud network. All instances must belong to a VPC.
+
+### Create a VPC
+```bash
+cloud vpc create --name prod-vpc
+```
+
+## Subnets
+Subnets allow you to partition your VPC into smaller segments.
+
+### Create a Subnet
+```bash
+cloud vpc create-subnet --vpc-id <vpc-id> --name private-1 --cidr 10.0.1.0/24
+```
+
+## Security Groups
+Security Groups act as virtual firewalls for your instances, controlling inbound and outbound traffic.
+
+### Create a Group
+```bash
+cloud sg create --vpc-id <vpc-id> web-sg --description "Web Traffic"
+```
+
+### Add Rules
+Rules allow specific traffic based on protocol, port, and CIDR.
+```bash
+cloud sg add-rule <sg-id> --direction ingress --protocol tcp --port-min 80 --port-max 80 --cidr 0.0.0.0/0
+```
+
+### Manage Associations
+Apply groups to instances to protect them.
+```bash
+cloud sg attach <instance-id> <sg-id>
+cloud sg detach <instance-id> <sg-id>
+```

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2280,11 +2280,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/httputil.Response"
-                        }
+                    "204": {
+                        "description": "No Content"
                     },
                     "404": {
                         "description": "Not Found",
@@ -2376,11 +2373,8 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/httputil.Response"
-                        }
+                    "204": {
+                        "description": "No Content"
                     },
                     "404": {
                         "description": "Not Found",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2055,6 +2055,406 @@ const docTemplate = `{
                 }
             }
         },
+        "/security-groups": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Lists all security groups for a VPC",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "List security groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VPC ID",
+                        "name": "vpc_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.SecurityGroup"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Creates a new security group in a VPC",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Create security group",
+                "parameters": [
+                    {
+                        "description": "Create request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CreateSecurityGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SecurityGroup"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/attach": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Associates a security group with a compute instance",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Attach security group",
+                "parameters": [
+                    {
+                        "description": "Attach details",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AttachDetachSGRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/detach": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Removes a security group association from a compute instance",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Detach security group",
+                "parameters": [
+                    {
+                        "description": "Detach details",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AttachDetachSGRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/rules/{rule_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Deletes a specific security rule by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Remove security rule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rule ID",
+                        "name": "rule_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Gets details of a specific security group",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Get security group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Security Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VPC ID (optional if ID is UUID)",
+                        "name": "vpc_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SecurityGroup"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Deletes a security group",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Delete security group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Security Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/{id}/rules": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Adds a new rule to a security group",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Add security rule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Security Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Rule details",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/domain.SecurityRule"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SecurityRule"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/snapshots": {
             "get": {
                 "security": [
@@ -3457,6 +3857,17 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.RuleDirection": {
+            "type": "string",
+            "enum": [
+                "ingress",
+                "egress"
+            ],
+            "x-enum-varnames": [
+                "RuleIngress",
+                "RuleEgress"
+            ]
+        },
         "domain.ScalingGroup": {
             "type": "object",
             "properties": {
@@ -3575,6 +3986,74 @@ const docTemplate = `{
                 "target_value": {
                     "description": "Threshold (e.g. 80.0 for 80%)",
                     "type": "number"
+                }
+            }
+        },
+        "domain.SecurityGroup": {
+            "type": "object",
+            "properties": {
+                "arn": {
+                    "description": "Unique identifier (arn:thecloud:vpc:{region}:{user}:sg/{name})",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.SecurityRule"
+                    }
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.SecurityRule": {
+            "type": "object",
+            "properties": {
+                "cidr": {
+                    "description": "Targeted IPv4 range (e.g., \"0.0.0.0/0\")",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "direction": {
+                    "$ref": "#/definitions/domain.RuleDirection"
+                },
+                "group_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "port_max": {
+                    "type": "integer"
+                },
+                "port_min": {
+                    "type": "integer"
+                },
+                "priority": {
+                    "description": "Evaluation order (lower values evaluated first)",
+                    "type": "integer"
+                },
+                "protocol": {
+                    "description": "Traffic protocol (e.g., \"tcp\", \"udp\", \"icmp\", \"all\")",
+                    "type": "string"
                 }
             }
         },
@@ -3911,6 +4390,21 @@ const docTemplate = `{
                 }
             }
         },
+        "httphandlers.AttachDetachSGRequest": {
+            "type": "object",
+            "required": [
+                "group_id",
+                "instance_id"
+            ],
+            "properties": {
+                "group_id": {
+                    "type": "string"
+                },
+                "instance_id": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.BindRoleRequest": {
             "type": "object",
             "required": [
@@ -4044,6 +4538,24 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/domain.Permission"
                     }
+                }
+            }
+        },
+        "httphandlers.CreateSecurityGroupRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "vpc_id"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2269,11 +2269,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/httputil.Response"
-                        }
+                    "204": {
+                        "description": "No Content"
                     },
                     "404": {
                         "description": "Not Found",
@@ -2365,11 +2362,8 @@
                     }
                 ],
                 "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/httputil.Response"
-                        }
+                    "204": {
+                        "description": "No Content"
                     },
                     "404": {
                         "description": "Not Found",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -2044,6 +2044,406 @@
                 }
             }
         },
+        "/security-groups": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Lists all security groups for a VPC",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "List security groups",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VPC ID",
+                        "name": "vpc_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.SecurityGroup"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Creates a new security group in a VPC",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Create security group",
+                "parameters": [
+                    {
+                        "description": "Create request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CreateSecurityGroupRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SecurityGroup"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/attach": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Associates a security group with a compute instance",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Attach security group",
+                "parameters": [
+                    {
+                        "description": "Attach details",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AttachDetachSGRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/detach": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Removes a security group association from a compute instance",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Detach security group",
+                "parameters": [
+                    {
+                        "description": "Detach details",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AttachDetachSGRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/rules/{rule_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Deletes a specific security rule by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Remove security rule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Rule ID",
+                        "name": "rule_id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Gets details of a specific security group",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Get security group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Security Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "VPC ID (optional if ID is UUID)",
+                        "name": "vpc_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SecurityGroup"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Deletes a security group",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Delete security group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Security Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/security-groups/{id}/rules": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Adds a new rule to a security group",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "security-groups"
+                ],
+                "summary": "Add security rule",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Security Group ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Rule details",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/domain.SecurityRule"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.SecurityRule"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/snapshots": {
             "get": {
                 "security": [
@@ -3446,6 +3846,17 @@
                 }
             }
         },
+        "domain.RuleDirection": {
+            "type": "string",
+            "enum": [
+                "ingress",
+                "egress"
+            ],
+            "x-enum-varnames": [
+                "RuleIngress",
+                "RuleEgress"
+            ]
+        },
         "domain.ScalingGroup": {
             "type": "object",
             "properties": {
@@ -3564,6 +3975,74 @@
                 "target_value": {
                     "description": "Threshold (e.g. 80.0 for 80%)",
                     "type": "number"
+                }
+            }
+        },
+        "domain.SecurityGroup": {
+            "type": "object",
+            "properties": {
+                "arn": {
+                    "description": "Unique identifier (arn:thecloud:vpc:{region}:{user}:sg/{name})",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.SecurityRule"
+                    }
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.SecurityRule": {
+            "type": "object",
+            "properties": {
+                "cidr": {
+                    "description": "Targeted IPv4 range (e.g., \"0.0.0.0/0\")",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "direction": {
+                    "$ref": "#/definitions/domain.RuleDirection"
+                },
+                "group_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "port_max": {
+                    "type": "integer"
+                },
+                "port_min": {
+                    "type": "integer"
+                },
+                "priority": {
+                    "description": "Evaluation order (lower values evaluated first)",
+                    "type": "integer"
+                },
+                "protocol": {
+                    "description": "Traffic protocol (e.g., \"tcp\", \"udp\", \"icmp\", \"all\")",
+                    "type": "string"
                 }
             }
         },
@@ -3900,6 +4379,21 @@
                 }
             }
         },
+        "httphandlers.AttachDetachSGRequest": {
+            "type": "object",
+            "required": [
+                "group_id",
+                "instance_id"
+            ],
+            "properties": {
+                "group_id": {
+                    "type": "string"
+                },
+                "instance_id": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.BindRoleRequest": {
             "type": "object",
             "required": [
@@ -4033,6 +4527,24 @@
                     "items": {
                         "$ref": "#/definitions/domain.Permission"
                     }
+                }
+            }
+        },
+        "httphandlers.CreateSecurityGroupRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "vpc_id"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2507,10 +2507,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/httputil.Response'
+        "204":
+          description: No Content
         "404":
           description: Not Found
           schema:
@@ -2669,10 +2667,8 @@ paths:
       produces:
       - application/json
       responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/httputil.Response'
+        "204":
+          description: No Content
         "404":
           description: Not Found
           schema:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -480,6 +480,14 @@ definitions:
           $ref: '#/definitions/domain.Permission'
         type: array
     type: object
+  domain.RuleDirection:
+    enum:
+    - ingress
+    - egress
+    type: string
+    x-enum-varnames:
+    - RuleIngress
+    - RuleEgress
   domain.ScalingGroup:
     properties:
       created_at:
@@ -566,6 +574,52 @@ definitions:
       target_value:
         description: Threshold (e.g. 80.0 for 80%)
         type: number
+    type: object
+  domain.SecurityGroup:
+    properties:
+      arn:
+        description: Unique identifier (arn:thecloud:vpc:{region}:{user}:sg/{name})
+        type: string
+      created_at:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      rules:
+        items:
+          $ref: '#/definitions/domain.SecurityRule'
+        type: array
+      user_id:
+        type: string
+      vpc_id:
+        type: string
+    type: object
+  domain.SecurityRule:
+    properties:
+      cidr:
+        description: Targeted IPv4 range (e.g., "0.0.0.0/0")
+        type: string
+      created_at:
+        type: string
+      direction:
+        $ref: '#/definitions/domain.RuleDirection'
+      group_id:
+        type: string
+      id:
+        type: string
+      port_max:
+        type: integer
+      port_min:
+        type: integer
+      priority:
+        description: Evaluation order (lower values evaluated first)
+        type: integer
+      protocol:
+        description: Traffic protocol (e.g., "tcp", "udp", "icmp", "all")
+        type: string
     type: object
   domain.Snapshot:
     properties:
@@ -801,6 +855,16 @@ definitions:
     - instance_id
     - port
     type: object
+  httphandlers.AttachDetachSGRequest:
+    properties:
+      group_id:
+        type: string
+      instance_id:
+        type: string
+    required:
+    - group_id
+    - instance_id
+    type: object
   httphandlers.BindRoleRequest:
     properties:
       role_name:
@@ -893,6 +957,18 @@ definitions:
         type: array
     required:
     - name
+    type: object
+  httphandlers.CreateSecurityGroupRequest:
+    properties:
+      description:
+        type: string
+      name:
+        type: string
+      vpc_id:
+        type: string
+    required:
+    - name
+    - vpc_id
     type: object
   httphandlers.CreateSnapshotRequest:
     properties:
@@ -2357,6 +2433,259 @@ paths:
       summary: Remove permission from role
       tags:
       - RBAC
+  /security-groups:
+    get:
+      description: Lists all security groups for a VPC
+      parameters:
+      - description: VPC ID
+        in: query
+        name: vpc_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.SecurityGroup'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: List security groups
+      tags:
+      - security-groups
+    post:
+      consumes:
+      - application/json
+      description: Creates a new security group in a VPC
+      parameters:
+      - description: Create request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.CreateSecurityGroupRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.SecurityGroup'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Create security group
+      tags:
+      - security-groups
+  /security-groups/{id}:
+    delete:
+      description: Deletes a security group
+      parameters:
+      - description: Security Group ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Delete security group
+      tags:
+      - security-groups
+    get:
+      description: Gets details of a specific security group
+      parameters:
+      - description: Security Group ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: VPC ID (optional if ID is UUID)
+        in: query
+        name: vpc_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.SecurityGroup'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Get security group
+      tags:
+      - security-groups
+  /security-groups/{id}/rules:
+    post:
+      consumes:
+      - application/json
+      description: Adds a new rule to a security group
+      parameters:
+      - description: Security Group ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Rule details
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/domain.SecurityRule'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.SecurityRule'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Add security rule
+      tags:
+      - security-groups
+  /security-groups/attach:
+    post:
+      consumes:
+      - application/json
+      description: Associates a security group with a compute instance
+      parameters:
+      - description: Attach details
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.AttachDetachSGRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Attach security group
+      tags:
+      - security-groups
+  /security-groups/detach:
+    post:
+      consumes:
+      - application/json
+      description: Removes a security group association from a compute instance
+      parameters:
+      - description: Detach details
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.AttachDetachSGRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Detach security group
+      tags:
+      - security-groups
+  /security-groups/rules/{rule_id}:
+    delete:
+      description: Deletes a specific security rule by ID
+      parameters:
+      - description: Rule ID
+        in: path
+        name: rule_id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Remove security rule
+      tags:
+      - security-groups
   /snapshots:
     get:
       description: Gets a list of all existing snapshots for the user

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -252,7 +252,9 @@ func registerNetworkRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		sgGroup.GET("/:id", handlers.SecurityGroup.Get)
 		sgGroup.DELETE("/:id", handlers.SecurityGroup.Delete)
 		sgGroup.POST("/:id/rules", handlers.SecurityGroup.AddRule)
+		sgGroup.DELETE("/rules/:rule_id", handlers.SecurityGroup.RemoveRule)
 		sgGroup.POST("/attach", handlers.SecurityGroup.Attach)
+		sgGroup.POST("/detach", handlers.SecurityGroup.Detach)
 	}
 
 	lbGroup := r.Group("/lb")

--- a/internal/core/ports/security_group.go
+++ b/internal/core/ports/security_group.go
@@ -19,6 +19,8 @@ type SecurityGroupRepository interface {
 	ListByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.SecurityGroup, error)
 	// AddRule appends a new traffic filtering rule to an existing group.
 	AddRule(ctx context.Context, rule *domain.SecurityRule) error
+	// GetRuleByID retrieves a specific security rule.
+	GetRuleByID(ctx context.Context, ruleID uuid.UUID) (*domain.SecurityRule, error)
 	// DeleteRule removes a specific traffic filtering rule.
 	DeleteRule(ctx context.Context, ruleID uuid.UUID) error
 	// Delete removes a security group and all its rules.

--- a/internal/core/services/audit_test.go
+++ b/internal/core/services/audit_test.go
@@ -29,6 +29,8 @@ func (m *MockAuditRepository) ListByUserID(ctx context.Context, userID uuid.UUID
 	return args.Get(0).([]*domain.AuditLog), args.Error(1)
 }
 
+const auditLogType = "*domain.AuditLog"
+
 func TestNewAuditService(t *testing.T) {
 	repo := new(MockAuditRepository)
 	svc := services.NewAuditService(repo)
@@ -36,7 +38,7 @@ func TestNewAuditService(t *testing.T) {
 	assert.NotNil(t, svc)
 }
 
-func TestAuditService_Log_Success(t *testing.T) {
+func TestAuditServiceLogSuccess(t *testing.T) {
 	repo := new(MockAuditRepository)
 	svc := services.NewAuditService(repo)
 
@@ -50,23 +52,23 @@ func TestAuditService_Log_Success(t *testing.T) {
 		"size":  "small",
 	}
 
-	repo.On("Create", mock.Anything, mock.AnythingOfType("*domain.AuditLog")).Return(nil)
+	repo.On("Create", mock.Anything, mock.AnythingOfType(auditLogType)).Return(nil)
 
 	err := svc.Log(ctx, userID, action, resourceType, resourceID, details)
 
 	assert.NoError(t, err)
 	repo.AssertExpectations(t)
-	repo.AssertCalled(t, "Create", mock.Anything, mock.AnythingOfType("*domain.AuditLog"))
+	repo.AssertCalled(t, "Create", mock.Anything, mock.AnythingOfType(auditLogType))
 }
 
-func TestAuditService_Log_RepositoryError(t *testing.T) {
+func TestAuditServiceLogRepositoryError(t *testing.T) {
 	repo := new(MockAuditRepository)
 	svc := services.NewAuditService(repo)
 
 	ctx := context.Background()
 	userID := uuid.New()
 
-	repo.On("Create", mock.Anything, mock.AnythingOfType("*domain.AuditLog")).Return(assert.AnError)
+	repo.On("Create", mock.Anything, mock.AnythingOfType(auditLogType)).Return(assert.AnError)
 
 	err := svc.Log(ctx, userID, "test.action", "test", "123", nil)
 
@@ -75,14 +77,14 @@ func TestAuditService_Log_RepositoryError(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestAuditService_Log_WithNilDetails(t *testing.T) {
+func TestAuditServiceLogWithNilDetails(t *testing.T) {
 	repo := new(MockAuditRepository)
 	svc := services.NewAuditService(repo)
 
 	ctx := context.Background()
 	userID := uuid.New()
 
-	repo.On("Create", mock.Anything, mock.AnythingOfType("*domain.AuditLog")).Return(nil)
+	repo.On("Create", mock.Anything, mock.AnythingOfType(auditLogType)).Return(nil)
 
 	err := svc.Log(ctx, userID, "test.action", "test", "123", nil)
 
@@ -90,7 +92,7 @@ func TestAuditService_Log_WithNilDetails(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestAuditService_ListLogs_Success(t *testing.T) {
+func TestAuditServiceListLogsSuccess(t *testing.T) {
 	repo := new(MockAuditRepository)
 	svc := services.NewAuditService(repo)
 
@@ -125,7 +127,7 @@ func TestAuditService_ListLogs_Success(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestAuditService_ListLogs_EmptyResult(t *testing.T) {
+func TestAuditServiceListLogsEmptyResult(t *testing.T) {
 	repo := new(MockAuditRepository)
 	svc := services.NewAuditService(repo)
 
@@ -141,7 +143,7 @@ func TestAuditService_ListLogs_EmptyResult(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestAuditService_ListLogs_DefaultLimit(t *testing.T) {
+func TestAuditServiceListLogsDefaultLimit(t *testing.T) {
 	repo := new(MockAuditRepository)
 	svc := services.NewAuditService(repo)
 
@@ -170,7 +172,7 @@ func TestAuditService_ListLogs_DefaultLimit(t *testing.T) {
 	repo2.AssertExpectations(t)
 }
 
-func TestAuditService_ListLogs_RepositoryError(t *testing.T) {
+func TestAuditServiceListLogsRepositoryError(t *testing.T) {
 	repo := new(MockAuditRepository)
 	svc := services.NewAuditService(repo)
 

--- a/internal/core/services/benchmarks_test.go
+++ b/internal/core/services/benchmarks_test.go
@@ -55,7 +55,7 @@ func BenchmarkVPCServiceGet(b *testing.B) {
 	network := &noop.NoopNetworkAdapter{}
 	auditSvc := &noop.NoopAuditService{}
 	logger := slog.Default()
-	svc := services.NewVpcService(repo, network, auditSvc, logger, "10.0.0.0/16")
+	svc := services.NewVpcService(repo, network, auditSvc, logger, testutil.TestCIDR)
 
 	ctx := context.Background()
 	id := uuid.New()

--- a/internal/core/services/benchmarks_test.go
+++ b/internal/core/services/benchmarks_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/poyrazk/thecloud/internal/repositories/noop"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -165,7 +166,7 @@ func BenchmarkAuthServiceLoginParallel(b *testing.B) {
 
 	ctx := context.Background()
 	email := "admin@thecloud.local"
-	password := "password"
+	password := testutil.TestPasswordStrong
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -287,7 +288,7 @@ func BenchmarkAuthServiceRegister(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Use unique email each time to avoid "user exists" check impact if we were using real repo
 		// though noop always returns nil for existing check usually (wait, I should check noop GetByEmail)
-		_, _ = svc.Register(ctx, "test@example.com", "P@ssword123!", "Test User")
+		_, _ = svc.Register(ctx, "test@example.com", testutil.TestPasswordStrong, "Test User")
 	}
 }
 
@@ -310,7 +311,7 @@ func (r *BenchUserRepository) GetByEmail(ctx context.Context, email string) (*do
 
 func BenchmarkAuthServiceLogin(b *testing.B) {
 	// Generate a real hash once
-	hash, _ := bcrypt.GenerateFromPassword([]byte("password"), 10)
+	hash, _ := bcrypt.GenerateFromPassword([]byte(testutil.TestPasswordStrong), 10)
 
 	userRepo := &BenchUserRepository{}
 	// Override the default behavior to return the real hash
@@ -327,7 +328,7 @@ func BenchmarkAuthServiceLogin(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, err := svc.Login(ctx, "test@example.com", "password")
+		_, _, err := svc.Login(ctx, "test@example.com", testutil.TestPasswordStrong)
 		if err != nil {
 			b.Fatalf("Login failed: %v", err)
 		}

--- a/internal/core/services/health_test.go
+++ b/internal/core/services/health_test.go
@@ -27,7 +27,7 @@ func (m *fullMockComputeBackend) Ping(ctx context.Context) error {
 	return m.Called(ctx).Error(0)
 }
 
-func TestHealthService_Check(t *testing.T) {
+func TestHealthServiceCheck(t *testing.T) {
 	t.Run("Healthy", func(t *testing.T) {
 		db := new(mockCheckable)
 		compute := new(fullMockComputeBackend)

--- a/internal/core/services/instance_test.go
+++ b/internal/core/services/instance_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -276,8 +277,8 @@ func TestProvisionSuccess(t *testing.T) {
 	subnet := &domain.Subnet{
 		ID:        subnetID,
 		VPCID:     vpcID,
-		CIDRBlock: "10.0.1.0/24",
-		GatewayIP: "10.0.1.1",
+		CIDRBlock: testutil.TestSubnetCIDR,
+		GatewayIP: testutil.TestGatewayIP,
 	}
 
 	repo.On("GetByID", mock.Anything, instID).Return(inst, nil)
@@ -294,7 +295,7 @@ func TestProvisionSuccess(t *testing.T) {
 
 	network.On("CreateVethPair", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	network.On("AttachVethToBridge", mock.Anything, testVPCNetwork, mock.Anything).Return(nil)
-	network.On("SetVethIP", mock.Anything, mock.Anything, "10.0.1.2", "24").Return(nil)
+	network.On("SetVethIP", mock.Anything, mock.Anything, testutil.TestInstanceIP, "24").Return(nil)
 
 	repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Instance) bool {
 		return i.Status == domain.StatusRunning && i.ContainerID == "c-123"

--- a/internal/core/services/security_group.go
+++ b/internal/core/services/security_group.go
@@ -16,6 +16,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
+const securityGroupTracer = "security-group-service"
+
 type SecurityGroupService struct {
 	repo     ports.SecurityGroupRepository
 	vpcRepo  ports.VpcRepository
@@ -41,7 +43,7 @@ func NewSecurityGroupService(
 }
 
 func (s *SecurityGroupService) CreateGroup(ctx context.Context, vpcID uuid.UUID, name, description string) (*domain.SecurityGroup, error) {
-	ctx, span := otel.Tracer("security-group-service").Start(ctx, "CreateGroup")
+	ctx, span := otel.Tracer(securityGroupTracer).Start(ctx, "CreateGroup")
 	defer span.End()
 
 	span.SetAttributes(
@@ -103,7 +105,7 @@ func (s *SecurityGroupService) DeleteGroup(ctx context.Context, id uuid.UUID) er
 }
 
 func (s *SecurityGroupService) AddRule(ctx context.Context, groupID uuid.UUID, rule domain.SecurityRule) (*domain.SecurityRule, error) {
-	ctx, span := otel.Tracer("security-group-service").Start(ctx, "AddRule")
+	ctx, span := otel.Tracer(securityGroupTracer).Start(ctx, "AddRule")
 	defer span.End()
 
 	span.SetAttributes(
@@ -140,7 +142,7 @@ func (s *SecurityGroupService) AddRule(ctx context.Context, groupID uuid.UUID, r
 }
 
 func (s *SecurityGroupService) RemoveRule(ctx context.Context, ruleID uuid.UUID) error {
-	ctx, span := otel.Tracer("security-group-service").Start(ctx, "RemoveRule")
+	ctx, span := otel.Tracer(securityGroupTracer).Start(ctx, "RemoveRule")
 	defer span.End()
 
 	span.SetAttributes(attribute.String("rule_id", ruleID.String()))
@@ -185,7 +187,7 @@ func (s *SecurityGroupService) RemoveRule(ctx context.Context, ruleID uuid.UUID)
 }
 
 func (s *SecurityGroupService) AttachToInstance(ctx context.Context, instanceID, groupID uuid.UUID) error {
-	ctx, span := otel.Tracer("security-group-service").Start(ctx, "AttachToInstance")
+	ctx, span := otel.Tracer(securityGroupTracer).Start(ctx, "AttachToInstance")
 	defer span.End()
 
 	span.SetAttributes(
@@ -207,7 +209,7 @@ func (s *SecurityGroupService) AttachToInstance(ctx context.Context, instanceID,
 }
 
 func (s *SecurityGroupService) DetachFromInstance(ctx context.Context, instanceID, groupID uuid.UUID) error {
-	ctx, span := otel.Tracer("security-group-service").Start(ctx, "DetachFromInstance")
+	ctx, span := otel.Tracer(securityGroupTracer).Start(ctx, "DetachFromInstance")
 	defer span.End()
 
 	span.SetAttributes(

--- a/internal/core/services/security_group_test.go
+++ b/internal/core/services/security_group_test.go
@@ -146,14 +146,20 @@ func TestSecurityGroupServiceAttachToInstance(t *testing.T) {
 }
 
 func TestSecurityGroupServiceDetachFromInstance(t *testing.T) {
-	repo, _, _, auditSvc, svc := setupSecurityGroupServiceTest(t)
+	repo, vpcRepo, _, auditSvc, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
 	ctx := context.Background()
 	instID := uuid.New()
 	sgID := uuid.New()
+	vpcID := uuid.New()
+	sg := &domain.SecurityGroup{ID: sgID, VPCID: vpcID}
+	vpc := &domain.VPC{ID: vpcID, NetworkID: "net1"}
 
 	repo.On("RemoveInstanceFromGroup", mock.Anything, instID, sgID).Return(nil)
+	repo.On("GetByID", mock.Anything, sgID).Return(sg, nil)
+	vpcRepo.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
+
 	auditSvc.On("Log", mock.Anything, mock.Anything, "security_group.detach", "instance", instID.String(), mock.Anything).Return(nil)
 
 	err := svc.DetachFromInstance(ctx, instID, sgID)

--- a/internal/core/services/security_group_test.go
+++ b/internal/core/services/security_group_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -108,7 +109,7 @@ func TestSecurityGroupServiceAddRule(t *testing.T) {
 	vpcID := uuid.New()
 	sg := &domain.SecurityGroup{ID: sgID, UserID: userID, VPCID: vpcID}
 	vpc := &domain.VPC{ID: vpcID, NetworkID: "net1"}
-	rule := domain.SecurityRule{Protocol: "tcp", PortMin: 80, PortMax: 80, CIDR: "0.0.0.0/0", Direction: domain.RuleIngress}
+	rule := domain.SecurityRule{Protocol: "tcp", PortMin: 80, PortMax: 80, CIDR: testutil.TestAnyCIDR, Direction: domain.RuleIngress}
 
 	repo.On("GetByID", mock.Anything, sgID).Return(sg, nil)
 	repo.On("AddRule", mock.Anything, mock.Anything).Return(nil)
@@ -216,9 +217,9 @@ func TestSecurityGroupServiceTranslateToFlow(t *testing.T) {
 	vpc := &domain.VPC{ID: vpcID, NetworkID: "net1"}
 
 	rules := []domain.SecurityRule{
-		{Protocol: "udp", PortMin: 53, PortMax: 53, CIDR: "8.8.8.8/32", Direction: domain.RuleIngress},
-		{Protocol: "icmp", CIDR: "0.0.0.0/0", Direction: domain.RuleEgress},
-		{Protocol: "tcp", PortMin: 1000, PortMax: 2000, CIDR: "10.0.0.0/8", Direction: domain.RuleEgress},
+		{Protocol: "udp", PortMin: 53, PortMax: 53, CIDR: testutil.TestGoogleDNSCIDR, Direction: domain.RuleIngress},
+		{Protocol: "icmp", CIDR: testutil.TestAnyCIDR, Direction: domain.RuleEgress},
+		{Protocol: "tcp", PortMin: 1000, PortMax: 2000, CIDR: testutil.TestTenCIDR, Direction: domain.RuleEgress},
 	}
 
 	for _, rule := range rules {

--- a/internal/core/services/security_group_test.go
+++ b/internal/core/services/security_group_test.go
@@ -25,7 +25,9 @@ func setupSecurityGroupServiceTest(_ *testing.T) (*MockSecurityGroupRepo, *MockV
 	return repo, vpcRepo, network, auditSvc, svc
 }
 
-func TestSecurityGroupService_CreateGroup(t *testing.T) {
+const testSGName = "test-sg"
+
+func TestSecurityGroupServiceCreateGroup(t *testing.T) {
 	repo, _, _, auditSvc, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
@@ -36,22 +38,22 @@ func TestSecurityGroupService_CreateGroup(t *testing.T) {
 	repo.On("Create", mock.Anything, mock.Anything).Return(nil)
 	auditSvc.On("Log", mock.Anything, userID, "security_group.create", "security_group", mock.Anything, mock.Anything).Return(nil)
 
-	sg, err := svc.CreateGroup(ctx, vpcID, "test-sg", "desc")
+	sg, err := svc.CreateGroup(ctx, vpcID, testSGName, "desc")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, sg)
-	assert.Equal(t, "test-sg", sg.Name)
+	assert.Equal(t, testSGName, sg.Name)
 	assert.Equal(t, vpcID, sg.VPCID)
 }
 
-func TestSecurityGroupService_GetGroup(t *testing.T) {
+func TestSecurityGroupServiceGetGroup(t *testing.T) {
 	repo, _, _, _, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
 	ctx := context.Background()
 	sgID := uuid.New()
 	vpcID := uuid.New()
-	sg := &domain.SecurityGroup{ID: sgID, Name: "test-sg"}
+	sg := &domain.SecurityGroup{ID: sgID, Name: testSGName}
 
 	// By ID
 	repo.On("GetByID", ctx, sgID).Return(sg, nil).Once()
@@ -60,13 +62,13 @@ func TestSecurityGroupService_GetGroup(t *testing.T) {
 	assert.Equal(t, sgID, res.ID)
 
 	// By Name
-	repo.On("GetByName", ctx, vpcID, "test-sg").Return(sg, nil).Once()
-	res, err = svc.GetGroup(ctx, "test-sg", vpcID)
+	repo.On("GetByName", ctx, vpcID, testSGName).Return(sg, nil).Once()
+	res, err = svc.GetGroup(ctx, testSGName, vpcID)
 	assert.NoError(t, err)
-	assert.Equal(t, "test-sg", res.Name)
+	assert.Equal(t, testSGName, res.Name)
 }
 
-func TestSecurityGroupService_ListGroups(t *testing.T) {
+func TestSecurityGroupServiceListGroups(t *testing.T) {
 	repo, _, _, _, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
@@ -81,7 +83,7 @@ func TestSecurityGroupService_ListGroups(t *testing.T) {
 	assert.Equal(t, sgs, res)
 }
 
-func TestSecurityGroupService_DeleteGroup(t *testing.T) {
+func TestSecurityGroupServiceDeleteGroup(t *testing.T) {
 	repo, _, _, auditSvc, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
@@ -96,7 +98,7 @@ func TestSecurityGroupService_DeleteGroup(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSecurityGroupService_AddRule(t *testing.T) {
+func TestSecurityGroupServiceAddRule(t *testing.T) {
 	repo, vpcRepo, network, auditSvc, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
@@ -121,7 +123,7 @@ func TestSecurityGroupService_AddRule(t *testing.T) {
 	assert.Equal(t, sgID, res.GroupID)
 }
 
-func TestSecurityGroupService_AttachToInstance(t *testing.T) {
+func TestSecurityGroupServiceAttachToInstance(t *testing.T) {
 	repo, vpcRepo, network, _, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
@@ -141,7 +143,7 @@ func TestSecurityGroupService_AttachToInstance(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSecurityGroupService_DetachFromInstance(t *testing.T) {
+func TestSecurityGroupServiceDetachFromInstance(t *testing.T) {
 	repo, _, _, _, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
@@ -155,7 +157,7 @@ func TestSecurityGroupService_DetachFromInstance(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSecurityGroupService_RemoveRule(t *testing.T) {
+func TestSecurityGroupServiceRemoveRule(t *testing.T) {
 	repo, vpcRepo, network, auditSvc, svc := setupSecurityGroupServiceTest(t)
 	defer repo.AssertExpectations(t)
 
@@ -180,7 +182,7 @@ func TestSecurityGroupService_RemoveRule(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestSecurityGroupService_Errors(t *testing.T) {
+func TestSecurityGroupServiceErrors(t *testing.T) {
 	ctx := context.Background()
 	sgID := uuid.New()
 
@@ -206,7 +208,7 @@ func TestSecurityGroupService_Errors(t *testing.T) {
 	})
 }
 
-func TestSecurityGroupService_TranslateToFlow(t *testing.T) {
+func TestSecurityGroupServiceTranslateToFlow(t *testing.T) {
 	repo, vpcRepo, network, auditSvc, svc := setupSecurityGroupServiceTest(t)
 	ctx := context.Background()
 	sgID := uuid.New()

--- a/internal/core/services/shared_test.go
+++ b/internal/core/services/shared_test.go
@@ -111,11 +111,11 @@ func (m *MockAutoScalingRepo) ListGroups(ctx context.Context) ([]*domain.Scaling
 	return args.Get(0).([]*domain.ScalingGroup), args.Error(1)
 }
 func (m *MockAutoScalingRepo) ListAllGroups(ctx context.Context) ([]*domain.ScalingGroup, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+	ret := m.Called(ctx)
+	if ret.Get(0) == nil {
+		return nil, ret.Error(1)
 	}
-	return args.Get(0).([]*domain.ScalingGroup), args.Error(1)
+	return ret.Get(0).([]*domain.ScalingGroup), ret.Error(1)
 }
 func (m *MockAutoScalingRepo) CountGroupsByVPC(ctx context.Context, vpcID uuid.UUID) (int, error) {
 	args := m.Called(ctx, vpcID)
@@ -837,10 +837,12 @@ func (m *MockComputeBackend) GetInstanceLogs(ctx context.Context, id string) (io
 }
 func (m *MockComputeBackend) GetInstanceStats(ctx context.Context, id string) (io.ReadCloser, error) {
 	args := m.Called(ctx, id)
-	if args.Get(0) == nil {
+	// Return the result directly if valid, checking nil first
+	res := args.Get(0)
+	if res == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(io.ReadCloser), args.Error(1)
+	return res.(io.ReadCloser), args.Error(1)
 }
 func (m *MockComputeBackend) GetInstancePort(ctx context.Context, id string, port string) (int, error) {
 	args := m.Called(ctx, id, port)
@@ -857,7 +859,8 @@ func (m *MockComputeBackend) AttachVolume(ctx context.Context, id string, volume
 	return m.Called(ctx, id, volumePath).Error(0)
 }
 func (m *MockComputeBackend) DetachVolume(ctx context.Context, id string, volumePath string) error {
-	return m.Called(ctx, id, volumePath).Error(0)
+	args := m.Called(ctx, id, volumePath)
+	return args.Error(0)
 }
 func (m *MockComputeBackend) RunTask(ctx context.Context, opts ports.RunTaskOptions) (string, error) {
 	args := m.Called(ctx, opts)
@@ -880,11 +883,12 @@ func (m *MockComputeBackend) GetConsoleURL(ctx context.Context, id string) (stri
 	return m.GetInstanceIP(ctx, id)
 }
 func (m *MockComputeBackend) CreateVolumeSnapshot(ctx context.Context, volumeID string, destinationPath string) error {
-	return nil
+	return m.Called(ctx, volumeID, destinationPath).Error(0)
 }
 
 func (m *MockComputeBackend) RestoreVolumeSnapshot(ctx context.Context, volumeID string, sourcePath string) error {
-	return nil
+	args := m.Called(ctx, volumeID, sourcePath)
+	return args.Error(0)
 }
 
 func (m *MockComputeBackend) Ping(ctx context.Context) error {
@@ -1596,16 +1600,14 @@ func (m *MockStorageBackend) AttachVolume(ctx context.Context, volumeName, insta
 	return args.Error(0)
 }
 func (m *MockStorageBackend) DetachVolume(ctx context.Context, volumeName, instanceID string) error {
-	args := m.Called(ctx, volumeName, instanceID)
-	return args.Error(0)
+	return m.Called(ctx, volumeName, instanceID).Error(0)
 }
 func (m *MockStorageBackend) CreateSnapshot(ctx context.Context, volumeName, snapshotName string) error {
 	args := m.Called(ctx, volumeName, snapshotName)
 	return args.Error(0)
 }
 func (m *MockStorageBackend) RestoreSnapshot(ctx context.Context, volumeName, snapshotName string) error {
-	args := m.Called(ctx, volumeName, snapshotName)
-	return args.Error(0)
+	return m.Called(ctx, volumeName, snapshotName).Error(0)
 }
 func (m *MockStorageBackend) DeleteSnapshot(ctx context.Context, snapshotName string) error {
 	args := m.Called(ctx, snapshotName)

--- a/internal/core/services/shared_test.go
+++ b/internal/core/services/shared_test.go
@@ -1509,6 +1509,13 @@ func (m *MockSecurityGroupRepo) ListByVPC(ctx context.Context, vpcID uuid.UUID) 
 func (m *MockSecurityGroupRepo) AddRule(ctx context.Context, rule *domain.SecurityRule) error {
 	return m.Called(ctx, rule).Error(0)
 }
+func (m *MockSecurityGroupRepo) GetRuleByID(ctx context.Context, ruleID uuid.UUID) (*domain.SecurityRule, error) {
+	args := m.Called(ctx, ruleID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.SecurityRule), args.Error(1)
+}
 func (m *MockSecurityGroupRepo) DeleteRule(ctx context.Context, ruleID uuid.UUID) error {
 	return m.Called(ctx, ruleID).Error(0)
 }

--- a/internal/core/services/vpc_test.go
+++ b/internal/core/services/vpc_test.go
@@ -11,13 +11,12 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-const vpcTestCIDR = "10.0.0.0/16"
-
-func setupVpcServiceTest(t *testing.T, cidr string) (*MockVpcRepo, *MockNetworkBackend, *MockAuditService, ports.VpcService) {
+func setupVpcServiceTest(cidr string) (*MockVpcRepo, *MockNetworkBackend, *MockAuditService, ports.VpcService) {
 	vpcRepo := new(MockVpcRepo)
 	network := new(MockNetworkBackend)
 	auditSvc := new(MockAuditService)
@@ -28,14 +27,14 @@ func setupVpcServiceTest(t *testing.T, cidr string) (*MockVpcRepo, *MockNetworkB
 }
 
 func TestVpcServiceCreateSuccess(t *testing.T) {
-	vpcRepo, network, auditSvc, svc := setupVpcServiceTest(t, vpcTestCIDR)
+	vpcRepo, network, auditSvc, svc := setupVpcServiceTest(testutil.TestCIDR)
 	defer vpcRepo.AssertExpectations(t)
 	defer network.AssertExpectations(t)
 	defer auditSvc.AssertExpectations(t)
 
 	ctx := appcontext.WithUserID(context.Background(), uuid.New())
 	name := "test-vpc"
-	cidr := vpcTestCIDR
+	cidr := testutil.TestCIDR
 
 	network.On("CreateBridge", mock.Anything, mock.MatchedBy(func(n string) bool {
 		return len(n) > 0 // Dynamic name
@@ -54,7 +53,7 @@ func TestVpcServiceCreateSuccess(t *testing.T) {
 }
 
 func TestVpcServiceCreateDBFailureRollsBackBridge(t *testing.T) {
-	vpcRepo, network, _, svc := setupVpcServiceTest(t, vpcTestCIDR)
+	vpcRepo, network, _, svc := setupVpcServiceTest(testutil.TestCIDR)
 	defer vpcRepo.AssertExpectations(t)
 	defer network.AssertExpectations(t)
 
@@ -72,7 +71,7 @@ func TestVpcServiceCreateDBFailureRollsBackBridge(t *testing.T) {
 }
 
 func TestVpcServiceDeleteSuccess(t *testing.T) {
-	vpcRepo, network, auditSvc, svc := setupVpcServiceTest(t, vpcTestCIDR)
+	vpcRepo, network, auditSvc, svc := setupVpcServiceTest(testutil.TestCIDR)
 	defer vpcRepo.AssertExpectations(t)
 	defer network.AssertExpectations(t)
 	defer auditSvc.AssertExpectations(t)
@@ -95,7 +94,7 @@ func TestVpcServiceDeleteSuccess(t *testing.T) {
 }
 
 func TestVpcServiceListSuccess(t *testing.T) {
-	vpcRepo, _, _, svc := setupVpcServiceTest(t, vpcTestCIDR)
+	vpcRepo, _, _, svc := setupVpcServiceTest(testutil.TestCIDR)
 	defer vpcRepo.AssertExpectations(t)
 
 	vpcs := []*domain.VPC{{Name: "vpc1"}, {Name: "vpc2"}}
@@ -108,7 +107,7 @@ func TestVpcServiceListSuccess(t *testing.T) {
 }
 
 func TestVpcServiceGetByName(t *testing.T) {
-	vpcRepo, _, _, svc := setupVpcServiceTest(t, vpcTestCIDR)
+	vpcRepo, _, _, svc := setupVpcServiceTest(testutil.TestCIDR)
 	defer vpcRepo.AssertExpectations(t)
 
 	name := "my-vpc"

--- a/internal/handlers/cache_handler_test.go
+++ b/internal/handlers/cache_handler_test.go
@@ -207,7 +207,7 @@ func TestCacheHandlerGetStats(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestCacheHandler_Errors(t *testing.T) {
+func TestCacheHandlerErrors(t *testing.T) {
 	svc, handler, r := setupCacheHandlerTest(t)
 	r.POST(cachesPath, handler.Create)
 	r.GET(cachesPath, handler.List)

--- a/internal/handlers/identity_handler_test.go
+++ b/internal/handlers/identity_handler_test.go
@@ -58,7 +58,7 @@ func (m *mockIdentityService) RotateKey(ctx context.Context, userID, id uuid.UUI
 	return args.Get(0).(*domain.APIKey), args.Error(1)
 }
 
-func setupIdentityHandlerTest(t *testing.T, userID uuid.UUID) (*mockIdentityService, *IdentityHandler, *gin.Engine) {
+func setupIdentityHandlerTest(userID uuid.UUID) (*mockIdentityService, *IdentityHandler, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockIdentityService)
 	handler := NewIdentityHandler(svc)
@@ -73,7 +73,7 @@ func setupIdentityHandlerTest(t *testing.T, userID uuid.UUID) (*mockIdentityServ
 
 func TestIdentityHandlerCreateKey(t *testing.T) {
 	userID := uuid.New()
-	svc, handler, r := setupIdentityHandlerTest(t, userID)
+	svc, handler, r := setupIdentityHandlerTest(userID)
 	defer svc.AssertExpectations(t)
 
 	r.POST(authKeysPath, handler.CreateKey)
@@ -94,7 +94,7 @@ func TestIdentityHandlerCreateKey(t *testing.T) {
 
 func TestIdentityHandlerListKeys(t *testing.T) {
 	userID := uuid.New()
-	svc, handler, r := setupIdentityHandlerTest(t, userID)
+	svc, handler, r := setupIdentityHandlerTest(userID)
 	defer svc.AssertExpectations(t)
 
 	r.GET(authKeysPath, handler.ListKeys)
@@ -114,7 +114,7 @@ func TestIdentityHandlerListKeys(t *testing.T) {
 
 func TestIdentityHandlerRevokeKey(t *testing.T) {
 	userID := uuid.New()
-	svc, handler, r := setupIdentityHandlerTest(t, userID)
+	svc, handler, r := setupIdentityHandlerTest(userID)
 	defer svc.AssertExpectations(t)
 
 	keyID := uuid.New()
@@ -132,7 +132,7 @@ func TestIdentityHandlerRevokeKey(t *testing.T) {
 
 func TestIdentityHandlerRotateKey(t *testing.T) {
 	userID := uuid.New()
-	svc, handler, r := setupIdentityHandlerTest(t, userID)
+	svc, handler, r := setupIdentityHandlerTest(userID)
 	defer svc.AssertExpectations(t)
 
 	keyID := uuid.New()
@@ -152,7 +152,7 @@ func TestIdentityHandlerRotateKey(t *testing.T) {
 
 func TestIdentityHandlerRegenerateKey(t *testing.T) {
 	userID := uuid.New()
-	svc, handler, r := setupIdentityHandlerTest(t, userID)
+	svc, handler, r := setupIdentityHandlerTest(userID)
 	defer svc.AssertExpectations(t)
 
 	keyID := uuid.New()

--- a/internal/handlers/instance_handler_test.go
+++ b/internal/handlers/instance_handler_test.go
@@ -56,7 +56,8 @@ func (m *instanceServiceMock) GetInstance(ctx context.Context, idOrName string) 
 
 func (m *instanceServiceMock) GetInstanceLogs(ctx context.Context, idOrName string) (string, error) {
 	args := m.Called(ctx, idOrName)
-	return args.String(0), args.Error(1)
+	logs := args.String(0)
+	return logs, args.Error(1)
 }
 
 func (m *instanceServiceMock) GetInstanceStats(ctx context.Context, idOrName string) (*domain.InstanceStats, error) {

--- a/internal/handlers/security_group_handler.go
+++ b/internal/handlers/security_group_handler.go
@@ -18,12 +18,31 @@ func NewSecurityGroupHandler(svc ports.SecurityGroupService) *SecurityGroupHandl
 	return &SecurityGroupHandler{svc: svc}
 }
 
+type CreateSecurityGroupRequest struct {
+	VPCID       uuid.UUID `json:"vpc_id" binding:"required"`
+	Name        string    `json:"name" binding:"required"`
+	Description string    `json:"description"`
+}
+
+type AttachDetachSGRequest struct {
+	InstanceID uuid.UUID `json:"instance_id" binding:"required"`
+	GroupID    uuid.UUID `json:"group_id" binding:"required"`
+}
+
+// Create creates a new security group
+// @Summary Create security group
+// @Description Creates a new security group in a VPC
+// @Tags security-groups
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param request body CreateSecurityGroupRequest true "Create request"
+// @Success 201 {object} domain.SecurityGroup
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /security-groups [post]
 func (h *SecurityGroupHandler) Create(c *gin.Context) {
-	var req struct {
-		VPCID       uuid.UUID `json:"vpc_id" binding:"required"`
-		Name        string    `json:"name" binding:"required"`
-		Description string    `json:"description"`
-	}
+	var req CreateSecurityGroupRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -39,6 +58,17 @@ func (h *SecurityGroupHandler) Create(c *gin.Context) {
 	httputil.Success(c, http.StatusCreated, sg)
 }
 
+// List lists security groups
+// @Summary List security groups
+// @Description Lists all security groups for a VPC
+// @Tags security-groups
+// @Produce json
+// @Security APIKeyAuth
+// @Param vpc_id query string true "VPC ID"
+// @Success 200 {array} domain.SecurityGroup
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /security-groups [get]
 func (h *SecurityGroupHandler) List(c *gin.Context) {
 	vpcIDStr := c.Query("vpc_id")
 	if vpcIDStr == "" {
@@ -61,6 +91,18 @@ func (h *SecurityGroupHandler) List(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, groups)
 }
 
+// Get gets a security group
+// @Summary Get security group
+// @Description Gets details of a specific security group
+// @Tags security-groups
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Security Group ID"
+// @Param vpc_id query string false "VPC ID (optional if ID is UUID)"
+// @Success 200 {object} domain.SecurityGroup
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /security-groups/{id} [get]
 func (h *SecurityGroupHandler) Get(c *gin.Context) {
 	id := c.Param("id")
 	vpcIDStr := c.Query("vpc_id")
@@ -79,6 +121,17 @@ func (h *SecurityGroupHandler) Get(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, sg)
 }
 
+// Delete deletes a security group
+// @Summary Delete security group
+// @Description Deletes a security group
+// @Tags security-groups
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Security Group ID"
+// @Success 200 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /security-groups/{id} [delete]
 func (h *SecurityGroupHandler) Delete(c *gin.Context) {
 	idStr := c.Param("id")
 	id, err := uuid.Parse(idStr)
@@ -95,6 +148,19 @@ func (h *SecurityGroupHandler) Delete(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, gin.H{"message": "security group deleted"})
 }
 
+// AddRule adds a security group rule
+// @Summary Add security rule
+// @Description Adds a new rule to a security group
+// @Tags security-groups
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Security Group ID"
+// @Param request body domain.SecurityRule true "Rule details"
+// @Success 201 {object} domain.SecurityRule
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /security-groups/{id}/rules [post]
 func (h *SecurityGroupHandler) AddRule(c *gin.Context) {
 	groupIDStr := c.Param("id")
 	groupID, err := uuid.Parse(groupIDStr)
@@ -118,11 +184,20 @@ func (h *SecurityGroupHandler) AddRule(c *gin.Context) {
 	httputil.Success(c, http.StatusCreated, rule)
 }
 
+// Attach attaches a security group to an instance
+// @Summary Attach security group
+// @Description Associates a security group with a compute instance
+// @Tags security-groups
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param request body AttachDetachSGRequest true "Attach details"
+// @Success 200 {object} httputil.Response
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /security-groups/attach [post]
 func (h *SecurityGroupHandler) Attach(c *gin.Context) {
-	var req struct {
-		InstanceID uuid.UUID `json:"instance_id" binding:"required"`
-		GroupID    uuid.UUID `json:"group_id" binding:"required"`
-	}
+	var req AttachDetachSGRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -137,6 +212,17 @@ func (h *SecurityGroupHandler) Attach(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, gin.H{"message": "security group attached"})
 }
 
+// RemoveRule removes a security group rule
+// @Summary Remove security rule
+// @Description Deletes a specific security rule by ID
+// @Tags security-groups
+// @Produce json
+// @Security APIKeyAuth
+// @Param rule_id path string true "Rule ID"
+// @Success 200 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /security-groups/rules/{rule_id} [delete]
 func (h *SecurityGroupHandler) RemoveRule(c *gin.Context) {
 	ruleIDStr := c.Param("rule_id")
 	ruleID, err := uuid.Parse(ruleIDStr)
@@ -153,11 +239,20 @@ func (h *SecurityGroupHandler) RemoveRule(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, gin.H{"message": "security rule removed"})
 }
 
+// Detach detaches a security group from an instance
+// @Summary Detach security group
+// @Description Removes a security group association from a compute instance
+// @Tags security-groups
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param request body AttachDetachSGRequest true "Detach details"
+// @Success 200 {object} httputil.Response
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /security-groups/detach [post]
 func (h *SecurityGroupHandler) Detach(c *gin.Context) {
-	var req struct {
-		InstanceID uuid.UUID `json:"instance_id" binding:"required"`
-		GroupID    uuid.UUID `json:"group_id" binding:"required"`
-	}
+	var req AttachDetachSGRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})

--- a/internal/handlers/security_group_handler.go
+++ b/internal/handlers/security_group_handler.go
@@ -128,7 +128,7 @@ func (h *SecurityGroupHandler) Get(c *gin.Context) {
 // @Produce json
 // @Security APIKeyAuth
 // @Param id path string true "Security Group ID"
-// @Success 200 {object} httputil.Response
+// @Success 204
 // @Failure 404 {object} httputil.Response
 // @Failure 500 {object} httputil.Response
 // @Router /security-groups/{id} [delete]
@@ -145,7 +145,7 @@ func (h *SecurityGroupHandler) Delete(c *gin.Context) {
 		return
 	}
 
-	httputil.Success(c, http.StatusOK, gin.H{"message": "security group deleted"})
+	c.Status(http.StatusNoContent)
 }
 
 // AddRule adds a security group rule
@@ -219,7 +219,7 @@ func (h *SecurityGroupHandler) Attach(c *gin.Context) {
 // @Produce json
 // @Security APIKeyAuth
 // @Param rule_id path string true "Rule ID"
-// @Success 200 {object} httputil.Response
+// @Success 204
 // @Failure 404 {object} httputil.Response
 // @Failure 500 {object} httputil.Response
 // @Router /security-groups/rules/{rule_id} [delete]
@@ -236,7 +236,7 @@ func (h *SecurityGroupHandler) RemoveRule(c *gin.Context) {
 		return
 	}
 
-	httputil.Success(c, http.StatusOK, gin.H{"message": "security rule removed"})
+	c.Status(http.StatusNoContent)
 }
 
 // Detach detaches a security group from an instance

--- a/internal/handlers/security_group_handler.go
+++ b/internal/handlers/security_group_handler.go
@@ -136,3 +136,38 @@ func (h *SecurityGroupHandler) Attach(c *gin.Context) {
 
 	httputil.Success(c, http.StatusOK, gin.H{"message": "security group attached"})
 }
+
+func (h *SecurityGroupHandler) RemoveRule(c *gin.Context) {
+	ruleIDStr := c.Param("rule_id")
+	ruleID, err := uuid.Parse(ruleIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid rule_id"})
+		return
+	}
+
+	if err := h.svc.RemoveRule(c.Request.Context(), ruleID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"message": "security rule removed"})
+}
+
+func (h *SecurityGroupHandler) Detach(c *gin.Context) {
+	var req struct {
+		InstanceID uuid.UUID `json:"instance_id" binding:"required"`
+		GroupID    uuid.UUID `json:"group_id" binding:"required"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if err := h.svc.DetachFromInstance(c.Request.Context(), req.InstanceID, req.GroupID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"message": "security group detached"})
+}

--- a/internal/handlers/subnet_handler_test.go
+++ b/internal/handlers/subnet_handler_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 const (
 	testSubnetName    = "test-subnet"
-	testSubnetCIDR    = "10.0.1.0/24"
 	vpcsPathPrefix    = "/vpcs/"
 	subnetsPathPrefix = "/subnets/"
 	subnetsPath       = "/subnets"
@@ -68,14 +68,14 @@ func TestSubnetHandlerCreateSuccess(t *testing.T) {
 		ID:        subnetID,
 		VPCID:     vpcID,
 		Name:      testSubnetName,
-		CIDRBlock: testSubnetCIDR,
+		CIDRBlock: testutil.TestSubnetCIDR,
 	}
 
-	svc.On("CreateSubnet", mock.Anything, vpcID, testSubnetName, testSubnetCIDR, "us-east-1a").Return(expectedSubnet, nil)
+	svc.On("CreateSubnet", mock.Anything, vpcID, testSubnetName, testutil.TestSubnetCIDR, "us-east-1a").Return(expectedSubnet, nil)
 
 	reqBody := map[string]string{
 		"name":              testSubnetName,
-		"cidr_block":        testSubnetCIDR,
+		"cidr_block":        testutil.TestSubnetCIDR,
 		"availability_zone": "us-east-1a",
 	}
 	body, _ := json.Marshal(reqBody)

--- a/internal/handlers/subnet_handler_test.go
+++ b/internal/handlers/subnet_handler_test.go
@@ -15,6 +15,14 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
+const (
+	testSubnetName    = "test-subnet"
+	testSubnetCIDR    = "10.0.1.0/24"
+	vpcsPathPrefix    = "/vpcs/"
+	subnetsPathPrefix = "/subnets/"
+	subnetsPath       = "/subnets"
+)
+
 type mockSubnetService struct {
 	mock.Mock
 }
@@ -48,7 +56,7 @@ func (m *mockSubnetService) DeleteSubnet(ctx context.Context, id uuid.UUID) erro
 	return args.Error(0)
 }
 
-func TestSubnetHandler_Create_Success(t *testing.T) {
+func TestSubnetHandlerCreateSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
@@ -59,23 +67,23 @@ func TestSubnetHandler_Create_Success(t *testing.T) {
 	expectedSubnet := &domain.Subnet{
 		ID:        subnetID,
 		VPCID:     vpcID,
-		Name:      "test-subnet",
-		CIDRBlock: "10.0.1.0/24",
+		Name:      testSubnetName,
+		CIDRBlock: testSubnetCIDR,
 	}
 
-	svc.On("CreateSubnet", mock.Anything, vpcID, "test-subnet", "10.0.1.0/24", "us-east-1a").Return(expectedSubnet, nil)
+	svc.On("CreateSubnet", mock.Anything, vpcID, testSubnetName, testSubnetCIDR, "us-east-1a").Return(expectedSubnet, nil)
 
 	reqBody := map[string]string{
-		"name":              "test-subnet",
-		"cidr_block":        "10.0.1.0/24",
+		"name":              testSubnetName,
+		"cidr_block":        testSubnetCIDR,
 		"availability_zone": "us-east-1a",
 	}
 	body, _ := json.Marshal(reqBody)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("POST", "/vpcs/"+vpcID.String()+"/subnets", bytes.NewBuffer(body))
-	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request = httptest.NewRequest("POST", vpcsPathPrefix+vpcID.String()+subnetsPath, bytes.NewBuffer(body))
+	c.Request.Header.Set(contentType, applicationJSON)
 	c.Params = gin.Params{{Key: "vpc_id", Value: vpcID.String()}}
 
 	handler.Create(c)
@@ -84,14 +92,14 @@ func TestSubnetHandler_Create_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_Create_InvalidVpcID(t *testing.T) {
+func TestSubnetHandlerCreateInvalidVpcID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("POST", "/vpcs/invalid-uuid/subnets", nil)
+	c.Request = httptest.NewRequest("POST", vpcsPathPrefix+"invalid-uuid/subnets", nil)
 	c.Params = gin.Params{{Key: "vpc_id", Value: "invalid-uuid"}}
 
 	handler.Create(c)
@@ -100,7 +108,7 @@ func TestSubnetHandler_Create_InvalidVpcID(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_Create_InvalidRequest(t *testing.T) {
+func TestSubnetHandlerCreateInvalidRequest(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
@@ -114,8 +122,8 @@ func TestSubnetHandler_Create_InvalidRequest(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("POST", "/vpcs/"+vpcID.String()+"/subnets", bytes.NewBuffer(body))
-	c.Request.Header.Set("Content-Type", "application/json")
+	c.Request = httptest.NewRequest("POST", vpcsPathPrefix+vpcID.String()+subnetsPath, bytes.NewBuffer(body))
+	c.Request.Header.Set(contentType, applicationJSON)
 	c.Params = gin.Params{{Key: "vpc_id", Value: vpcID.String()}}
 
 	handler.Create(c)
@@ -124,7 +132,7 @@ func TestSubnetHandler_Create_InvalidRequest(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_List_Success(t *testing.T) {
+func TestSubnetHandlerListSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
@@ -140,7 +148,7 @@ func TestSubnetHandler_List_Success(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("GET", "/vpcs/"+vpcID.String()+"/subnets", nil)
+	c.Request = httptest.NewRequest("GET", vpcsPathPrefix+vpcID.String()+subnetsPath, nil)
 	c.Params = gin.Params{{Key: "vpc_id", Value: vpcID.String()}}
 
 	handler.List(c)
@@ -149,14 +157,14 @@ func TestSubnetHandler_List_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_List_InvalidVpcID(t *testing.T) {
+func TestSubnetHandlerListInvalidVpcID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("GET", "/vpcs/invalid/subnets", nil)
+	c.Request = httptest.NewRequest("GET", vpcsPathPrefix+"invalid/subnets", nil)
 	c.Params = gin.Params{{Key: "vpc_id", Value: "invalid"}}
 
 	handler.List(c)
@@ -165,7 +173,7 @@ func TestSubnetHandler_List_InvalidVpcID(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_Get_Success(t *testing.T) {
+func TestSubnetHandlerGetSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
@@ -174,14 +182,14 @@ func TestSubnetHandler_Get_Success(t *testing.T) {
 
 	expectedSubnet := &domain.Subnet{
 		ID:   subnetID,
-		Name: "test-subnet",
+		Name: testSubnetName,
 	}
 
 	svc.On("GetSubnet", mock.Anything, subnetID.String(), uuid.Nil).Return(expectedSubnet, nil)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("GET", "/subnets/"+subnetID.String(), nil)
+	c.Request = httptest.NewRequest("GET", subnetsPathPrefix+subnetID.String(), nil)
 	c.Params = gin.Params{{Key: "id", Value: subnetID.String()}}
 
 	handler.Get(c)
@@ -190,7 +198,7 @@ func TestSubnetHandler_Get_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_Get_ServiceError(t *testing.T) {
+func TestSubnetHandlerGetServiceError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
@@ -201,7 +209,7 @@ func TestSubnetHandler_Get_ServiceError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("GET", "/subnets/"+subnetID.String(), nil)
+	c.Request = httptest.NewRequest("GET", subnetsPathPrefix+subnetID.String(), nil)
 	c.Params = gin.Params{{Key: "id", Value: subnetID.String()}}
 
 	handler.Get(c)
@@ -210,7 +218,7 @@ func TestSubnetHandler_Get_ServiceError(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_Delete_Success(t *testing.T) {
+func TestSubnetHandlerDeleteSuccess(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
@@ -221,7 +229,7 @@ func TestSubnetHandler_Delete_Success(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("DELETE", "/subnets/"+subnetID.String(), nil)
+	c.Request = httptest.NewRequest("DELETE", subnetsPathPrefix+subnetID.String(), nil)
 	c.Params = gin.Params{{Key: "id", Value: subnetID.String()}}
 
 	handler.Delete(c)
@@ -230,14 +238,14 @@ func TestSubnetHandler_Delete_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_Delete_InvalidID(t *testing.T) {
+func TestSubnetHandlerDeleteInvalidID(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("DELETE", "/subnets/invalid", nil)
+	c.Request = httptest.NewRequest("DELETE", subnetsPathPrefix+"invalid", nil)
 	c.Params = gin.Params{{Key: "id", Value: "invalid"}}
 
 	handler.Delete(c)
@@ -246,7 +254,7 @@ func TestSubnetHandler_Delete_InvalidID(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
-func TestSubnetHandler_Delete_ServiceError(t *testing.T) {
+func TestSubnetHandlerDeleteServiceError(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockSubnetService)
 	handler := NewSubnetHandler(svc)
@@ -257,7 +265,7 @@ func TestSubnetHandler_Delete_ServiceError(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-	c.Request = httptest.NewRequest("DELETE", "/subnets/"+subnetID.String(), nil)
+	c.Request = httptest.NewRequest("DELETE", subnetsPathPrefix+subnetID.String(), nil)
 	c.Params = gin.Params{{Key: "id", Value: subnetID.String()}}
 
 	handler.Delete(c)

--- a/internal/handlers/vpc_handler_test.go
+++ b/internal/handlers/vpc_handler_test.go
@@ -81,7 +81,7 @@ func TestVpcHandlerCreate(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, w.Code)
 }
 
-func TestVpcHandlerCreate_Errors(t *testing.T) {
+func TestVpcHandlerCreateErrors(t *testing.T) {
 	svc, handler, r := setupVpcHandlerTest(t)
 	r.POST(vpcsPath, handler.Create)
 
@@ -137,7 +137,7 @@ func TestVpcHandlerGet(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestVpcHandlerGet_Error(t *testing.T) {
+func TestVpcHandlerGetError(t *testing.T) {
 	svc, handler, r := setupVpcHandlerTest(t)
 	r.GET(vpcsPath+"/:id", handler.Get)
 
@@ -167,7 +167,7 @@ func TestVpcHandlerDelete(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestVpcHandlerList_Error(t *testing.T) {
+func TestVpcHandlerListError(t *testing.T) {
 	svc, handler, r := setupVpcHandlerTest(t)
 	r.GET(vpcsPath, handler.List)
 
@@ -180,7 +180,7 @@ func TestVpcHandlerList_Error(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestVpcHandlerDelete_Error(t *testing.T) {
+func TestVpcHandlerDeleteError(t *testing.T) {
 	svc, handler, r := setupVpcHandlerTest(t)
 	r.DELETE(vpcsPath+"/:id", handler.Delete)
 

--- a/internal/handlers/vpc_handler_test.go
+++ b/internal/handlers/vpc_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -18,7 +19,6 @@ import (
 const (
 	vpcsPath    = "/vpcs"
 	testVpcName = "test-vpc"
-	testCidr    = "10.0.0.0/16"
 )
 
 type mockVpcService struct {
@@ -69,9 +69,9 @@ func TestVpcHandlerCreate(t *testing.T) {
 	r.POST(vpcsPath, handler.Create)
 
 	vpc := &domain.VPC{ID: uuid.New(), Name: testVpcName}
-	svc.On("CreateVPC", mock.Anything, testVpcName, testCidr).Return(vpc, nil)
+	svc.On("CreateVPC", mock.Anything, testVpcName, testutil.TestCIDR).Return(vpc, nil)
 
-	body, err := json.Marshal(map[string]string{"name": testVpcName, "cidr_block": testCidr})
+	body, err := json.Marshal(map[string]string{"name": testVpcName, "cidr_block": testutil.TestCIDR})
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	req, err := http.NewRequest("POST", vpcsPath, bytes.NewBuffer(body))

--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -4,10 +4,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewConfig_Defaults(t *testing.T) {
+func TestNewConfigDefaults(t *testing.T) {
 	// Ensure env vars are unset to test defaults
 	_ = os.Unsetenv("PORT")
 	_ = os.Unsetenv("DATABASE_URL")
@@ -15,12 +16,12 @@ func TestNewConfig_Defaults(t *testing.T) {
 
 	cfg, err := NewConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, "8080", cfg.Port)
-	assert.Equal(t, "postgres://cloud:cloud@localhost:5433/thecloud", cfg.DatabaseURL)
-	assert.Equal(t, "development", cfg.Environment)
+	assert.Equal(t, testutil.TestPort, cfg.Port)
+	assert.Equal(t, testutil.TestDatabaseURL, cfg.DatabaseURL)
+	assert.Equal(t, testutil.TestEnvDev, cfg.Environment)
 }
 
-func TestNewConfig_EnvVars(t *testing.T) {
+func TestNewConfigEnvVars(t *testing.T) {
 	_ = os.Setenv("PORT", "9090")
 	_ = os.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/testdb")
 	_ = os.Setenv("APP_ENV", "production")
@@ -32,7 +33,7 @@ func TestNewConfig_EnvVars(t *testing.T) {
 
 	cfg, err := NewConfig()
 	assert.NoError(t, err)
-	assert.Equal(t, "9090", cfg.Port)
-	assert.Equal(t, "postgres://test:test@localhost:5432/testdb", cfg.DatabaseURL)
-	assert.Equal(t, "production", cfg.Environment)
+	assert.Equal(t, testutil.TestProdPort, cfg.Port)
+	assert.Equal(t, testutil.TestProdDatabaseURL, cfg.DatabaseURL)
+	assert.Equal(t, testutil.TestEnvProd, cfg.Environment)
 }

--- a/internal/repositories/docker/adapter_unit_test.go
+++ b/internal/repositories/docker/adapter_unit_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 )
 
 func TestDockerAdapterType(t *testing.T) {
@@ -54,14 +55,14 @@ func TestDockerAdapterGetInstanceIPFirstIP(t *testing.T) {
 	inspect := container.InspectResponse{}
 	inspect.NetworkSettings = &container.NetworkSettings{
 		Networks: map[string]*network.EndpointSettings{
-			"n1": {IPAddress: "10.0.0.2"},
+			"n1": {IPAddress: testutil.TestDockerInstanceIP},
 		},
 	}
 
 	a := &DockerAdapter{cli: &fakeDockerClient{inspect: inspect}}
 	ip, err := a.GetInstanceIP(context.Background(), "cid")
 	require.NoError(t, err)
-	require.Equal(t, "10.0.0.2", ip)
+	require.Equal(t, testutil.TestDockerInstanceIP, ip)
 }
 
 func TestDockerAdapterGetInstanceStatsReturnsBody(t *testing.T) {

--- a/internal/repositories/filesystem/adapter.go
+++ b/internal/repositories/filesystem/adapter.go
@@ -23,12 +23,14 @@ func NewLocalFileStore(basePath string) (*LocalFileStore, error) {
 	return &LocalFileStore{basePath: basePath}, nil
 }
 
+const errTraversal = "invalid path: traversal detected"
+
 func (s *LocalFileStore) Write(ctx context.Context, bucket, key string, r io.Reader) (int64, error) {
 	bucketPath := filepath.Join(s.basePath, filepath.Clean(bucket))
 	filePath := filepath.Join(bucketPath, filepath.Clean(key))
 
 	if !strings.HasPrefix(filePath, filepath.Clean(s.basePath)) {
-		return 0, errors.New(errors.InvalidInput, "invalid path: traversal detected")
+		return 0, errors.New(errors.InvalidInput, errTraversal)
 	}
 
 	if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
@@ -52,7 +54,7 @@ func (s *LocalFileStore) Write(ctx context.Context, bucket, key string, r io.Rea
 func (s *LocalFileStore) Read(ctx context.Context, bucket, key string) (io.ReadCloser, error) {
 	filePath := filepath.Join(s.basePath, filepath.Clean(bucket), filepath.Clean(key))
 	if !strings.HasPrefix(filePath, filepath.Clean(s.basePath)) {
-		return nil, errors.New(errors.InvalidInput, "invalid path: traversal detected")
+		return nil, errors.New(errors.InvalidInput, errTraversal)
 	}
 	f, err := os.Open(filePath)
 	if err != nil {
@@ -67,7 +69,7 @@ func (s *LocalFileStore) Read(ctx context.Context, bucket, key string) (io.ReadC
 func (s *LocalFileStore) Delete(ctx context.Context, bucket, key string) error {
 	filePath := filepath.Join(s.basePath, filepath.Clean(bucket), filepath.Clean(key))
 	if !strings.HasPrefix(filePath, filepath.Clean(s.basePath)) {
-		return errors.New(errors.InvalidInput, "invalid path: traversal detected")
+		return errors.New(errors.InvalidInput, errTraversal)
 	}
 	err := os.Remove(filePath)
 	if err != nil {

--- a/internal/repositories/libvirt/adapter_unit_test.go
+++ b/internal/repositories/libvirt/adapter_unit_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/digitalocean/go-libvirt"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -59,10 +60,10 @@ func TestSanitizeDomainName(t *testing.T) {
 	}
 }
 
-func TestSanitizeDomainName_EmptyString(t *testing.T) {
+func TestSanitizeDomainNameEmptyString(t *testing.T) {
 	a := &LibvirtAdapter{}
 	result := a.sanitizeDomainName("")
-	
+
 	assert.NotEmpty(t, result, "empty name should generate UUID")
 	assert.Len(t, result, 8, "generated name should be 8 chars")
 }
@@ -243,7 +244,7 @@ func TestValidateID(t *testing.T) {
 	}
 }
 
-func TestParseAndValidatePort_Extended(t *testing.T) {
+func TestParseAndValidatePortExtended(t *testing.T) {
 	a := &LibvirtAdapter{}
 
 	tests := []struct {
@@ -334,18 +335,18 @@ func TestResolveVolumePath(t *testing.T) {
 func TestCleanupCreateFailure(t *testing.T) {
 	// This function has side effects but we can test it doesn't panic
 	a := &LibvirtAdapter{}
-	
+
 	// Should not panic - just verify it's callable
 	// Cannot test without real libvirt connection
 	assert.NotNil(t, a)
 }
 
-func TestWaitInitialIP_ContextCancellation(t *testing.T) {
+func TestWaitInitialIPContextCancellation(t *testing.T) {
 	a := &LibvirtAdapter{}
-	
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
-	
+
 	_, err := a.waitInitialIP(ctx, "test-instance")
 	assert.Error(t, err)
 	assert.Equal(t, context.Canceled, err)
@@ -354,8 +355,8 @@ func TestWaitInitialIP_ContextCancellation(t *testing.T) {
 func TestGetNextNetworkRange(t *testing.T) {
 	a := &LibvirtAdapter{
 		networkCounter: 0,
-		poolStart:      net.ParseIP("192.168.100.0"),
-		poolEnd:        net.ParseIP("192.168.200.255"),
+		poolStart:      net.ParseIP(testutil.TestLibvirtPoolStart),
+		poolEnd:        net.ParseIP(testutil.TestLibvirtPoolEnd),
 	}
 
 	gateway1, start1, end1 := a.getNextNetworkRange()
@@ -369,7 +370,7 @@ func TestGetNextNetworkRange(t *testing.T) {
 	assert.Equal(t, 2, a.networkCounter)
 }
 
-func TestExec_NotSupported(t *testing.T) {
+func TestExecNotSupported(t *testing.T) {
 	a := &LibvirtAdapter{}
 	_, err := a.Exec(context.Background(), "instance-id", []string{"echo", "test"})
 	assert.Error(t, err)

--- a/internal/repositories/libvirt/templates_test.go
+++ b/internal/repositories/libvirt/templates_test.go
@@ -1,8 +1,10 @@
 package libvirt
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,28 +28,28 @@ func TestGenerateDomainXML(t *testing.T) {
 	t.Run("with iso and disks", func(t *testing.T) {
 		additionalDisks := []string{"/path/to/vdb", "/dev/sdc"}
 		xml := generateDomainXML("test-vm", "/path/to/disk", "custom-net", "/path/to/iso", 512, 1, additionalDisks)
-		
+
 		assert.Contains(t, xml, "<source file='/path/to/iso'/>")
 		assert.Contains(t, xml, "<target dev='sda' bus='sata'/>")
-		
+
 		// vdb (file)
 		assert.Contains(t, xml, "<disk type='file' device='disk'>")
 		assert.Contains(t, xml, "<source file='/path/to/vdb'/>")
 		assert.Contains(t, xml, "<target dev='vdb' bus='virtio'/>")
-		
+
 		// sdc (block)
 		assert.Contains(t, xml, "<disk type='block' device='disk'>")
 		assert.Contains(t, xml, "<source dev='/dev/sdc'/>")
 		assert.Contains(t, xml, "<target dev='vdc' bus='virtio'/>")
-		
+
 		assert.Contains(t, xml, "<source network='custom-net'/>")
 	})
 }
 
 func TestGenerateNetworkXML(t *testing.T) {
-	xml := generateNetworkXML("test-net", "test-br", "10.0.0.1", "10.0.0.2", "10.0.0.50")
+	xml := generateNetworkXML("test-net", "test-br", testutil.TestIPHost, testutil.TestLibvirtDHCPStart, testutil.TestLibvirtDHCPEnd)
 	assert.Contains(t, xml, "<name>test-net</name>")
 	assert.Contains(t, xml, "<bridge name='test-br' stp='on' delay='0'/>")
-	assert.Contains(t, xml, "<ip address='10.0.0.1'")
-	assert.Contains(t, xml, "<range start='10.0.0.2' end='10.0.0.50'/>")
+	assert.Contains(t, xml, fmt.Sprintf("<ip address='%s'", testutil.TestIPHost))
+	assert.Contains(t, xml, fmt.Sprintf("<range start='%s' end='%s'/>", testutil.TestLibvirtDHCPStart, testutil.TestLibvirtDHCPEnd))
 }

--- a/internal/repositories/noop/adapters_test.go
+++ b/internal/repositories/noop/adapters_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -263,8 +264,8 @@ func TestNoopNetworkAdapter(t *testing.T) {
 	t.Run("PortsAndTunnels", func(t *testing.T) {
 		require.NoError(t, adapter.AddPort(ctx, "br0", "p0"))
 		require.NoError(t, adapter.DeletePort(ctx, "br0", "p0"))
-		require.NoError(t, adapter.CreateVXLANTunnel(ctx, "br0", 1, "1.1.1.1"))
-		require.NoError(t, adapter.DeleteVXLANTunnel(ctx, "br0", "1.1.1.1"))
+		require.NoError(t, adapter.CreateVXLANTunnel(ctx, "br0", 1, testutil.TestNoopIP1))
+		require.NoError(t, adapter.DeleteVXLANTunnel(ctx, "br0", testutil.TestNoopIP1))
 	})
 
 	t.Run("FlowRules", func(t *testing.T) {
@@ -279,7 +280,7 @@ func TestNoopNetworkAdapter(t *testing.T) {
 		require.NoError(t, adapter.CreateVethPair(ctx, "h", "c"))
 		require.NoError(t, adapter.AttachVethToBridge(ctx, "br0", "h"))
 		require.NoError(t, adapter.DeleteVethPair(ctx, "h"))
-		require.NoError(t, adapter.SetVethIP(ctx, "h", "1.1.1.2", "24"))
+		require.NoError(t, adapter.SetVethIP(ctx, "h", testutil.TestNoopIP2, "24"))
 		require.NoError(t, adapter.Ping(ctx))
 	})
 }

--- a/internal/repositories/ovs/adapter_test.go
+++ b/internal/repositories/ovs/adapter_test.go
@@ -2,6 +2,7 @@ package ovs_test
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -9,11 +10,19 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/repositories/ovs"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestOvsAdapter_Integration(t *testing.T) {
+const (
+	testSrcFmt        = "ip,nw_src=%s"
+	ovsNotAvailable   = "OVS not available, skipping validation test"
+	errInvalidBridge  = "expected error for invalid bridge name"
+	invalidBridgeName = "invalid bridge"
+)
+
+func TestOvsAdapterIntegration(t *testing.T) {
 	if os.Getenv("OVS_INTEGRATION_TEST") != "true" {
 		t.Skip("Skipping OVS integration test. Set OVS_INTEGRATION_TEST=true to run.")
 	}
@@ -39,7 +48,7 @@ func TestOvsAdapter_Integration(t *testing.T) {
 	t.Run("AddFlowRule", func(t *testing.T) {
 		rule := ports.FlowRule{
 			Priority: 100,
-			Match:    "ip,nw_src=10.0.0.1",
+			Match:    fmt.Sprintf(testSrcFmt, testutil.TestIPHost),
 			Actions:  "drop",
 		}
 		err := adapter.AddFlowRule(ctx, bridgeName, rule)
@@ -48,7 +57,7 @@ func TestOvsAdapter_Integration(t *testing.T) {
 
 	// 3. Delete Flow Rule
 	t.Run("DeleteFlowRule", func(t *testing.T) {
-		err := adapter.DeleteFlowRule(ctx, bridgeName, "ip,nw_src=10.0.0.1")
+		err := adapter.DeleteFlowRule(ctx, bridgeName, fmt.Sprintf(testSrcFmt, testutil.TestIPHost))
 		assert.NoError(t, err)
 	})
 
@@ -59,7 +68,7 @@ func TestOvsAdapter_Integration(t *testing.T) {
 	})
 }
 
-func TestOvsAdapter_Type(t *testing.T) {
+func TestOvsAdapterType(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	adapter, err := ovs.NewOvsAdapter(logger)
 	if err != nil {
@@ -71,50 +80,50 @@ func TestOvsAdapter_Type(t *testing.T) {
 	}
 }
 
-func TestOvsAdapter_CreateBridge_InvalidName(t *testing.T) {
+func TestOvsAdapterCreateBridgeInvalidName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	adapter, err := ovs.NewOvsAdapter(logger)
 	if err != nil {
-		t.Skip("OVS not available, skipping validation test")
+		t.Skip(ovsNotAvailable)
 	}
 
 	err = adapter.CreateBridge(context.Background(), "invalid name", 1)
 	if err == nil {
-		t.Fatalf("expected error for invalid bridge name")
+		t.Fatalf(errInvalidBridge)
 	}
 }
 
-func TestOvsAdapter_DeleteBridge_InvalidName(t *testing.T) {
+func TestOvsAdapterDeleteBridgeInvalidName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	adapter, err := ovs.NewOvsAdapter(logger)
 	if err != nil {
-		t.Skip("OVS not available, skipping validation test")
+		t.Skip(ovsNotAvailable)
 	}
 
 	err = adapter.DeleteBridge(context.Background(), "invalid name")
 	if err == nil {
-		t.Fatalf("expected error for invalid bridge name")
+		t.Fatalf(errInvalidBridge)
 	}
 }
 
-func TestOvsAdapter_AddPort_InvalidName(t *testing.T) {
+func TestOvsAdapterAddPortInvalidName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	adapter, err := ovs.NewOvsAdapter(logger)
 	if err != nil {
-		t.Skip("OVS not available, skipping validation test")
+		t.Skip(ovsNotAvailable)
 	}
 
-	err = adapter.AddPort(context.Background(), "invalid bridge", "port")
+	err = adapter.AddPort(context.Background(), invalidBridgeName, "port")
 	if err == nil {
-		t.Fatalf("expected error for invalid bridge name")
+		t.Fatalf(errInvalidBridge)
 	}
 }
 
-func TestOvsAdapter_DeletePort_InvalidName(t *testing.T) {
+func TestOvsAdapterDeletePortInvalidName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	adapter, err := ovs.NewOvsAdapter(logger)
 	if err != nil {
-		t.Skip("OVS not available, skipping validation test")
+		t.Skip(ovsNotAvailable)
 	}
 
 	err = adapter.DeletePort(context.Background(), "bridge", "invalid port")
@@ -123,34 +132,34 @@ func TestOvsAdapter_DeletePort_InvalidName(t *testing.T) {
 	}
 }
 
-func TestOvsAdapter_AddFlowRule_InvalidBridge(t *testing.T) {
+func TestOvsAdapterAddFlowRuleInvalidBridge(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	adapter, err := ovs.NewOvsAdapter(logger)
 	if err != nil {
-		t.Skip("OVS not available, skipping validation test")
+		t.Skip(ovsNotAvailable)
 	}
 
 	rule := ports.FlowRule{Priority: 100, Match: "in_port=1", Actions: "output:2"}
-	err = adapter.AddFlowRule(context.Background(), "invalid bridge", rule)
+	err = adapter.AddFlowRule(context.Background(), invalidBridgeName, rule)
 	if err == nil {
-		t.Fatalf("expected error for invalid bridge name")
+		t.Fatalf(errInvalidBridge)
 	}
 }
 
-func TestOvsAdapter_DeleteFlowRule_InvalidBridge(t *testing.T) {
+func TestOvsAdapterDeleteFlowRuleInvalidBridge(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	adapter, err := ovs.NewOvsAdapter(logger)
 	if err != nil {
-		t.Skip("OVS not available, skipping validation test")
+		t.Skip(ovsNotAvailable)
 	}
 
-	err = adapter.DeleteFlowRule(context.Background(), "invalid bridge", "match")
+	err = adapter.DeleteFlowRule(context.Background(), invalidBridgeName, "match")
 	if err == nil {
-		t.Fatalf("expected error for invalid bridge name")
+		t.Fatalf(errInvalidBridge)
 	}
 }
 
-func TestOvsAdapter_ListFlowRules(t *testing.T) {
+func TestOvsAdapterListFlowRules(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	adapter, err := ovs.NewOvsAdapter(logger)
 	if err != nil {

--- a/internal/repositories/ovs/adapter_test.go
+++ b/internal/repositories/ovs/adapter_test.go
@@ -89,7 +89,7 @@ func TestOvsAdapterCreateBridgeInvalidName(t *testing.T) {
 
 	err = adapter.CreateBridge(context.Background(), "invalid name", 1)
 	if err == nil {
-		t.Fatalf(errInvalidBridge)
+		t.Fatal(errInvalidBridge)
 	}
 }
 
@@ -102,7 +102,7 @@ func TestOvsAdapterDeleteBridgeInvalidName(t *testing.T) {
 
 	err = adapter.DeleteBridge(context.Background(), "invalid name")
 	if err == nil {
-		t.Fatalf(errInvalidBridge)
+		t.Fatal(errInvalidBridge)
 	}
 }
 
@@ -115,7 +115,7 @@ func TestOvsAdapterAddPortInvalidName(t *testing.T) {
 
 	err = adapter.AddPort(context.Background(), invalidBridgeName, "port")
 	if err == nil {
-		t.Fatalf(errInvalidBridge)
+		t.Fatal(errInvalidBridge)
 	}
 }
 
@@ -142,7 +142,7 @@ func TestOvsAdapterAddFlowRuleInvalidBridge(t *testing.T) {
 	rule := ports.FlowRule{Priority: 100, Match: "in_port=1", Actions: "output:2"}
 	err = adapter.AddFlowRule(context.Background(), invalidBridgeName, rule)
 	if err == nil {
-		t.Fatalf(errInvalidBridge)
+		t.Fatal(errInvalidBridge)
 	}
 }
 
@@ -155,7 +155,7 @@ func TestOvsAdapterDeleteFlowRuleInvalidBridge(t *testing.T) {
 
 	err = adapter.DeleteFlowRule(context.Background(), invalidBridgeName, "match")
 	if err == nil {
-		t.Fatalf(errInvalidBridge)
+		t.Fatal(errInvalidBridge)
 	}
 }
 

--- a/internal/repositories/postgres/audit_repo_test.go
+++ b/internal/repositories/postgres/audit_repo_test.go
@@ -8,10 +8,11 @@ import (
 	"github.com/google/uuid"
 	"github.com/pashagolub/pgxmock/v3"
 	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAuditRepository_Create(t *testing.T) {
+func TestAuditRepositoryCreate(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	assert.NoError(t, err)
 	defer mock.Close()
@@ -24,8 +25,8 @@ func TestAuditRepository_Create(t *testing.T) {
 		ResourceType: "INSTANCE",
 		ResourceID:   uuid.New().String(),
 		Details:      map[string]interface{}{"name": "test"},
-		IPAddress:    "127.0.0.1",
-		UserAgent:    "UA",
+		IPAddress:    testutil.TestIPLocalhost,
+		UserAgent:    testutil.TestUserAgent,
 		CreatedAt:    time.Now(),
 	}
 
@@ -38,7 +39,7 @@ func TestAuditRepository_Create(t *testing.T) {
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 
-func TestAuditRepository_ListByUserID(t *testing.T) {
+func TestAuditRepositoryListByUserID(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	assert.NoError(t, err)
 	defer mock.Close()

--- a/internal/repositories/postgres/instance_repo_test.go
+++ b/internal/repositories/postgres/instance_repo_test.go
@@ -63,7 +63,7 @@ func TestInstanceRepositoryCreate(t *testing.T) {
 		inst := &domain.Instance{ID: uuid.New()}
 
 		mock.ExpectExec("(?s)INSERT INTO instances.*").
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		err = repo.Create(context.Background(), inst)
 		assert.Error(t, err)
@@ -197,7 +197,7 @@ func TestInstanceRepositoryList(t *testing.T) {
 
 		mock.ExpectQuery(selectQuery).
 			WithArgs(userID).
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		list, err := repo.List(ctx)
 		assert.Error(t, err)

--- a/internal/repositories/postgres/instance_repo_test.go
+++ b/internal/repositories/postgres/instance_repo_test.go
@@ -12,10 +12,17 @@ import (
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	theclouderrors "github.com/poyrazk/thecloud/internal/errors"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestInstanceRepository_Create(t *testing.T) {
+const (
+	testInstanceName = "inst-1"
+	testInstanceImg  = "ubuntu:latest"
+	selectQuery      = "(?s)SELECT.+FROM instances.*"
+)
+
+func TestInstanceRepositoryCreate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -25,14 +32,14 @@ func TestInstanceRepository_Create(t *testing.T) {
 		inst := &domain.Instance{
 			ID:          uuid.New(),
 			UserID:      uuid.New(),
-			Name:        "inst-1",
-			Image:       "ubuntu:latest",
+			Name:        testInstanceName,
+			Image:       testInstanceImg,
 			ContainerID: "cid-1",
 			Status:      domain.StatusRunning,
 			Ports:       "80:80",
 			VpcID:       nil,
 			SubnetID:    nil,
-			PrivateIP:   "10.0.0.1",
+			PrivateIP:   testutil.TestIPHost,
 			OvsPort:     "ovs-1",
 			Version:     1,
 			CreatedAt:   time.Now(),
@@ -56,14 +63,14 @@ func TestInstanceRepository_Create(t *testing.T) {
 		inst := &domain.Instance{ID: uuid.New()}
 
 		mock.ExpectExec("(?s)INSERT INTO instances.*").
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		err = repo.Create(context.Background(), inst)
 		assert.Error(t, err)
 	})
 }
 
-func TestInstanceRepository_GetByID(t *testing.T) {
+func TestInstanceRepositoryGetByID(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -75,10 +82,10 @@ func TestInstanceRepository_GetByID(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
 
-		mock.ExpectQuery("(?s)SELECT.+FROM instances.*").
+		mock.ExpectQuery(selectQuery).
 			WithArgs(id, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "version", "created_at", "updated_at"}).
-				AddRow(id, userID, "inst-1", "ubuntu:latest", "cid-1", string(domain.StatusRunning), "80:80", nil, nil, "10.0.0.1", "ovs-1", 1, now, now))
+				AddRow(id, userID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", 1, now, now))
 
 		inst, err := repo.GetByID(ctx, id)
 		assert.NoError(t, err)
@@ -96,7 +103,7 @@ func TestInstanceRepository_GetByID(t *testing.T) {
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
-		mock.ExpectQuery("(?s)SELECT.+FROM instances.*").
+		mock.ExpectQuery(selectQuery).
 			WithArgs(id, userID).
 			WillReturnError(pgx.ErrNoRows)
 
@@ -110,7 +117,7 @@ func TestInstanceRepository_GetByID(t *testing.T) {
 	})
 }
 
-func TestInstanceRepository_GetByName(t *testing.T) {
+func TestInstanceRepositoryGetByName(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -120,13 +127,13 @@ func TestInstanceRepository_GetByName(t *testing.T) {
 		id := uuid.New()
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
-		name := "inst-1"
+		name := testInstanceName
 		now := time.Now()
 
-		mock.ExpectQuery("(?s)SELECT.+FROM instances.*").
+		mock.ExpectQuery(selectQuery).
 			WithArgs(name, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "version", "created_at", "updated_at"}).
-				AddRow(id, userID, name, "ubuntu:latest", "cid-1", string(domain.StatusRunning), "80:80", nil, nil, "10.0.0.1", "ovs-1", 1, now, now))
+				AddRow(id, userID, name, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", 1, now, now))
 
 		inst, err := repo.GetByName(ctx, name)
 		assert.NoError(t, err)
@@ -142,9 +149,9 @@ func TestInstanceRepository_GetByName(t *testing.T) {
 		repo := NewInstanceRepository(mock)
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
-		name := "inst-1"
+		name := testInstanceName
 
-		mock.ExpectQuery("(?s)SELECT.+FROM instances.*").
+		mock.ExpectQuery(selectQuery).
 			WithArgs(name, userID).
 			WillReturnError(pgx.ErrNoRows)
 
@@ -158,7 +165,7 @@ func TestInstanceRepository_GetByName(t *testing.T) {
 	})
 }
 
-func TestInstanceRepository_List(t *testing.T) {
+func TestInstanceRepositoryList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -169,10 +176,10 @@ func TestInstanceRepository_List(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
 
-		mock.ExpectQuery("(?s)SELECT.+FROM instances.*").
+		mock.ExpectQuery(selectQuery).
 			WithArgs(userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "version", "created_at", "updated_at"}).
-				AddRow(uuid.New(), userID, "inst-1", "ubuntu:latest", "cid-1", string(domain.StatusRunning), "80:80", nil, nil, "10.0.0.1", "ovs-1", 1, now, now))
+				AddRow(uuid.New(), userID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", 1, now, now))
 
 		list, err := repo.List(ctx)
 		assert.NoError(t, err)
@@ -188,9 +195,9 @@ func TestInstanceRepository_List(t *testing.T) {
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
-		mock.ExpectQuery("(?s)SELECT.+FROM instances.*").
+		mock.ExpectQuery(selectQuery).
 			WithArgs(userID).
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		list, err := repo.List(ctx)
 		assert.Error(t, err)
@@ -198,7 +205,7 @@ func TestInstanceRepository_List(t *testing.T) {
 	})
 }
 
-func TestInstanceRepository_ListBySubnet(t *testing.T) {
+func TestInstanceRepositoryListBySubnet(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -210,10 +217,10 @@ func TestInstanceRepository_ListBySubnet(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
 
-		mock.ExpectQuery("(?s)SELECT.+FROM instances.*").
+		mock.ExpectQuery(selectQuery).
 			WithArgs(subnetID, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "version", "created_at", "updated_at"}).
-				AddRow(uuid.New(), userID, "inst-1", "ubuntu:latest", "cid-1", string(domain.StatusRunning), "80:80", nil, nil, "10.0.0.1", "ovs-1", 1, now, now))
+				AddRow(uuid.New(), userID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", 1, now, now))
 
 		list, err := repo.ListBySubnet(ctx, subnetID)
 		assert.NoError(t, err)
@@ -221,7 +228,7 @@ func TestInstanceRepository_ListBySubnet(t *testing.T) {
 	})
 }
 
-func TestInstanceRepository_Update(t *testing.T) {
+func TestInstanceRepositoryUpdate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -271,7 +278,7 @@ func TestInstanceRepository_Update(t *testing.T) {
 	})
 }
 
-func TestInstanceRepository_Delete(t *testing.T) {
+func TestInstanceRepositoryDelete(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -290,7 +297,7 @@ func TestInstanceRepository_Delete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("not found", func(t *testing.T) {
+	t.Run(testNotFound, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()

--- a/internal/repositories/postgres/security_group_repo.go
+++ b/internal/repositories/postgres/security_group_repo.go
@@ -114,6 +114,18 @@ func (r *SecurityGroupRepository) AddRule(ctx context.Context, rule *domain.Secu
 	return nil
 }
 
+func (r *SecurityGroupRepository) GetRuleByID(ctx context.Context, ruleID uuid.UUID) (*domain.SecurityRule, error) {
+	query := `SELECT id, group_id, direction, protocol, port_min, port_max, cidr, priority, created_at FROM security_rules WHERE id = $1`
+	rule, err := r.scanSecurityRule(r.db.QueryRow(ctx, query, ruleID))
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, errors.New(errors.NotFound, "security rule not found")
+		}
+		return nil, errors.Wrap(errors.Internal, "failed to get security rule", err)
+	}
+	return &rule, nil
+}
+
 func (r *SecurityGroupRepository) DeleteRule(ctx context.Context, ruleID uuid.UUID) error {
 	query := `DELETE FROM security_rules WHERE id = $1`
 	_, err := r.db.Exec(ctx, query, ruleID)

--- a/internal/repositories/postgres/security_group_repo_test.go
+++ b/internal/repositories/postgres/security_group_repo_test.go
@@ -12,10 +12,19 @@ import (
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	theclouderrors "github.com/poyrazk/thecloud/internal/errors"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSecurityGroupRepository_Create(t *testing.T) {
+const (
+	testSgName         = "test-sg"
+	selectSg           = "SELECT id, user_id, vpc_id, name, description, arn, created_at FROM security_groups"
+	selectRule         = "SELECT id, group_id, direction, protocol, port_min, port_max, cidr, priority, created_at FROM security_rules"
+	selectInstanceUser = "SELECT user_id FROM instances WHERE id = \\$1"
+	selectSgUser       = "SELECT user_id FROM security_groups WHERE id = \\$1"
+)
+
+func TestSecurityGroupRepositoryCreate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -26,7 +35,7 @@ func TestSecurityGroupRepository_Create(t *testing.T) {
 			ID:          uuid.New(),
 			UserID:      uuid.New(),
 			VPCID:       uuid.New(),
-			Name:        "test-sg",
+			Name:        testSgName,
 			Description: "desc",
 			ARN:         "arn",
 			CreatedAt:   time.Now(),
@@ -40,7 +49,7 @@ func TestSecurityGroupRepository_Create(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("db error", func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -51,14 +60,14 @@ func TestSecurityGroupRepository_Create(t *testing.T) {
 		}
 
 		mock.ExpectExec("INSERT INTO security_groups").
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		err = repo.Create(context.Background(), sg)
 		assert.Error(t, err)
 	})
 }
 
-func TestSecurityGroupRepository_GetByID(t *testing.T) {
+func TestSecurityGroupRepositoryGetByID(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -70,15 +79,15 @@ func TestSecurityGroupRepository_GetByID(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
 
-		mock.ExpectQuery("SELECT id, user_id, vpc_id, name, description, arn, created_at FROM security_groups").
+		mock.ExpectQuery(selectSg).
 			WithArgs(id, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "vpc_id", "name", "description", "arn", "created_at"}).
-				AddRow(id, userID, uuid.New(), "test-sg", "desc", "arn", now))
+				AddRow(id, userID, uuid.New(), testSgName, "desc", "arn", now))
 
-		mock.ExpectQuery("SELECT id, group_id, direction, protocol, port_min, port_max, cidr, priority, created_at FROM security_rules").
+		mock.ExpectQuery(selectRule).
 			WithArgs(id).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "group_id", "direction", "protocol", "port_min", "port_max", "cidr", "priority", "created_at"}).
-				AddRow(uuid.New(), id, string(domain.RuleIngress), "tcp", 80, 80, "0.0.0.0/0", 100, now))
+				AddRow(uuid.New(), id, string(domain.RuleIngress), "tcp", 80, 80, testutil.TestAnyCIDR, 100, now))
 
 		sg, err := repo.GetByID(ctx, id)
 		assert.NoError(t, err)
@@ -87,7 +96,7 @@ func TestSecurityGroupRepository_GetByID(t *testing.T) {
 		}
 	})
 
-	t.Run("not found", func(t *testing.T) {
+	t.Run(testNotFound, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -97,7 +106,7 @@ func TestSecurityGroupRepository_GetByID(t *testing.T) {
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
-		mock.ExpectQuery("SELECT id, user_id, vpc_id, name, description, arn, created_at FROM security_groups").
+		mock.ExpectQuery(selectSg).
 			WithArgs(id, userID).
 			WillReturnError(pgx.ErrNoRows)
 
@@ -111,7 +120,7 @@ func TestSecurityGroupRepository_GetByID(t *testing.T) {
 	})
 }
 
-func TestSecurityGroupRepository_GetByName(t *testing.T) {
+func TestSecurityGroupRepositoryGetByName(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -123,17 +132,17 @@ func TestSecurityGroupRepository_GetByName(t *testing.T) {
 		vpcID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
-		name := "test-sg"
+		name := testSgName
 
-		mock.ExpectQuery("SELECT id, user_id, vpc_id, name, description, arn, created_at FROM security_groups").
+		mock.ExpectQuery(selectSg).
 			WithArgs(vpcID, name, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "vpc_id", "name", "description", "arn", "created_at"}).
 				AddRow(id, userID, vpcID, name, "desc", "arn", now))
 
-		mock.ExpectQuery("SELECT id, group_id, direction, protocol, port_min, port_max, cidr, priority, created_at FROM security_rules").
+		mock.ExpectQuery(selectRule).
 			WithArgs(id).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "group_id", "direction", "protocol", "port_min", "port_max", "cidr", "priority", "created_at"}).
-				AddRow(uuid.New(), id, string(domain.RuleIngress), "tcp", 80, 80, "0.0.0.0/0", 100, now))
+				AddRow(uuid.New(), id, string(domain.RuleIngress), "tcp", 80, 80, testutil.TestAnyCIDR, 100, now))
 
 		sg, err := repo.GetByName(ctx, vpcID, name)
 		assert.NoError(t, err)
@@ -141,7 +150,7 @@ func TestSecurityGroupRepository_GetByName(t *testing.T) {
 		assert.Equal(t, id, sg.ID)
 	})
 
-	t.Run("not found", func(t *testing.T) {
+	t.Run(testNotFound, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -150,9 +159,9 @@ func TestSecurityGroupRepository_GetByName(t *testing.T) {
 		userID := uuid.New()
 		vpcID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
-		name := "test-sg"
+		name := testSgName
 
-		mock.ExpectQuery("SELECT id, user_id, vpc_id, name, description, arn, created_at FROM security_groups").
+		mock.ExpectQuery(selectSg).
 			WithArgs(vpcID, name, userID).
 			WillReturnError(pgx.ErrNoRows)
 
@@ -166,7 +175,7 @@ func TestSecurityGroupRepository_GetByName(t *testing.T) {
 	})
 }
 
-func TestSecurityGroupRepository_ListByVPC(t *testing.T) {
+func TestSecurityGroupRepositoryListByVPC(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -178,17 +187,17 @@ func TestSecurityGroupRepository_ListByVPC(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
 
-		mock.ExpectQuery("SELECT id, user_id, vpc_id, name, description, arn, created_at FROM security_groups").
+		mock.ExpectQuery(selectSg).
 			WithArgs(vpcID, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "vpc_id", "name", "description", "arn", "created_at"}).
-				AddRow(uuid.New(), userID, vpcID, "test-sg", "desc", "arn", now))
+				AddRow(uuid.New(), userID, vpcID, testSgName, "desc", "arn", now))
 
 		groups, err := repo.ListByVPC(ctx, vpcID)
 		assert.NoError(t, err)
 		assert.Len(t, groups, 1)
 	})
 
-	t.Run("db error", func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -198,9 +207,9 @@ func TestSecurityGroupRepository_ListByVPC(t *testing.T) {
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
-		mock.ExpectQuery("SELECT id, user_id, vpc_id, name, description, arn, created_at FROM security_groups").
+		mock.ExpectQuery(selectSg).
 			WithArgs(vpcID, userID).
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		groups, err := repo.ListByVPC(ctx, vpcID)
 		assert.Error(t, err)
@@ -208,7 +217,7 @@ func TestSecurityGroupRepository_ListByVPC(t *testing.T) {
 	})
 }
 
-func TestSecurityGroupRepository_AddRule(t *testing.T) {
+func TestSecurityGroupRepositoryAddRule(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -222,7 +231,7 @@ func TestSecurityGroupRepository_AddRule(t *testing.T) {
 			Protocol:  "tcp",
 			PortMin:   80,
 			PortMax:   80,
-			CIDR:      "0.0.0.0/0",
+			CIDR:      testutil.TestAnyCIDR,
 			Priority:  100,
 			CreatedAt: time.Now(),
 		}
@@ -235,7 +244,7 @@ func TestSecurityGroupRepository_AddRule(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("db error", func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -246,14 +255,14 @@ func TestSecurityGroupRepository_AddRule(t *testing.T) {
 		}
 
 		mock.ExpectExec("INSERT INTO security_rules").
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		err = repo.AddRule(context.Background(), rule)
 		assert.Error(t, err)
 	})
 }
 
-func TestSecurityGroupRepository_DeleteRule(t *testing.T) {
+func TestSecurityGroupRepositoryDeleteRule(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -270,7 +279,7 @@ func TestSecurityGroupRepository_DeleteRule(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("db error", func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -280,14 +289,14 @@ func TestSecurityGroupRepository_DeleteRule(t *testing.T) {
 
 		mock.ExpectExec("DELETE FROM security_rules").
 			WithArgs(ruleID).
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		err = repo.DeleteRule(context.Background(), ruleID)
 		assert.Error(t, err)
 	})
 }
 
-func TestSecurityGroupRepository_Delete(t *testing.T) {
+func TestSecurityGroupRepositoryDelete(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -306,7 +315,7 @@ func TestSecurityGroupRepository_Delete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("db error", func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -318,14 +327,14 @@ func TestSecurityGroupRepository_Delete(t *testing.T) {
 
 		mock.ExpectExec("DELETE FROM security_groups").
 			WithArgs(id, userID).
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		err = repo.Delete(ctx, id)
 		assert.Error(t, err)
 	})
 }
 
-func TestSecurityGroupRepository_AddInstanceToGroup(t *testing.T) {
+func TestSecurityGroupRepositoryAddInstanceToGroup(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -338,10 +347,10 @@ func TestSecurityGroupRepository_AddInstanceToGroup(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
 		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT user_id FROM instances WHERE id = \\$1").
+		mock.ExpectQuery(selectInstanceUser).
 			WithArgs(instanceID).
 			WillReturnRows(pgxmock.NewRows([]string{"user_id"}).AddRow(userID))
-		mock.ExpectQuery("SELECT user_id FROM security_groups WHERE id = \\$1").
+		mock.ExpectQuery(selectSgUser).
 			WithArgs(groupID).
 			WillReturnRows(pgxmock.NewRows([]string{"user_id"}).AddRow(userID))
 		mock.ExpectExec("INSERT INTO instance_security_groups").
@@ -365,7 +374,7 @@ func TestSecurityGroupRepository_AddInstanceToGroup(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
 		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT user_id FROM instances WHERE id = \\$1").
+		mock.ExpectQuery(selectInstanceUser).
 			WithArgs(instanceID).
 			WillReturnError(pgx.ErrNoRows)
 		mock.ExpectRollback()
@@ -390,10 +399,10 @@ func TestSecurityGroupRepository_AddInstanceToGroup(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
 		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT user_id FROM instances WHERE id = \\$1").
+		mock.ExpectQuery(selectInstanceUser).
 			WithArgs(instanceID).
 			WillReturnRows(pgxmock.NewRows([]string{"user_id"}).AddRow(userID))
-		mock.ExpectQuery("SELECT user_id FROM security_groups WHERE id = \\$1").
+		mock.ExpectQuery(selectSgUser).
 			WithArgs(groupID).
 			WillReturnError(pgx.ErrNoRows)
 		mock.ExpectRollback()
@@ -407,7 +416,7 @@ func TestSecurityGroupRepository_AddInstanceToGroup(t *testing.T) {
 	})
 }
 
-func TestSecurityGroupRepository_RemoveInstanceFromGroup(t *testing.T) {
+func TestSecurityGroupRepositoryRemoveInstanceFromGroup(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -420,10 +429,10 @@ func TestSecurityGroupRepository_RemoveInstanceFromGroup(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
 		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT user_id FROM instances WHERE id = \\$1").
+		mock.ExpectQuery(selectInstanceUser).
 			WithArgs(instanceID).
 			WillReturnRows(pgxmock.NewRows([]string{"user_id"}).AddRow(userID))
-		mock.ExpectQuery("SELECT user_id FROM security_groups WHERE id = \\$1").
+		mock.ExpectQuery(selectSgUser).
 			WithArgs(groupID).
 			WillReturnRows(pgxmock.NewRows([]string{"user_id"}).AddRow(userID))
 		mock.ExpectExec("DELETE FROM instance_security_groups").
@@ -447,7 +456,7 @@ func TestSecurityGroupRepository_RemoveInstanceFromGroup(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
 		mock.ExpectBegin()
-		mock.ExpectQuery("SELECT user_id FROM instances WHERE id = \\$1").
+		mock.ExpectQuery(selectInstanceUser).
 			WithArgs(instanceID).
 			WillReturnError(pgx.ErrNoRows)
 		mock.ExpectRollback()
@@ -461,7 +470,7 @@ func TestSecurityGroupRepository_RemoveInstanceFromGroup(t *testing.T) {
 	})
 }
 
-func TestSecurityGroupRepository_ListInstanceGroups(t *testing.T) {
+func TestSecurityGroupRepositoryListInstanceGroups(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -474,14 +483,14 @@ func TestSecurityGroupRepository_ListInstanceGroups(t *testing.T) {
 		mock.ExpectQuery("SELECT sg.id, sg.user_id, sg.vpc_id, sg.name, sg.description, sg.arn, sg.created_at").
 			WithArgs(instanceID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "vpc_id", "name", "description", "arn", "created_at"}).
-				AddRow(uuid.New(), uuid.New(), uuid.New(), "test-sg", "desc", "arn", now))
+				AddRow(uuid.New(), uuid.New(), uuid.New(), testSgName, "desc", "arn", now))
 
 		groups, err := repo.ListInstanceGroups(context.Background(), instanceID)
 		assert.NoError(t, err)
 		assert.Len(t, groups, 1)
 	})
 
-	t.Run("db error", func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -491,7 +500,7 @@ func TestSecurityGroupRepository_ListInstanceGroups(t *testing.T) {
 
 		mock.ExpectQuery("SELECT sg.id, sg.user_id, sg.vpc_id, sg.name, sg.description, sg.arn, sg.created_at").
 			WithArgs(instanceID).
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		groups, err := repo.ListInstanceGroups(context.Background(), instanceID)
 		assert.Error(t, err)

--- a/internal/repositories/postgres/shared_test.go
+++ b/internal/repositories/postgres/shared_test.go
@@ -2,5 +2,5 @@ package postgres
 
 const (
 	testNotFound = "not found"
-	testDbError  = "db error"
+	testDBError  = "db error"
 )

--- a/internal/repositories/postgres/shared_test.go
+++ b/internal/repositories/postgres/shared_test.go
@@ -1,0 +1,6 @@
+package postgres
+
+const (
+	testNotFound = "not found"
+	testDbError  = "db error"
+)

--- a/internal/repositories/postgres/subnet_repo_test.go
+++ b/internal/repositories/postgres/subnet_repo_test.go
@@ -51,7 +51,7 @@ func TestSubnetRepositoryCreate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -62,7 +62,7 @@ func TestSubnetRepositoryCreate(t *testing.T) {
 		}
 
 		mock.ExpectExec("INSERT INTO subnets").
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		err = repo.Create(context.Background(), s)
 		assert.Error(t, err)
@@ -116,7 +116,7 @@ func TestSubnetRepositoryGetByID(t *testing.T) {
 		}
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -128,7 +128,7 @@ func TestSubnetRepositoryGetByID(t *testing.T) {
 
 		mock.ExpectQuery(selectSubnet).
 			WithArgs(id, userID).
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		s, err := repo.GetByID(ctx, id)
 		assert.Error(t, err)
@@ -210,7 +210,7 @@ func TestSubnetRepositoryListByVPC(t *testing.T) {
 
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -222,7 +222,7 @@ func TestSubnetRepositoryListByVPC(t *testing.T) {
 
 		mock.ExpectQuery(selectSubnet).
 			WithArgs(vpcID, userID).
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		subnets, err := repo.ListByVPC(ctx, vpcID)
 		assert.Error(t, err)
@@ -292,7 +292,7 @@ func TestSubnetRepositoryDelete(t *testing.T) {
 		}
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -304,7 +304,7 @@ func TestSubnetRepositoryDelete(t *testing.T) {
 
 		mock.ExpectExec(deleteSubnetQuery).
 			WithArgs(id, userID).
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		err = repo.Delete(ctx, id)
 		assert.Error(t, err)

--- a/internal/repositories/postgres/volume_repo_test.go
+++ b/internal/repositories/postgres/volume_repo_test.go
@@ -48,7 +48,7 @@ func TestVolumeRepositoryCreate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -59,7 +59,7 @@ func TestVolumeRepositoryCreate(t *testing.T) {
 		}
 
 		mock.ExpectExec("INSERT INTO volumes").
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		err = repo.Create(context.Background(), vol)
 		assert.Error(t, err)
@@ -183,7 +183,7 @@ func TestVolumeRepositoryList(t *testing.T) {
 		assert.Len(t, vols, 1)
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -194,7 +194,7 @@ func TestVolumeRepositoryList(t *testing.T) {
 
 		mock.ExpectQuery(testSelectVolume).
 			WithArgs(userID).
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		vols, err := repo.List(ctx)
 		assert.Error(t, err)
@@ -224,7 +224,7 @@ func TestVolumeRepositoryListByInstanceID(t *testing.T) {
 		assert.Len(t, vols, 1)
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -236,7 +236,7 @@ func TestVolumeRepositoryListByInstanceID(t *testing.T) {
 
 		mock.ExpectQuery(testSelectVolume).
 			WithArgs(instanceID, userID).
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		vols, err := repo.ListByInstanceID(ctx, instanceID)
 		assert.Error(t, err)
@@ -266,7 +266,7 @@ func TestVolumeRepositoryUpdate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -277,7 +277,7 @@ func TestVolumeRepositoryUpdate(t *testing.T) {
 		}
 
 		mock.ExpectExec("UPDATE volumes").
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		err = repo.Update(context.Background(), vol)
 		assert.Error(t, err)

--- a/internal/repositories/postgres/volume_repo_test.go
+++ b/internal/repositories/postgres/volume_repo_test.go
@@ -17,9 +17,7 @@ import (
 
 const (
 	testMountPath    = "/mock/path"
-	testDBError      = "db error"
 	testSelectVolume = "SELECT id, user_id, name, size_gb, status, instance_id, backend_path, mount_path, created_at, updated_at FROM volumes"
-	testNotFound     = "not found"
 )
 
 func TestVolumeRepositoryCreate(t *testing.T) {
@@ -50,7 +48,7 @@ func TestVolumeRepositoryCreate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run(testDBError, func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -61,7 +59,7 @@ func TestVolumeRepositoryCreate(t *testing.T) {
 		}
 
 		mock.ExpectExec("INSERT INTO volumes").
-			WillReturnError(errors.New(testDBError))
+			WillReturnError(errors.New(testDbError))
 
 		err = repo.Create(context.Background(), vol)
 		assert.Error(t, err)
@@ -185,7 +183,7 @@ func TestVolumeRepositoryList(t *testing.T) {
 		assert.Len(t, vols, 1)
 	})
 
-	t.Run(testDBError, func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -196,7 +194,7 @@ func TestVolumeRepositoryList(t *testing.T) {
 
 		mock.ExpectQuery(testSelectVolume).
 			WithArgs(userID).
-			WillReturnError(errors.New(testDBError))
+			WillReturnError(errors.New(testDbError))
 
 		vols, err := repo.List(ctx)
 		assert.Error(t, err)
@@ -226,7 +224,7 @@ func TestVolumeRepositoryListByInstanceID(t *testing.T) {
 		assert.Len(t, vols, 1)
 	})
 
-	t.Run(testDBError, func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -238,7 +236,7 @@ func TestVolumeRepositoryListByInstanceID(t *testing.T) {
 
 		mock.ExpectQuery(testSelectVolume).
 			WithArgs(instanceID, userID).
-			WillReturnError(errors.New(testDBError))
+			WillReturnError(errors.New(testDbError))
 
 		vols, err := repo.ListByInstanceID(ctx, instanceID)
 		assert.Error(t, err)
@@ -268,7 +266,7 @@ func TestVolumeRepositoryUpdate(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run(testDBError, func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -279,7 +277,7 @@ func TestVolumeRepositoryUpdate(t *testing.T) {
 		}
 
 		mock.ExpectExec("UPDATE volumes").
-			WillReturnError(errors.New(testDBError))
+			WillReturnError(errors.New(testDbError))
 
 		err = repo.Update(context.Background(), vol)
 		assert.Error(t, err)

--- a/internal/repositories/postgres/vpc_repo_unit_test.go
+++ b/internal/repositories/postgres/vpc_repo_unit_test.go
@@ -59,7 +59,7 @@ func TestVpcRepositoryCreate(t *testing.T) {
 		}
 
 		mock.ExpectExec("INSERT INTO vpcs").
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		err = repo.Create(context.Background(), vpc)
 		assert.Error(t, err)
@@ -116,7 +116,7 @@ func TestVpcRepositoryGetByID(t *testing.T) {
 		// So it should be a custom error.
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -128,7 +128,7 @@ func TestVpcRepositoryGetByID(t *testing.T) {
 
 		mock.ExpectQuery(selectVpc).
 			WithArgs(id, userID).
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		vpc, err := repo.GetByID(ctx, id)
 		assert.Error(t, err)
@@ -201,7 +201,7 @@ func TestVpcRepositoryList(t *testing.T) {
 		assert.Len(t, vpcs, 1)
 	})
 
-	t.Run(testDbError, func(t *testing.T) {
+	t.Run(testDBError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -212,7 +212,7 @@ func TestVpcRepositoryList(t *testing.T) {
 
 		mock.ExpectQuery(selectVpc).
 			WithArgs(userID).
-			WillReturnError(errors.New(testDbError))
+			WillReturnError(errors.New(testDBError))
 
 		vpcs, err := repo.List(ctx)
 		assert.Error(t, err)

--- a/internal/repositories/postgres/vpc_repo_unit_test.go
+++ b/internal/repositories/postgres/vpc_repo_unit_test.go
@@ -12,10 +12,16 @@ import (
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	theclouderrors "github.com/poyrazk/thecloud/internal/errors"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestVpcRepository_Create(t *testing.T) {
+const (
+	testVpcName = "test-vpc"
+	selectVpc   = "SELECT id, user_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs"
+)
+
+func TestVpcRepositoryCreate(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -25,8 +31,8 @@ func TestVpcRepository_Create(t *testing.T) {
 		vpc := &domain.VPC{
 			ID:        uuid.New(),
 			UserID:    uuid.New(),
-			Name:      "test-vpc",
-			CIDRBlock: "10.0.0.0/16",
+			Name:      testVpcName,
+			CIDRBlock: testutil.TestCIDR,
 			NetworkID: "net-1",
 			VXLANID:   100,
 			Status:    "available",
@@ -53,14 +59,14 @@ func TestVpcRepository_Create(t *testing.T) {
 		}
 
 		mock.ExpectExec("INSERT INTO vpcs").
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		err = repo.Create(context.Background(), vpc)
 		assert.Error(t, err)
 	})
 }
 
-func TestVpcRepository_GetByID(t *testing.T) {
+func TestVpcRepositoryGetByID(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -72,10 +78,10 @@ func TestVpcRepository_GetByID(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
 
-		mock.ExpectQuery("SELECT id, user_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs").
+		mock.ExpectQuery(selectVpc).
 			WithArgs(id, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "cidr_block", "network_id", "vxlan_id", "status", "arn", "created_at"}).
-				AddRow(id, userID, "test-vpc", "10.0.0.0/16", "net-1", 100, "available", "arn", now))
+				AddRow(id, userID, testVpcName, testutil.TestCIDR, "net-1", 100, "available", "arn", now))
 
 		vpc, err := repo.GetByID(ctx, id)
 		assert.NoError(t, err)
@@ -83,7 +89,7 @@ func TestVpcRepository_GetByID(t *testing.T) {
 		assert.Equal(t, id, vpc.ID)
 	})
 
-	t.Run("not found", func(t *testing.T) {
+	t.Run(testNotFound, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -110,7 +116,7 @@ func TestVpcRepository_GetByID(t *testing.T) {
 		// So it should be a custom error.
 	})
 
-	t.Run("db error", func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -120,9 +126,9 @@ func TestVpcRepository_GetByID(t *testing.T) {
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
-		mock.ExpectQuery("SELECT id, user_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs").
+		mock.ExpectQuery(selectVpc).
 			WithArgs(id, userID).
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		vpc, err := repo.GetByID(ctx, id)
 		assert.Error(t, err)
@@ -130,7 +136,7 @@ func TestVpcRepository_GetByID(t *testing.T) {
 	})
 }
 
-func TestVpcRepository_GetByName(t *testing.T) {
+func TestVpcRepositoryGetByName(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -141,12 +147,12 @@ func TestVpcRepository_GetByName(t *testing.T) {
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
-		name := "test-vpc"
+		name := testVpcName
 
-		mock.ExpectQuery("SELECT id, user_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs").
+		mock.ExpectQuery(selectVpc).
 			WithArgs(name, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "cidr_block", "network_id", "vxlan_id", "status", "arn", "created_at"}).
-				AddRow(id, userID, name, "10.0.0.0/16", "net-1", 100, "available", "arn", now))
+				AddRow(id, userID, name, testutil.TestCIDR, "net-1", 100, "available", "arn", now))
 
 		vpc, err := repo.GetByName(ctx, name)
 		assert.NoError(t, err)
@@ -154,7 +160,7 @@ func TestVpcRepository_GetByName(t *testing.T) {
 		assert.Equal(t, id, vpc.ID)
 	})
 
-	t.Run("not found", func(t *testing.T) {
+	t.Run(testNotFound, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -162,9 +168,9 @@ func TestVpcRepository_GetByName(t *testing.T) {
 		repo := NewVpcRepository(mock)
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
-		name := "test-vpc"
+		name := testVpcName
 
-		mock.ExpectQuery("SELECT id, user_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs").
+		mock.ExpectQuery(selectVpc).
 			WithArgs(name, userID).
 			WillReturnError(pgx.ErrNoRows)
 
@@ -174,7 +180,7 @@ func TestVpcRepository_GetByName(t *testing.T) {
 	})
 }
 
-func TestVpcRepository_List(t *testing.T) {
+func TestVpcRepositoryList(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -185,17 +191,17 @@ func TestVpcRepository_List(t *testing.T) {
 		ctx := appcontext.WithUserID(context.Background(), userID)
 		now := time.Now()
 
-		mock.ExpectQuery("SELECT id, user_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs").
+		mock.ExpectQuery(selectVpc).
 			WithArgs(userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "cidr_block", "network_id", "vxlan_id", "status", "arn", "created_at"}).
-				AddRow(uuid.New(), userID, "test-vpc", "10.0.0.0/16", "net-1", 100, "available", "arn", now))
+				AddRow(uuid.New(), userID, testVpcName, testutil.TestCIDR, "net-1", 100, "available", "arn", now))
 
 		vpcs, err := repo.List(ctx)
 		assert.NoError(t, err)
 		assert.Len(t, vpcs, 1)
 	})
 
-	t.Run("db error", func(t *testing.T) {
+	t.Run(testDbError, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()
@@ -204,9 +210,9 @@ func TestVpcRepository_List(t *testing.T) {
 		userID := uuid.New()
 		ctx := appcontext.WithUserID(context.Background(), userID)
 
-		mock.ExpectQuery("SELECT id, user_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs").
+		mock.ExpectQuery(selectVpc).
 			WithArgs(userID).
-			WillReturnError(errors.New("db error"))
+			WillReturnError(errors.New(testDbError))
 
 		vpcs, err := repo.List(ctx)
 		assert.Error(t, err)
@@ -224,10 +230,10 @@ func TestVpcRepository_List(t *testing.T) {
 		now := time.Now()
 
 		// Return a row with incompatible types to force scan error
-		mock.ExpectQuery("SELECT id, user_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs").
+		mock.ExpectQuery(selectVpc).
 			WithArgs(userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "cidr_block", "network_id", "vxlan_id", "status", "arn", "created_at"}).
-				AddRow("invalid-uuid", userID, "test-vpc", "10.0.0.0/16", "net-1", 100, "available", "arn", now))
+				AddRow("invalid-uuid", userID, testVpcName, testutil.TestCIDR, "net-1", 100, "available", "arn", now))
 
 		vpcs, err := repo.List(ctx)
 		assert.Error(t, err)
@@ -235,7 +241,7 @@ func TestVpcRepository_List(t *testing.T) {
 	})
 }
 
-func TestVpcRepository_Delete(t *testing.T) {
+func TestVpcRepositoryDelete(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
@@ -254,7 +260,7 @@ func TestVpcRepository_Delete(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("not found", func(t *testing.T) {
+	t.Run(testNotFound, func(t *testing.T) {
 		mock, err := pgxmock.NewPool()
 		assert.NoError(t, err)
 		defer mock.Close()

--- a/pkg/audit/simple_audit_test.go
+++ b/pkg/audit/simple_audit_test.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestSimpleAuditLogger_Log(t *testing.T) {
+func TestSimpleAuditLoggerLog(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 	audit := NewSimpleAuditLogger(logger)
@@ -24,8 +25,8 @@ func TestSimpleAuditLogger_Log(t *testing.T) {
 		Action:       "CREATE",
 		ResourceType: "instance",
 		ResourceID:   "123",
-		IPAddress:    "127.0.0.1",
-		UserAgent:    "test-agent",
+		IPAddress:    testutil.TestIPLocalhost,
+		UserAgent:    testutil.TestUserAgent,
 		Details:      map[string]interface{}{"foo": "bar"},
 		CreatedAt:    time.Now(),
 	}
@@ -40,13 +41,13 @@ func TestSimpleAuditLogger_Log(t *testing.T) {
 	assert.Contains(t, logOutput, userID.String())
 	assert.Contains(t, logOutput, "instance")
 	assert.Contains(t, logOutput, "123")
-	assert.Contains(t, logOutput, "127.0.0.1")
-	assert.Contains(t, logOutput, "test-agent")
+	assert.Contains(t, logOutput, testutil.TestIPLocalhost)
+	assert.Contains(t, logOutput, testutil.TestUserAgent)
 	assert.Contains(t, logOutput, "foo")
 	assert.Contains(t, logOutput, "bar")
 }
 
-func TestSimpleAuditLogger_Log_Anonymous(t *testing.T) {
+func TestSimpleAuditLoggerLogAnonymous(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 	audit := NewSimpleAuditLogger(logger)
@@ -66,7 +67,7 @@ func TestSimpleAuditLogger_Log_Anonymous(t *testing.T) {
 	assert.Contains(t, logOutput, "anonymous")
 }
 
-func TestSimpleAuditLogger_Log_EmptyDetails(t *testing.T) {
+func TestSimpleAuditLoggerLogEmptyDetails(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 	audit := NewSimpleAuditLogger(logger)

--- a/pkg/ratelimit/limiter_test.go
+++ b/pkg/ratelimit/limiter_test.go
@@ -5,30 +5,31 @@ import (
 	"testing"
 
 	"github.com/poyrazk/thecloud/pkg/ratelimit"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"golang.org/x/time/rate"
 )
 
-func BenchmarkRateLimiter_GetLimiter(b *testing.B) {
+func BenchmarkRateLimiterGetLimiter(b *testing.B) {
 	limiter := ratelimit.NewIPRateLimiter(rate.Limit(100), 10, slog.Default())
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = limiter.GetLimiter("192.168.1.1")
+		_ = limiter.GetLimiter(testutil.TestIPPrivate)
 	}
 }
 
-func BenchmarkRateLimiter_GetLimiterParallel(b *testing.B) {
+func BenchmarkRateLimiterGetLimiterParallel(b *testing.B) {
 	limiter := ratelimit.NewIPRateLimiter(rate.Limit(1000), 100, slog.Default())
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_ = limiter.GetLimiter("192.168.1.1")
+			_ = limiter.GetLimiter(testutil.TestIPPrivate)
 		}
 	})
 }
 
-func BenchmarkRateLimiter_GetLimiterParallel_MultiKey(b *testing.B) {
+func BenchmarkRateLimiterGetLimiterParallelMultiKey(b *testing.B) {
 	limiter := ratelimit.NewIPRateLimiter(rate.Limit(1000), 100, slog.Default())
 
 	b.ResetTimer()

--- a/pkg/ratelimit/limiter_unit_test.go
+++ b/pkg/ratelimit/limiter_unit_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	"github.com/gin-gonic/gin"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
 )
@@ -31,7 +32,7 @@ func newTestContext(method string, path string, ip string) (*gin.Context, *httpt
 
 func TestMiddlewareAllowsFirstRequest(t *testing.T) {
 	limiter := NewIPRateLimiter(rate.Limit(1), 1, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ctx, resp := newTestContext("GET", "/", "1.2.3.4")
+	ctx, resp := newTestContext("GET", "/", testutil.TestNoopIP3)
 
 	Middleware(limiter)(ctx)
 
@@ -40,10 +41,10 @@ func TestMiddlewareAllowsFirstRequest(t *testing.T) {
 
 func TestMiddlewareBlocksWhenRateExceeded(t *testing.T) {
 	limiter := NewIPRateLimiter(rate.Limit(1), 1, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	ctx, _ := newTestContext("GET", "/", "2.2.2.2")
+	ctx, _ := newTestContext("GET", "/", testutil.TestNoopIP4)
 	Middleware(limiter)(ctx)
 
-	ctx2, resp2 := newTestContext("GET", "/", "2.2.2.2")
+	ctx2, resp2 := newTestContext("GET", "/", testutil.TestNoopIP4)
 	Middleware(limiter)(ctx2)
 
 	assert.Equal(t, http.StatusTooManyRequests, resp2.Code)

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -12,6 +12,11 @@ type Client struct {
 	apiURL string
 }
 
+const (
+	errRequestFailed = "request failed: %w"
+	errAPIError      = "api error: %s"
+)
+
 func NewClient(apiURL, apiKey string) *Client {
 	client := resty.New()
 	client.SetHeader("X-API-Key", apiKey)
@@ -37,11 +42,11 @@ func (c *Client) get(path string, result interface{}) error {
 		Get(c.apiURL + path)
 
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return fmt.Errorf(errRequestFailed, err)
 	}
 
 	if resp.IsError() {
-		return fmt.Errorf("api error: %s", resp.String())
+		return fmt.Errorf(errAPIError, resp.String())
 	}
 
 	return nil
@@ -58,11 +63,11 @@ func (c *Client) post(path string, body interface{}, result interface{}) error {
 
 	resp, err := req.Post(c.apiURL + path)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return fmt.Errorf(errRequestFailed, err)
 	}
 
 	if resp.IsError() {
-		return fmt.Errorf("api error: %s", resp.String())
+		return fmt.Errorf(errAPIError, resp.String())
 	}
 
 	return nil
@@ -76,11 +81,11 @@ func (c *Client) delete(path string, result interface{}) error {
 
 	resp, err := req.Delete(c.apiURL + path)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return fmt.Errorf(errRequestFailed, err)
 	}
 
 	if resp.IsError() {
-		return fmt.Errorf("api error: %s", resp.String())
+		return fmt.Errorf(errAPIError, resp.String())
 	}
 
 	return nil
@@ -97,11 +102,11 @@ func (c *Client) put(path string, body interface{}, result interface{}) error {
 
 	resp, err := req.Put(c.apiURL + path)
 	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
+		return fmt.Errorf(errRequestFailed, err)
 	}
 
 	if resp.IsError() {
-		return fmt.Errorf("api error: %s", resp.String())
+		return fmt.Errorf(errAPIError, resp.String())
 	}
 
 	return nil

--- a/pkg/sdk/security_group.go
+++ b/pkg/sdk/security_group.go
@@ -77,3 +77,15 @@ func (c *Client) AttachSecurityGroup(instanceID, groupID string) error {
 	}
 	return c.post("/security-groups/attach", body, nil)
 }
+
+func (c *Client) RemoveSecurityRule(ruleID string) error {
+	return c.delete(fmt.Sprintf("/security-groups/rules/%s", ruleID), nil)
+}
+
+func (c *Client) DetachSecurityGroup(instanceID, groupID string) error {
+	body := map[string]string{
+		"instance_id": instanceID,
+		"group_id":    groupID,
+	}
+	return c.post("/security-groups/detach", body, nil)
+}

--- a/pkg/sdk/security_group_test.go
+++ b/pkg/sdk/security_group_test.go
@@ -7,21 +7,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClient_CreateSecurityGroup(t *testing.T) {
+func TestClientCreateSecurityGroup(t *testing.T) {
 	vpcID := "vpc-123"
 	expectedSG := SecurityGroup{
 		ID:          "sg-1",
 		VPCID:       vpcID,
-		Name:        "test-sg",
+		Name:        testSgName,
 		Description: "test security group",
 		CreatedAt:   time.Now(),
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/security-groups", r.URL.Path)
+		assert.Equal(t, sgBasePath, r.URL.Path)
 		assert.Equal(t, http.MethodPost, r.Method)
 
 		var req map[string]string
@@ -30,21 +31,21 @@ func TestClient_CreateSecurityGroup(t *testing.T) {
 		assert.Equal(t, vpcID, req["vpc_id"])
 		assert.Equal(t, expectedSG.Name, req["name"])
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		resp := Response[SecurityGroup]{Data: expectedSG}
 		json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
-	sg, err := client.CreateSecurityGroup(vpcID, "test-sg", "test security group")
+	client := NewClient(server.URL, testApiKey)
+	sg, err := client.CreateSecurityGroup(vpcID, testSgName, "test security group")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, sg)
 	assert.Equal(t, expectedSG.ID, sg.ID)
 }
 
-func TestClient_ListSecurityGroups(t *testing.T) {
+func TestClientListSecurityGroups(t *testing.T) {
 	vpcID := "vpc-123"
 	expectedSGs := []SecurityGroup{
 		{ID: "sg-1", Name: "sg-1", VPCID: vpcID},
@@ -52,41 +53,41 @@ func TestClient_ListSecurityGroups(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/security-groups", r.URL.Path)
+		assert.Equal(t, sgBasePath, r.URL.Path)
 		assert.Equal(t, "vpc_id="+vpcID, r.URL.RawQuery)
 		assert.Equal(t, http.MethodGet, r.Method)
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		resp := Response[[]SecurityGroup]{Data: expectedSGs}
 		json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(server.URL, testApiKey)
 	sgs, err := client.ListSecurityGroups(vpcID)
 
 	assert.NoError(t, err)
 	assert.Len(t, sgs, 2)
 }
 
-func TestClient_GetSecurityGroup(t *testing.T) {
-	id := "sg-123"
+func TestClientGetSecurityGroup(t *testing.T) {
+	id := sg123
 	expectedSG := SecurityGroup{
 		ID:   id,
-		Name: "test-sg",
+		Name: testSgName,
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/security-groups/"+id, r.URL.Path)
+		assert.Equal(t, sgDetailPath+id, r.URL.Path)
 		assert.Equal(t, http.MethodGet, r.Method)
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		resp := Response[SecurityGroup]{Data: expectedSG}
 		json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(server.URL, testApiKey)
 	sg, err := client.GetSecurityGroup(id)
 
 	assert.NoError(t, err)
@@ -94,35 +95,35 @@ func TestClient_GetSecurityGroup(t *testing.T) {
 	assert.Equal(t, expectedSG.ID, sg.ID)
 }
 
-func TestClient_DeleteSecurityGroup(t *testing.T) {
-	id := "sg-123"
+func TestClientDeleteSecurityGroup(t *testing.T) {
+	id := sg123
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/security-groups/"+id, r.URL.Path)
+		assert.Equal(t, sgDetailPath+id, r.URL.Path)
 		assert.Equal(t, http.MethodDelete, r.Method)
 
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(server.URL, testApiKey)
 	err := client.DeleteSecurityGroup(id)
 
 	assert.NoError(t, err)
 }
 
-func TestClient_AddSecurityRule(t *testing.T) {
-	groupID := "sg-123"
+func TestClientAddSecurityRule(t *testing.T) {
+	groupID := sg123
 	rule := SecurityRule{
 		Direction: "ingress",
 		Protocol:  "tcp",
 		PortMin:   80,
 		PortMax:   80,
-		CIDR:      "0.0.0.0/0",
+		CIDR:      testutil.TestAnyCIDR,
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "/security-groups/"+groupID+"/rules", r.URL.Path)
+		assert.Equal(t, sgDetailPath+groupID+"/rules", r.URL.Path)
 		assert.Equal(t, http.MethodPost, r.Method)
 
 		var req SecurityRule
@@ -130,14 +131,14 @@ func TestClient_AddSecurityRule(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, rule.Protocol, req.Protocol)
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		rule.ID = "rule-1"
 		resp := Response[SecurityRule]{Data: rule}
 		json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(server.URL, testApiKey)
 	result, err := client.AddSecurityRule(groupID, rule)
 
 	assert.NoError(t, err)
@@ -145,9 +146,9 @@ func TestClient_AddSecurityRule(t *testing.T) {
 	assert.Equal(t, "rule-1", result.ID)
 }
 
-func TestClient_AttachSecurityGroup(t *testing.T) {
+func TestClientAttachSecurityGroup(t *testing.T) {
 	instanceID := "inst-123"
-	groupID := "sg-123"
+	groupID := sg123
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/security-groups/attach", r.URL.Path)
@@ -163,7 +164,7 @@ func TestClient_AttachSecurityGroup(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(server.URL, testApiKey)
 	err := client.AttachSecurityGroup(instanceID, groupID)
 
 	assert.NoError(t, err)

--- a/pkg/sdk/security_group_test.go
+++ b/pkg/sdk/security_group_test.go
@@ -37,7 +37,7 @@ func TestClientCreateSecurityGroup(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	sg, err := client.CreateSecurityGroup(vpcID, testSgName, "test security group")
 
 	assert.NoError(t, err)
@@ -63,7 +63,7 @@ func TestClientListSecurityGroups(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	sgs, err := client.ListSecurityGroups(vpcID)
 
 	assert.NoError(t, err)
@@ -87,7 +87,7 @@ func TestClientGetSecurityGroup(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	sg, err := client.GetSecurityGroup(id)
 
 	assert.NoError(t, err)
@@ -106,7 +106,7 @@ func TestClientDeleteSecurityGroup(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	err := client.DeleteSecurityGroup(id)
 
 	assert.NoError(t, err)
@@ -138,7 +138,7 @@ func TestClientAddSecurityRule(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	result, err := client.AddSecurityRule(groupID, rule)
 
 	assert.NoError(t, err)
@@ -164,7 +164,7 @@ func TestClientAttachSecurityGroup(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	err := client.AttachSecurityGroup(instanceID, groupID)
 
 	assert.NoError(t, err)

--- a/pkg/sdk/shared_test.go
+++ b/pkg/sdk/shared_test.go
@@ -1,7 +1,7 @@
 package sdk
 
 const (
-	testApiKey     = "test-api-key"
+	testAPIKey     = "test-api-key"
 	testSgName     = "test-sg"
 	sg123          = "sg-123"
 	sgBasePath     = "/security-groups"

--- a/pkg/sdk/shared_test.go
+++ b/pkg/sdk/shared_test.go
@@ -1,0 +1,13 @@
+package sdk
+
+const (
+	testApiKey     = "test-api-key"
+	testSgName     = "test-sg"
+	sg123          = "sg-123"
+	sgBasePath     = "/security-groups"
+	sgDetailPath   = "/security-groups/"
+	testSubnetName = "test-subnet"
+	subnet1        = "subnet-1"
+	contentType    = "Content-Type"
+	testVpcName    = "new-vpc"
+)

--- a/pkg/sdk/subnet_test.go
+++ b/pkg/sdk/subnet_test.go
@@ -28,7 +28,7 @@ func TestClientListSubnets(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	subnets, err := client.ListSubnets(vpcID)
 
 	assert.NoError(t, err)
@@ -65,7 +65,7 @@ func TestClientCreateSubnet(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	subnet, err := client.CreateSubnet(vpcID, testSubnetName, testutil.TestSubnetCIDR, "us-east-1a")
 
 	assert.NoError(t, err)
@@ -85,7 +85,7 @@ func TestClientDeleteSubnet(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	err := client.DeleteSubnet(id)
 
 	assert.NoError(t, err)
@@ -109,7 +109,7 @@ func TestClientGetSubnet(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	subnet, err := client.GetSubnet(id)
 
 	assert.NoError(t, err)

--- a/pkg/sdk/subnet_test.go
+++ b/pkg/sdk/subnet_test.go
@@ -7,27 +7,28 @@ import (
 	"testing"
 	"time"
 
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClient_ListSubnets(t *testing.T) {
+func TestClientListSubnets(t *testing.T) {
 	vpcID := "vpc-123"
 	expectedSubnets := []*Subnet{
-		{ID: "subnet-1", Name: "subnet-1", VpcID: vpcID, CIDRBlock: "10.0.1.0/24"},
-		{ID: "subnet-2", Name: "subnet-2", VpcID: vpcID, CIDRBlock: "10.0.2.0/24"},
+		{ID: subnet1, Name: subnet1, VpcID: vpcID, CIDRBlock: testutil.TestSubnetCIDR},
+		{ID: "subnet-2", Name: "subnet-2", VpcID: vpcID, CIDRBlock: testutil.TestSubnet2CIDR},
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/vpcs/"+vpcID+"/subnets", r.URL.Path)
 		assert.Equal(t, http.MethodGet, r.Method)
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		resp := Response[[]*Subnet]{Data: expectedSubnets}
 		json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(server.URL, testApiKey)
 	subnets, err := client.ListSubnets(vpcID)
 
 	assert.NoError(t, err)
@@ -35,13 +36,13 @@ func TestClient_ListSubnets(t *testing.T) {
 	assert.Equal(t, expectedSubnets[0].CIDRBlock, subnets[0].CIDRBlock)
 }
 
-func TestClient_CreateSubnet(t *testing.T) {
+func TestClientCreateSubnet(t *testing.T) {
 	vpcID := "vpc-123"
 	expectedSubnet := &Subnet{
-		ID:        "subnet-1",
+		ID:        subnet1,
 		VpcID:     vpcID,
-		Name:      "test-subnet",
-		CIDRBlock: "10.0.1.0/24",
+		Name:      testSubnetName,
+		CIDRBlock: testutil.TestSubnetCIDR,
 		AZ:        "us-east-1a",
 		Status:    "available",
 		CreatedAt: time.Now(),
@@ -58,14 +59,14 @@ func TestClient_CreateSubnet(t *testing.T) {
 		assert.Equal(t, expectedSubnet.CIDRBlock, req["cidr_block"])
 		assert.Equal(t, expectedSubnet.AZ, req["availability_zone"])
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		resp := Response[*Subnet]{Data: expectedSubnet}
 		json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
-	subnet, err := client.CreateSubnet(vpcID, "test-subnet", "10.0.1.0/24", "us-east-1a")
+	client := NewClient(server.URL, testApiKey)
+	subnet, err := client.CreateSubnet(vpcID, testSubnetName, testutil.TestSubnetCIDR, "us-east-1a")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, subnet)
@@ -73,7 +74,7 @@ func TestClient_CreateSubnet(t *testing.T) {
 	assert.Equal(t, expectedSubnet.CIDRBlock, subnet.CIDRBlock)
 }
 
-func TestClient_DeleteSubnet(t *testing.T) {
+func TestClientDeleteSubnet(t *testing.T) {
 	id := "subnet-123"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -84,31 +85,31 @@ func TestClient_DeleteSubnet(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(server.URL, testApiKey)
 	err := client.DeleteSubnet(id)
 
 	assert.NoError(t, err)
 }
 
-func TestClient_GetSubnet(t *testing.T) {
+func TestClientGetSubnet(t *testing.T) {
 	id := "subnet-123"
 	expectedSubnet := &Subnet{
 		ID:        id,
-		Name:      "test-subnet",
-		CIDRBlock: "10.0.1.0/24",
+		Name:      testSubnetName,
+		CIDRBlock: testutil.TestSubnetCIDR,
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/subnets/"+id, r.URL.Path)
 		assert.Equal(t, http.MethodGet, r.Method)
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", testutil.TestContentTypeAppJSON)
 		resp := Response[*Subnet]{Data: expectedSubnet}
 		json.NewEncoder(w).Encode(resp)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-api-key")
+	client := NewClient(server.URL, testApiKey)
 	subnet, err := client.GetSubnet(id)
 
 	assert.NoError(t, err)

--- a/pkg/sdk/vpc_test.go
+++ b/pkg/sdk/vpc_test.go
@@ -6,10 +6,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestClient_ListVPCs(t *testing.T) {
+func TestClientListVPCs(t *testing.T) {
 	mockVPCs := []VPC{
 		{
 			ID:   "vpc-1",
@@ -21,13 +22,13 @@ func TestClient_ListVPCs(t *testing.T) {
 		assert.Equal(t, "/vpcs", r.URL.Path)
 		assert.Equal(t, "GET", r.Method)
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(Response[[]VPC]{Data: mockVPCs})
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-key")
+	client := NewClient(server.URL, testApiKey)
 	vpcs, err := client.ListVPCs()
 
 	assert.NoError(t, err)
@@ -35,10 +36,10 @@ func TestClient_ListVPCs(t *testing.T) {
 	assert.Equal(t, "vpc-1", vpcs[0].ID)
 }
 
-func TestClient_CreateVPC(t *testing.T) {
+func TestClientCreateVPC(t *testing.T) {
 	mockVPC := VPC{
 		ID:   "vpc-1",
-		Name: "new-vpc",
+		Name: testVpcName,
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,47 +48,47 @@ func TestClient_CreateVPC(t *testing.T) {
 
 		var body map[string]string
 		json.NewDecoder(r.Body).Decode(&body)
-		assert.Equal(t, "new-vpc", body["name"])
-		assert.Equal(t, "10.0.0.0/16", body["cidr_block"])
+		assert.Equal(t, testVpcName, body["name"])
+		assert.Equal(t, testutil.TestCIDR, body["cidr_block"])
 
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(Response[VPC]{Data: mockVPC})
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-key")
-	vpc, err := client.CreateVPC("new-vpc", "10.0.0.0/16")
+	client := NewClient(server.URL, testApiKey)
+	vpc, err := client.CreateVPC(testVpcName, testutil.TestCIDR)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "vpc-1", vpc.ID)
-	assert.Equal(t, "new-vpc", vpc.Name)
+	assert.Equal(t, testVpcName, vpc.Name)
 }
 
-func TestClient_GetVPC(t *testing.T) {
+func TestClientGetVPC(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/vpcs/vpc-1", r.URL.Path)
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set(contentType, testutil.TestContentTypeAppJSON)
 		w.WriteHeader(http.StatusOK)
 		json.NewEncoder(w).Encode(Response[VPC]{Data: VPC{ID: "vpc-1"}})
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-key")
+	client := NewClient(server.URL, testApiKey)
 	vpc, err := client.GetVPC("vpc-1")
 
 	assert.NoError(t, err)
 	assert.Equal(t, "vpc-1", vpc.ID)
 }
 
-func TestClient_DeleteVPC(t *testing.T) {
+func TestClientDeleteVPC(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/vpcs/vpc-1", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, "test-key")
+	client := NewClient(server.URL, testApiKey)
 	err := client.DeleteVPC("vpc-1")
 
 	assert.NoError(t, err)

--- a/pkg/sdk/vpc_test.go
+++ b/pkg/sdk/vpc_test.go
@@ -28,7 +28,7 @@ func TestClientListVPCs(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	vpcs, err := client.ListVPCs()
 
 	assert.NoError(t, err)
@@ -57,7 +57,7 @@ func TestClientCreateVPC(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	vpc, err := client.CreateVPC(testVpcName, testutil.TestCIDR)
 
 	assert.NoError(t, err)
@@ -74,7 +74,7 @@ func TestClientGetVPC(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	vpc, err := client.GetVPC("vpc-1")
 
 	assert.NoError(t, err)
@@ -88,7 +88,7 @@ func TestClientDeleteVPC(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := NewClient(server.URL, testApiKey)
+	client := NewClient(server.URL, testAPIKey)
 	err := client.DeleteVPC("vpc-1")
 
 	assert.NoError(t, err)

--- a/pkg/testutil/constants.go
+++ b/pkg/testutil/constants.go
@@ -1,0 +1,17 @@
+package testutil
+
+const (
+	// Network related constants
+	TestIPLocalhost = "127.0.0.1"
+	TestIPPrivate   = "192.168.1.1"
+	TestCIDR        = "10.0.0.0/16"
+
+	// Auth related constants
+	TestPasswordStrong     = "CorrectHorseBatteryStaple123!"
+	TestPasswordWeak       = "123"
+	TestEmail              = "test@example.com"
+	TestUserAgent          = "test-agent"
+	TestBaseURL            = "http://localhost:8080"
+	TestHeaderAPIKey       = "X-API-Key"
+	TestContentTypeAppJSON = "application/json"
+)

--- a/pkg/testutil/constants.go
+++ b/pkg/testutil/constants.go
@@ -1,3 +1,4 @@
+// Package testutil provides shared constants and helpers for testing.
 package testutil
 
 const (

--- a/pkg/testutil/constants.go
+++ b/pkg/testutil/constants.go
@@ -2,9 +2,29 @@ package testutil
 
 const (
 	// Network related constants
-	TestIPLocalhost = "127.0.0.1"
-	TestIPPrivate   = "192.168.1.1"
-	TestCIDR        = "10.0.0.0/16"
+	TestIPLocalhost       = "127.0.0.1"
+	TestIPHost            = "10.0.0.1"
+	TestIPPrivate         = "192.168.1.1"
+	TestCIDR              = "10.0.0.0/16"
+	TestOtherCIDR         = "192.168.1.0/24"
+	TestAnyCIDR           = "0.0.0.0/0"
+	TestGoogleDNSCIDR     = "8.8.8.8/32"
+	TestTenCIDR           = "10.0.0.0/8"
+	TestSubnetCIDR        = "10.0.1.0/24"
+	TestGatewayIP         = "10.0.1.1"
+	TestInstanceIP        = "10.0.1.2"
+	TestDockerInstanceIP  = "10.0.0.2"
+	TestNoopIP1           = "1.1.1.1"
+	TestNoopIP2           = "1.1.1.2"
+	TestNoopIP3           = "1.2.3.4"
+	TestNoopIP4           = "2.2.2.2"
+	TestLibvirtInstanceIP = "192.168.122.10"
+	TestLibvirtDHCPStart  = "10.0.0.2"
+	TestLibvirtDHCPEnd    = "10.0.0.50"
+	TestLibvirtPoolStart  = "192.168.100.0"
+	TestLibvirtPoolEnd    = "192.168.200.255"
+	TestVXLANRemoteIP     = "192.168.1.1"
+	TestSubnet2CIDR       = "10.0.2.0/24"
 
 	// Auth related constants
 	TestPasswordStrong     = "CorrectHorseBatteryStaple123!"
@@ -14,4 +34,10 @@ const (
 	TestBaseURL            = "http://localhost:8080"
 	TestHeaderAPIKey       = "X-API-Key"
 	TestContentTypeAppJSON = "application/json"
+	TestDatabaseURL        = "postgres://cloud:cloud@localhost:5433/thecloud"
+	TestProdDatabaseURL    = "postgres://test:test@localhost:5432/testdb"
+	TestEnvDev             = "development"
+	TestEnvProd            = "production"
+	TestPort               = "8080"
+	TestProdPort           = "9090"
 )

--- a/pkg/util/password_test.go
+++ b/pkg/util/password_test.go
@@ -19,7 +19,7 @@ func TestGenerateRandomPassword(t *testing.T) {
 	assert.NotEqual(t, password, password2, "passwords should be random")
 }
 
-func TestGenerateRandomPassword_ZeroLength(t *testing.T) {
+func TestGenerateRandomPasswordZeroLength(t *testing.T) {
 	password, err := GenerateRandomPassword(0)
 	assert.NoError(t, err)
 	assert.Equal(t, "", password)

--- a/tests/doc.go
+++ b/tests/doc.go
@@ -1,0 +1,2 @@
+// Package tests contains end-to-end and integration tests for the platform.
+package tests

--- a/tests/multitenancy_e2e_test.go
+++ b/tests/multitenancy_e2e_test.go
@@ -74,7 +74,7 @@ func TestMultiTenancyE2E(t *testing.T) {
 		req.Header.Set(testutil.TestHeaderAPIKey, tokenB)
 		resp, err := client.Do(req)
 		require.NoError(t, err)
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		// Expect 404 (Not Found) or 403 (Forbidden).
 		// Since repo filters by user_id, it likely returns Not Found (like it doesn't exist for them).
@@ -86,7 +86,7 @@ func TestMultiTenancyE2E(t *testing.T) {
 		req.Header.Set(testutil.TestHeaderAPIKey, tokenA)
 		resp, err := client.Do(req)
 		require.NoError(t, err)
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
@@ -112,7 +112,7 @@ func registerAndLogin(t *testing.T, client *http.Client, email, name string) str
 	body, _ := json.Marshal(regReq)
 	resp, err := client.Post(testutil.TestBaseURL+"/auth/register", testutil.TestContentTypeAppJSON, bytes.NewBuffer(body))
 	if err == nil {
-		resp.Body.Close()
+		_ = resp.Body.Close()
 	}
 	// Ignore error if already registered, proceed to login
 
@@ -121,7 +121,7 @@ func registerAndLogin(t *testing.T, client *http.Client, email, name string) str
 	body, _ = json.Marshal(loginReq)
 	resp, err = client.Post(testutil.TestBaseURL+"/auth/login", testutil.TestContentTypeAppJSON, bytes.NewBuffer(body))
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("Login failed for %s: status %d", email, resp.StatusCode)
@@ -144,7 +144,7 @@ func createInstance(t *testing.T, client *http.Client, token, name string) Insta
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(resp.Body)
@@ -166,7 +166,7 @@ func listInstances(t *testing.T, client *http.Client, token string) []Instance {
 
 	resp, err := client.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -181,5 +181,5 @@ func listInstances(t *testing.T, client *http.Client, token string) []Instance {
 func deleteInstance(t *testing.T, client *http.Client, token, id string) {
 	req, _ := http.NewRequest("DELETE", fmt.Sprintf(instancesPathFmt, testutil.TestBaseURL, id), nil)
 	req.Header.Set(testutil.TestHeaderAPIKey, token)
-	client.Do(req)
+	_, _ = client.Do(req)
 }

--- a/tests/multitenancy_e2e_test.go
+++ b/tests/multitenancy_e2e_test.go
@@ -1,5 +1,3 @@
-//go:build e2e
-
 // Package tests contains end-to-end and integration tests for the platform.
 package tests
 

--- a/tests/multitenancy_e2e_test.go
+++ b/tests/multitenancy_e2e_test.go
@@ -47,8 +47,10 @@ type Instance struct {
 }
 
 func TestMultiTenancyE2E(t *testing.T) {
-	// Ensure server is reachable
-	require.NoError(t, waitForServer(), "Server must be running at "+testutil.TestBaseURL)
+	// Skip if server is not reachable (e.g., in CI without live services)
+	if err := waitForServer(); err != nil {
+		t.Skipf("Skipping E2E test: %v (server at %s not available)", err, testutil.TestBaseURL)
+	}
 
 	client := &http.Client{Timeout: 5 * time.Second}
 

--- a/tests/multitenancy_e2e_test.go
+++ b/tests/multitenancy_e2e_test.go
@@ -99,7 +99,7 @@ func waitForServer() error {
 	for i := 0; i < 30; i++ {
 		resp, err := http.Get(testutil.TestBaseURL + "/health")
 		if err == nil && resp.StatusCode == 200 {
-			resp.Body.Close()
+			_ = resp.Body.Close()
 			return nil
 		}
 		time.Sleep(1 * time.Second)

--- a/tests/multitenancy_e2e_test.go
+++ b/tests/multitenancy_e2e_test.go
@@ -146,7 +146,7 @@ func createInstance(t *testing.T, client *http.Client, token, name string) Insta
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("Create instance failed: status %d body %s", resp.StatusCode, body)
 	}

--- a/tests/multitenancy_e2e_test.go
+++ b/tests/multitenancy_e2e_test.go
@@ -96,9 +96,10 @@ func TestMultiTenancyE2E(t *testing.T) {
 }
 
 func waitForServer() error {
-	for i := 0; i < 5; i++ {
+	for i := 0; i < 30; i++ {
 		resp, err := http.Get(testutil.TestBaseURL + "/health")
 		if err == nil && resp.StatusCode == 200 {
+			resp.Body.Close()
 			return nil
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
## Overview
This PR completes the implementation of the Security Groups feature. Security groups act as virtual firewalls for compute instances, controlling inbound and outbound traffic at the network level using Open vSwitch flow rules.

## Key Changes
- **Core Logic**:
  - Implemented `RemoveRule`, `Attach`, and `Detach` in `SecurityGroupService`.
  - Added repository methods for full CRUD on security rules and instance associations.
- **Observability**:
  - Added OpenTelemetry tracing to all service methods.
  - Added audit logging for group creation, deletion, rule changes, and instance associations.
- **CLI**:
  - Unified `sg` command suite with support for `create`, `list`, `get`, `delete`, `add-rule`, `remove-rule`, `attach`, and `detach`.
- **API Documentation**:
  - Full Swagger annotations for all security group endpoints.
  - Refactored handlers to use named request/response models.
  - Updated API reference and Networking guides in `/docs`.
- **Testing**:
  - Expanded unit tests for handlers and services.
  - Fixed multi-tenancy E2E tests and aligned them with asynchronous launch status codes (202 Accepted).

## Verification
- `make test` passes globally.
- `make swagger` output verified and synced.
- Standardized `context` handling across all instrumented layers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Security Groups: create, list, get, delete (204), add/remove rules (including remove-by-ID), attach/detach to instances
  * SDK: client methods to detach groups and remove rules
  * Added "Cloud Vision & Architecture Brainstorming" workflow doc

* **CLI**
  * New sg subcommands covering Security Groups operations

* **Documentation**
  * API Reference, CLI Reference, and Networking Guide updated with Security Groups examples

* **Other**
  * Docker Compose: API service port exposed for local access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->