### PR TITLE
fix: Address QA findings and improve test reliability

### DIFF
--- a/internal/core/services/cache.go
+++ b/internal/core/services/cache.go
@@ -70,12 +70,12 @@ func (s *CacheService) CreateCache(ctx context.Context, name, version string, me
 		UpdatedAt: time.Now(),
 	}
 
-	if err := s.repo.Create(ctx, cache); err != nil {
+	networkID, err := s.resolveNetworkID(ctx, vpcID)
+	if err != nil {
 		return nil, err
 	}
 
-	networkID, err := s.resolveNetworkID(ctx, vpcID)
-	if err != nil {
+	if err := s.repo.Create(ctx, cache); err != nil {
 		return nil, err
 	}
 

--- a/internal/core/services/cluster.go
+++ b/internal/core/services/cluster.go
@@ -52,6 +52,12 @@ func NewClusterService(params ClusterServiceParams) (*ClusterService, error) {
 	}, nil
 }
 
+// Default cluster configuration values.
+const (
+	defaultClusterVersion = "v1.29.0"
+	defaultWorkerCount    = 2
+)
+
 // CreateCluster initiates the provisioning of a new Kubernetes cluster.
 func (s *ClusterService) CreateCluster(ctx context.Context, params ports.CreateClusterParams) (*domain.Cluster, error) {
 	// 1. Verify VPC exists and belongs to user
@@ -62,10 +68,10 @@ func (s *ClusterService) CreateCluster(ctx context.Context, params ports.CreateC
 
 	// Default version if not specified
 	if params.Version == "" {
-		params.Version = "v1.29.0"
+		params.Version = defaultClusterVersion
 	}
 	if params.Workers == 0 {
-		params.Workers = 2 // Default 2 workers
+		params.Workers = defaultWorkerCount
 	}
 
 	// 2. Generate SSH Key Pair for the cluster

--- a/internal/repositories/k8s/provisioner_all_test.go
+++ b/internal/repositories/k8s/provisioner_all_test.go
@@ -51,6 +51,7 @@ func TestKubeadmProvisionerK8sOps(t *testing.T) {
 
 		err := p.ExportEnsureClusterSecurityGroup(ctx, cluster)
 		assert.NoError(t, err)
+		sgSvc.AssertExpectations(t)
 	})
 
 	t.Run("CreateNode", func(t *testing.T) {
@@ -63,6 +64,9 @@ func TestKubeadmProvisionerK8sOps(t *testing.T) {
 		inst, err := p.ExportCreateNode(ctx, cluster, "master-0", domain.NodeRoleControlPlane)
 		assert.NoError(t, err)
 		assert.Equal(t, masterID, inst.ID)
+		instSvc.AssertExpectations(t)
+		sgSvc.AssertExpectations(t)
+		repo.AssertExpectations(t)
 	})
 
 	t.Run("HealthAndRepair", func(t *testing.T) {
@@ -90,6 +94,8 @@ func TestKubeadmProvisionerK8sOps(t *testing.T) {
 		instSvc.On("Exec", ctx, masterID.String(), mock.Anything).Return("success", nil)
 		err = p.Repair(ctx, cluster)
 		assert.NoError(t, err)
+		repo.AssertExpectations(t)
+		instSvc.AssertExpectations(t)
 	})
 
 	t.Run("KubeConfig", func(t *testing.T) {
@@ -105,6 +111,8 @@ func TestKubeadmProvisionerK8sOps(t *testing.T) {
 		conf, err := p.GetKubeconfig(ctx, cluster, "admin")
 		assert.NoError(t, err)
 		assert.Equal(t, "kubeconfig-content", conf)
+		repo.AssertExpectations(t)
+		instSvc.AssertExpectations(t)
 	})
 
 	t.Run("ScaleDown", func(t *testing.T) {
@@ -120,5 +128,7 @@ func TestKubeadmProvisionerK8sOps(t *testing.T) {
 
 		err := p.Scale(ctx, cluster)
 		assert.NoError(t, err)
+		repo.AssertExpectations(t)
+		instSvc.AssertExpectations(t)
 	})
 }

--- a/internal/storage/node/rpc_test.go
+++ b/internal/storage/node/rpc_test.go
@@ -84,7 +84,9 @@ func TestRPCServerGetClusterStatus(t *testing.T) {
 
 func TestRPCServerStoreError(t *testing.T) {
 	tmpDir := t.TempDir()
-	store, _ := NewLocalStore(tmpDir)
+	store, err := NewLocalStore(tmpDir)
+	require.NoError(t, err)
+
 	server := NewRPCServer(store, nil)
 
 	resp, err := server.Store(context.Background(), &pb.StoreRequest{
@@ -100,7 +102,9 @@ func TestRPCServerStoreError(t *testing.T) {
 
 func TestRPCServerDeleteMissing(t *testing.T) {
 	tmpDir := t.TempDir()
-	store, _ := NewLocalStore(tmpDir)
+	store, err := NewLocalStore(tmpDir)
+	require.NoError(t, err)
+
 	server := NewRPCServer(store, nil)
 
 	resp, err := server.Delete(context.Background(), &pb.DeleteRequest{

--- a/pkg/sdk/iac_test.go
+++ b/pkg/sdk/iac_test.go
@@ -146,18 +146,50 @@ func TestClient_IacErrors(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, "test-api-key")
-	_, err := client.CreateStack("stack", "template", map[string]string{})
-	assert.Error(t, err)
 
-	_, err = client.ListStacks()
-	assert.Error(t, err)
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "CreateStack",
+			call: func() error {
+				_, err := client.CreateStack("stack", "template", map[string]string{})
+				return err
+			},
+		},
+		{
+			name: "ListStacks",
+			call: func() error {
+				_, err := client.ListStacks()
+				return err
+			},
+		},
+		{
+			name: "GetStack",
+			call: func() error {
+				_, err := client.GetStack("stack-1")
+				return err
+			},
+		},
+		{
+			name: "DeleteStack",
+			call: func() error {
+				return client.DeleteStack("stack-1")
+			},
+		},
+		{
+			name: "ValidateTemplate",
+			call: func() error {
+				_, err := client.ValidateTemplate("template")
+				return err
+			},
+		},
+	}
 
-	_, err = client.GetStack("stack-1")
-	assert.Error(t, err)
-
-	err = client.DeleteStack("stack-1")
-	assert.Error(t, err)
-
-	_, err = client.ValidateTemplate("template")
-	assert.Error(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Error(t, tc.call())
+		})
+	}
 }

--- a/pkg/sdk/vpc_test.go
+++ b/pkg/sdk/vpc_test.go
@@ -102,15 +102,43 @@ func TestClient_VPCErrors(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, testAPIKey)
-	_, err := client.ListVPCs()
-	assert.Error(t, err)
 
-	_, err = client.CreateVPC("vpc", testutil.TestCIDR)
-	assert.Error(t, err)
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "ListVPCs",
+			call: func() error {
+				_, err := client.ListVPCs()
+				return err
+			},
+		},
+		{
+			name: "CreateVPC",
+			call: func() error {
+				_, err := client.CreateVPC("vpc", testutil.TestCIDR)
+				return err
+			},
+		},
+		{
+			name: "GetVPC",
+			call: func() error {
+				_, err := client.GetVPC("vpc-1")
+				return err
+			},
+		},
+		{
+			name: "DeleteVPC",
+			call: func() error {
+				return client.DeleteVPC("vpc-1")
+			},
+		},
+	}
 
-	_, err = client.GetVPC("vpc-1")
-	assert.Error(t, err)
-
-	err = client.DeleteVPC("vpc-1")
-	assert.Error(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Error(t, tc.call())
+		})
+	}
 }

--- a/pkg/sshutil/client_test.go
+++ b/pkg/sshutil/client_test.go
@@ -82,7 +82,7 @@ func TestWaitForSSHTimeout(t *testing.T) {
 	// Use small timeout for test speed
 	err := client.WaitForSSH(context.Background(), 100*time.Millisecond)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), testErrTimedOut)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestWaitForSSHContextCanceled(t *testing.T) {
@@ -93,7 +93,7 @@ func TestWaitForSSHContextCanceled(t *testing.T) {
 
 	err := client.WaitForSSH(ctx, 2*time.Second)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), testErrTimedOut)
+	assert.ErrorIs(t, err, context.Canceled)
 }
 
 func TestWaitForSSHHostWithoutPortTimeout(t *testing.T) {
@@ -106,7 +106,7 @@ func TestWaitForSSHHostWithoutPortTimeout(t *testing.T) {
 
 	err := client.WaitForSSH(ctx, 2*time.Second)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), testErrTimedOut)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestRunConnectionRefused(t *testing.T) {

--- a/tests/compute_e2e_test.go
+++ b/tests/compute_e2e_test.go
@@ -120,7 +120,7 @@ func TestComputeE2E(t *testing.T) {
 		resp := postRequest(t, client, fmt.Sprintf("%s%s/%s/stop", testutil.TestBaseURL, testutil.TestRouteInstances, instanceID), token, nil)
 		defer resp.Body.Close()
 
-		assert.Contains(t, []int{http.StatusOK, http.StatusConflict, http.StatusInternalServerError}, resp.StatusCode)
+		assert.Contains(t, []int{http.StatusOK, http.StatusConflict}, resp.StatusCode)
 	})
 
 	// 6. Terminate Instance


### PR DESCRIPTION
This PR addresses several issues identified during QA review:

### Fixes
- **Cache Service**: Validated VPC existence before creating cache records to prevent orphaned entries `internal/core/services/cache.go`.
- **Cluster Service**: Replaced magic literals with named constants for default configuration `internal/core/services/cluster.go`.
- **Test Reliability**:
    - **Metrics Worker**: Replaced flaky sleep-based test with deterministic polling `metrics_worker_test.go`.
    - **SSH Util**: Updated error assertions to check for specific error types (`context.DeadlineExceeded`) rather than substrings `client_test.go`.
    - **E2E**: Tightened status code assertions in `compute_e2e_test.go` to expose potential backend failures (removed 500 from allowlist).
- **Test Refactoring**: 
    - Converted `SDK` and `Handler` tests to table-driven format for better maintainability and coverage.
    - Added explicit mock expectation assertions (`AssertExpectations`) in handler and provisioner tests.
    - Added error checking for test setup helpers in `rpc_test.go`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added e2e test infrastructure with configurable timeout support
  * Cluster creation now applies default Kubernetes version (v1.29.0) and worker count (2) when not specified
  * Multitenancy context propagation across API requests
  * VPC network integration for database and cache deployments
  * Automatic default CIDR assignment for VPC creation

* **Bug Fixes**
  * Improved SSH command output handling to prevent race conditions

* **Tests**
  * Comprehensive test coverage expanded across service, handler, and repository layers
  * End-to-end tests updated for multitenancy scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->