### PR TITLE
test: expand CLI coverage

### DIFF
--- a/cmd/cloud/autoscaling_cli_test.go
+++ b/cmd/cloud/autoscaling_cli_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	asgTestAPIKey = "asg-key"
+	asgTestID     = "asg-1"
+	asgTestName   = "web-scaling"
+)
+
+func TestASGCreateJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/autoscaling/groups" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":            asgTestID,
+				"name":          asgTestName,
+				"vpc_id":        "vpc-1",
+				"image":         "nginx:latest",
+				"min_instances": 1,
+				"max_instances": 3,
+				"desired_count": 2,
+				"current_count": 1,
+				"status":        "active",
+				"created_at":    time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = asgTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	_ = asgCreateCmd.Flags().Set("name", asgTestName)
+	_ = asgCreateCmd.Flags().Set("vpc", "vpc-1")
+	_ = asgCreateCmd.Flags().Set("image", "nginx:latest")
+	_ = asgCreateCmd.Flags().Set("min", "1")
+	_ = asgCreateCmd.Flags().Set("max", "3")
+	_ = asgCreateCmd.Flags().Set("desired", "2")
+
+	out := captureStdout(t, func() {
+		asgCreateCmd.Run(asgCreateCmd, nil)
+	})
+	if !strings.Contains(out, asgTestName) {
+		t.Fatalf("expected JSON output to include group name, got: %s", out)
+	}
+}
+
+func TestASGListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/autoscaling/groups" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":            asgTestID,
+					"name":          asgTestName,
+					"vpc_id":        "vpc-1",
+					"image":         "nginx:latest",
+					"min_instances": 1,
+					"max_instances": 3,
+					"desired_count": 2,
+					"current_count": 1,
+					"status":        "active",
+					"created_at":    time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = asgTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		asgListCmd.Run(asgListCmd, nil)
+	})
+	if !strings.Contains(out, asgTestID) {
+		t.Fatalf("expected JSON output to include group id, got: %s", out)
+	}
+}
+
+func TestASGDeleteCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/autoscaling/groups/"+asgTestID || r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = asgTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		asgRmCmd.Run(asgRmCmd, []string{asgTestID})
+	})
+	if !strings.Contains(out, "Scaling Group deleted") {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestASGPolicyAddCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/autoscaling/groups/"+asgTestID+"/policies" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = asgTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = asgPolicyAddCmd.Flags().Set("name", "cpu-80")
+	_ = asgPolicyAddCmd.Flags().Set("metric", "cpu")
+	_ = asgPolicyAddCmd.Flags().Set("target", "80")
+	_ = asgPolicyAddCmd.Flags().Set("scale-out", "1")
+	_ = asgPolicyAddCmd.Flags().Set("scale-in", "1")
+	_ = asgPolicyAddCmd.Flags().Set("cooldown", "60")
+
+	out := captureStdout(t, func() {
+		asgPolicyAddCmd.Run(asgPolicyAddCmd, []string{asgTestID})
+	})
+	if !strings.Contains(out, "Policy added") {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}

--- a/cmd/cloud/autoscaling_cli_test.go
+++ b/cmd/cloud/autoscaling_cli_test.go
@@ -17,6 +17,7 @@ const (
 
 func TestASGCreateJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/autoscaling/groups" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -67,6 +68,7 @@ func TestASGCreateJSONOutput(t *testing.T) {
 
 func TestASGListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/autoscaling/groups" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -112,6 +114,7 @@ func TestASGListJSONOutput(t *testing.T) {
 
 func TestASGDeleteCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/autoscaling/groups/"+asgTestID || r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -139,6 +142,7 @@ func TestASGDeleteCmd(t *testing.T) {
 
 func TestASGPolicyAddCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/autoscaling/groups/"+asgTestID+"/policies" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/container_cli_test.go
+++ b/cmd/cloud/container_cli_test.go
@@ -16,6 +16,7 @@ const (
 
 func TestCreateDeploymentCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/containers/deployments" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -55,6 +56,7 @@ func TestCreateDeploymentCmd(t *testing.T) {
 
 func TestListDeploymentsCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/containers/deployments" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -102,6 +104,7 @@ func TestScaleDeploymentInvalidReplicas(t *testing.T) {
 
 func TestDeleteDeploymentCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/containers/deployments/"+containerTestID || r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/container_cli_test.go
+++ b/cmd/cloud/container_cli_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	containerTestAPIKey = "container-key"
+	containerTestID     = "dep-1"
+	containerTestName   = "web"
+)
+
+func TestCreateDeploymentCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/containers/deployments" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"id":            containerTestID,
+			"name":          containerTestName,
+			"image":         "nginx:latest",
+			"replicas":      1,
+			"current_count": 1,
+			"ports":         "80:80",
+			"status":        "running",
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = containerTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = createDeploymentCmd.Flags().Set("replicas", "1")
+	_ = createDeploymentCmd.Flags().Set("ports", "80:80")
+
+	out := captureStdout(t, func() {
+		createDeploymentCmd.Run(createDeploymentCmd, []string{containerTestName, "nginx:latest"})
+	})
+	if !strings.Contains(out, "Deployment created") || !strings.Contains(out, containerTestName) {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestListDeploymentsCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/containers/deployments" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := []map[string]interface{}{
+			{
+				"id":            containerTestID,
+				"name":          containerTestName,
+				"image":         "nginx:latest",
+				"replicas":      2,
+				"current_count": 2,
+				"ports":         "80:80",
+				"status":        "running",
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = containerTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		listDeploymentsCmd.Run(listDeploymentsCmd, nil)
+	})
+	if !strings.Contains(out, containerTestName) {
+		t.Fatalf("expected list output to include deployment name, got: %s", out)
+	}
+}
+
+func TestScaleDeploymentInvalidReplicas(t *testing.T) {
+	out := captureStdout(t, func() {
+		scaleDeploymentCmd.Run(scaleDeploymentCmd, []string{containerTestID, "invalid"})
+	})
+	if !strings.Contains(out, "invalid replica count") {
+		t.Fatalf("expected invalid replica count error, got: %s", out)
+	}
+}
+
+func TestDeleteDeploymentCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/containers/deployments/"+containerTestID || r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = containerTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		deleteDeploymentCmd.Run(deleteDeploymentCmd, []string{containerTestID})
+	})
+	if !strings.Contains(out, "Deletion initiated") {
+		t.Fatalf("expected deletion output, got: %s", out)
+	}
+}

--- a/cmd/cloud/cron_cli_test.go
+++ b/cmd/cloud/cron_cli_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	cronTestAPIKey   = "cron-key"
+	cronTestJobID    = "cron-1"
+	cronTestJobName  = "nightly"
+	cronTestSchedule = "0 0 * * *"
+	cronTestURL      = "https://example.com/hook"
+)
+
+func TestCreateCronCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cron/jobs" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		job := map[string]interface{}{
+			"id":       cronTestJobID,
+			"name":     cronTestJobName,
+			"schedule": cronTestSchedule,
+			"url":      cronTestURL,
+			"status":   "active",
+			"next_run": "2024-01-01T00:00:00Z",
+		}
+		_ = json.NewEncoder(w).Encode(job)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = cronTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = createCronCmd.Flags().Set("method", "POST")
+	_ = createCronCmd.Flags().Set("payload", "{}")
+
+	out := captureStdout(t, func() {
+		createCronCmd.Run(createCronCmd, []string{cronTestJobName, cronTestSchedule, cronTestURL})
+	})
+	if !strings.Contains(out, "Cron job created") || !strings.Contains(out, cronTestJobID) {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestPauseCronCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cron/jobs/"+cronTestJobID+"/pause" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = cronTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		pauseCronCmd.Run(pauseCronCmd, []string{cronTestJobID})
+	})
+	if !strings.Contains(out, "Job paused") {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestDeleteCronCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cron/jobs/"+cronTestJobID || r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = cronTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		deleteCronCmd.Run(deleteCronCmd, []string{cronTestJobID})
+	})
+	if !strings.Contains(out, "Job deleted") {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}

--- a/cmd/cloud/cron_cli_test.go
+++ b/cmd/cloud/cron_cli_test.go
@@ -18,6 +18,7 @@ const (
 
 func TestCreateCronCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/cron/jobs" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -56,6 +57,7 @@ func TestCreateCronCmd(t *testing.T) {
 
 func TestPauseCronCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/cron/jobs/"+cronTestJobID+"/pause" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -83,6 +85,7 @@ func TestPauseCronCmd(t *testing.T) {
 
 func TestDeleteCronCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/cron/jobs/"+cronTestJobID || r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/db_cli_test.go
+++ b/cmd/cloud/db_cli_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	dbTestAPIKey = "db-key"
+	dbTestID     = "db-1"
+	dbTestName   = "appdb"
+)
+
+func TestDBListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/databases" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":         dbTestID,
+					"name":       dbTestName,
+					"engine":     "postgres",
+					"version":    "16",
+					"status":     "available",
+					"port":       5432,
+					"username":   "admin",
+					"created_at": time.Now().UTC().Format(time.RFC3339),
+					"updated_at": time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = dbTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		dbListCmd.Run(dbListCmd, nil)
+	})
+	if !strings.Contains(out, dbTestID) {
+		t.Fatalf("expected JSON output to include database id, got: %s", out)
+	}
+}
+
+func TestDBCreateJSONMasksPassword(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/databases" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":         dbTestID,
+				"name":       dbTestName,
+				"engine":     "postgres",
+				"version":    "16",
+				"status":     "available",
+				"port":       5432,
+				"username":   "admin",
+				"password":   "secret",
+				"created_at": time.Now().UTC().Format(time.RFC3339),
+				"updated_at": time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = dbTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	_ = dbCreateCmd.Flags().Set("name", dbTestName)
+	_ = dbCreateCmd.Flags().Set("engine", "postgres")
+	_ = dbCreateCmd.Flags().Set("version", "16")
+
+	out := captureStdout(t, func() {
+		dbCreateCmd.Run(dbCreateCmd, nil)
+	})
+	if strings.Contains(out, "secret") {
+		t.Fatalf("expected password to be masked, got: %s", out)
+	}
+	if !strings.Contains(out, "********") {
+		t.Fatalf("expected masked password, got: %s", out)
+	}
+}
+
+func TestDBConnectionCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/databases/"+dbTestID+"/connection" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]string{"connection_string": "postgres://user:pass@localhost:5432/db"},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = dbTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		dbConnCmd.Run(dbConnCmd, []string{dbTestID})
+	})
+	if !strings.Contains(out, "Connection String") {
+		t.Fatalf("expected connection string output, got: %s", out)
+	}
+}

--- a/cmd/cloud/db_cli_test.go
+++ b/cmd/cloud/db_cli_test.go
@@ -17,6 +17,7 @@ const (
 
 func TestDBListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/databases" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -61,6 +62,7 @@ func TestDBListJSONOutput(t *testing.T) {
 
 func TestDBCreateJSONMasksPassword(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/databases" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -111,6 +113,7 @@ func TestDBCreateJSONMasksPassword(t *testing.T) {
 
 func TestDBConnectionCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/databases/"+dbTestID+"/connection" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/events_cli_test.go
+++ b/cmd/cloud/events_cli_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 const (
@@ -14,15 +16,17 @@ const (
 )
 
 func TestEventsListJSONOutput(t *testing.T) {
+	eventID := uuid.New().String()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/events" || r.Method != http.MethodGet {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/events" || r.Method != http.MethodGet || r.URL.Query().Get("limit") != "50" {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		payload := map[string]interface{}{
 			"data": []map[string]interface{}{
 				{
-					"id":            "evt-1",
+					"id":            eventID,
 					"action":        "create",
 					"resource_id":   "res-1",
 					"resource_type": "instance",
@@ -49,7 +53,7 @@ func TestEventsListJSONOutput(t *testing.T) {
 	out := captureStdout(t, func() {
 		listEventsCmd.Run(listEventsCmd, nil)
 	})
-	if !strings.Contains(out, "evt-1") {
+	if !strings.Contains(out, eventID) {
 		t.Fatalf("expected JSON output to include event id, got: %s", out)
 	}
 }

--- a/cmd/cloud/events_cli_test.go
+++ b/cmd/cloud/events_cli_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	eventsTestAPIKey = "events-key"
+)
+
+func TestEventsListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/events" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":            "evt-1",
+					"action":        "create",
+					"resource_id":   "res-1",
+					"resource_type": "instance",
+					"metadata":      "details",
+					"created_at":    time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = eventsTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		listEventsCmd.Run(listEventsCmd, nil)
+	})
+	if !strings.Contains(out, "evt-1") {
+		t.Fatalf("expected JSON output to include event id, got: %s", out)
+	}
+}

--- a/cmd/cloud/function_cli_test.go
+++ b/cmd/cloud/function_cli_test.go
@@ -19,6 +19,7 @@ const (
 
 func TestFunctionCreateCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/functions" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -67,6 +68,7 @@ func TestFunctionCreateCmd(t *testing.T) {
 
 func TestFunctionListEmpty(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/functions" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/function_cli_test.go
+++ b/cmd/cloud/function_cli_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	functionTestAPIKey = "function-key"
+	functionTestID     = "fn-1"
+	functionTestName   = "hello"
+)
+
+func TestFunctionCreateCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/functions" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":         functionTestID,
+				"name":       functionTestName,
+				"runtime":    "nodejs20",
+				"status":     "active",
+				"created_at": time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	codePath := filepath.Join(t.TempDir(), "fn.zip")
+	if err := os.WriteFile(codePath, []byte("zip"), 0644); err != nil {
+		t.Fatalf("write code: %v", err)
+	}
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = functionTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = createFnCmd.Flags().Set("name", functionTestName)
+	_ = createFnCmd.Flags().Set("runtime", "nodejs20")
+	_ = createFnCmd.Flags().Set("handler", "index.handler")
+	_ = createFnCmd.Flags().Set("code", codePath)
+
+	out := captureStdout(t, func() {
+		if err := createFnCmd.RunE(createFnCmd, nil); err != nil {
+			t.Fatalf("create function: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Function") || !strings.Contains(out, functionTestID) {
+		t.Fatalf("expected create output, got: %s", out)
+	}
+}
+
+func TestFunctionListEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/functions" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = functionTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		if err := listFnCmd.RunE(listFnCmd, nil); err != nil {
+			t.Fatalf("list function: %v", err)
+		}
+	})
+	if !strings.Contains(out, "No functions found") {
+		t.Fatalf("expected empty list output, got: %s", out)
+	}
+}

--- a/cmd/cloud/gateway_cli_test.go
+++ b/cmd/cloud/gateway_cli_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	gatewayTestAPIKey = "gateway-key"
+	gatewayTestID     = "route-1"
+)
+
+func TestGatewayCreateRouteCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gateway/routes" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":           gatewayTestID,
+				"name":         "api",
+				"path_prefix":  "/api",
+				"target_url":   "https://example.com",
+				"strip_prefix": true,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = gatewayTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = createRouteCmd.Flags().Set("strip", "true")
+	_ = createRouteCmd.Flags().Set("rate-limit", "100")
+
+	out := captureStdout(t, func() {
+		createRouteCmd.Run(createRouteCmd, []string{"api", "/api", "https://example.com"})
+	})
+	if !strings.Contains(out, "Route created") {
+		t.Fatalf("expected create output, got: %s", out)
+	}
+}
+
+func TestGatewayDeleteRouteCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/gateway/routes/"+gatewayTestID || r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = gatewayTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		deleteRouteCmd.Run(deleteRouteCmd, []string{gatewayTestID})
+	})
+	if !strings.Contains(out, "Route deleted") {
+		t.Fatalf("expected delete output, got: %s", out)
+	}
+}

--- a/cmd/cloud/iac_cli_test.go
+++ b/cmd/cloud/iac_cli_test.go
@@ -13,11 +13,12 @@ import (
 
 const (
 	iacTestAPIKey = "iac-key"
-	iacTestID     = "stack-1"
+	iacTestID     = "11111111-1111-1111-1111-111111111111"
 )
 
 func TestIACListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/iac/stacks" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -55,6 +56,7 @@ func TestIACListJSONOutput(t *testing.T) {
 
 func TestIACValidateTemplateSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/iac/validate" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/iac_cli_test.go
+++ b/cmd/cloud/iac_cli_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	iacTestAPIKey = "iac-key"
+	iacTestID     = "stack-1"
+)
+
+func TestIACListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/iac/stacks" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := []map[string]interface{}{
+			{
+				"id":         iacTestID,
+				"name":       "demo",
+				"status":     "CREATE_COMPLETE",
+				"created_at": time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = iacTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		iacListCmd.Run(iacListCmd, nil)
+	})
+	if !strings.Contains(out, iacTestID) {
+		t.Fatalf("expected JSON output to include stack id, got: %s", out)
+	}
+}
+
+func TestIACValidateTemplateSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/iac/validate" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"valid":  true,
+			"errors": []string{},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	templatePath := filepath.Join(t.TempDir(), "template.yaml")
+	if err := os.WriteFile(templatePath, []byte("resources: []"), 0644); err != nil {
+		t.Fatalf("write template: %v", err)
+	}
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = iacTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		iacValidateCmd.Run(iacValidateCmd, []string{templatePath})
+	})
+	if !strings.Contains(out, "Template is valid") {
+		t.Fatalf("expected valid template output, got: %s", out)
+	}
+}

--- a/cmd/cloud/kubernetes_test.go
+++ b/cmd/cloud/kubernetes_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	kubernetesTestContentType = "Content-Type"
+	kubernetesTestAppJSON     = "application/json"
+	kubernetesTestAPIKey      = "kube-test-key"
+)
+
+func TestListClustersJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/clusters" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set(kubernetesTestContentType, kubernetesTestAppJSON)
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":           uuid.New().String(),
+					"name":         "kube-1",
+					"version":      "v1.29.0",
+					"worker_count": 2,
+					"status":       "running",
+					"created_at":   time.Now().UTC().Format(time.RFC3339),
+					"updated_at":   time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = kubernetesTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		listClustersCmd.Run(listClustersCmd, nil)
+	})
+	if !containsAll(out, []string{"kube-1", "worker_count"}) {
+		t.Fatalf("expected JSON output to include cluster data, got: %s", out)
+	}
+}
+
+func TestCreateClusterSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/clusters" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set(kubernetesTestContentType, kubernetesTestAppJSON)
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":           uuid.New().String(),
+				"name":         "dev-cluster",
+				"version":      "v1.29.0",
+				"worker_count": 2,
+				"status":       "provisioning",
+				"created_at":   time.Now().UTC().Format(time.RFC3339),
+				"updated_at":   time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = kubernetesTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	clusterID := uuid.New()
+	_ = createClusterCmd.Flags().Set("name", "dev-cluster")
+	_ = createClusterCmd.Flags().Set("vpc", clusterID.String())
+	_ = createClusterCmd.Flags().Set("version", "v1.29.0")
+	_ = createClusterCmd.Flags().Set("workers", "2")
+	_ = createClusterCmd.Flags().Set("isolate", "true")
+	_ = createClusterCmd.Flags().Set("ha", "false")
+
+	out := captureStdout(t, func() {
+		createClusterCmd.Run(createClusterCmd, nil)
+	})
+	if !containsAll(out, []string{"Cluster creation initiated", "dev-cluster"}) {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func containsAll(out string, values []string) bool {
+	for _, v := range values {
+		if !strings.Contains(out, v) {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/cloud/loadbalancer_cli_test.go
+++ b/cmd/cloud/loadbalancer_cli_test.go
@@ -15,6 +15,7 @@ const (
 
 func TestLBListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/lb" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -56,6 +57,7 @@ func TestLBListJSONOutput(t *testing.T) {
 
 func TestLBAddTargetCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/lb/"+lbTestID+"/targets" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/loadbalancer_cli_test.go
+++ b/cmd/cloud/loadbalancer_cli_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	lbTestAPIKey = "lb-key"
+	lbTestID     = "lb-1"
+)
+
+func TestLBListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/lb" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":        lbTestID,
+					"name":      "public",
+					"vpc_id":    "vpc-1",
+					"port":      80,
+					"algorithm": "round-robin",
+					"status":    "ACTIVE",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = lbTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		lbListCmd.Run(lbListCmd, nil)
+	})
+	if !strings.Contains(out, lbTestID) {
+		t.Fatalf("expected JSON output to include lb id, got: %s", out)
+	}
+}
+
+func TestLBAddTargetCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/lb/"+lbTestID+"/targets" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = lbTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = lbAddTargetCmd.Flags().Set("instance", "inst-1")
+	_ = lbAddTargetCmd.Flags().Set("port", "80")
+	_ = lbAddTargetCmd.Flags().Set("weight", "1")
+
+	out := captureStdout(t, func() {
+		lbAddTargetCmd.Run(lbAddTargetCmd, []string{lbTestID})
+	})
+	if !strings.Contains(out, "Target") {
+		t.Fatalf("expected add target output, got: %s", out)
+	}
+}

--- a/cmd/cloud/notify_cli_test.go
+++ b/cmd/cloud/notify_cli_test.go
@@ -16,6 +16,7 @@ const (
 
 func TestCreateTopicCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/notify/topics" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -50,6 +51,7 @@ func TestCreateTopicCmd(t *testing.T) {
 
 func TestPublishCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/notify/topics/"+notifyTestTopicID+"/publish" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/notify_cli_test.go
+++ b/cmd/cloud/notify_cli_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	notifyTestAPIKey  = "notify-key"
+	notifyTestTopicID = "topic-1"
+	notifyTestTopic   = "alerts"
+)
+
+func TestCreateTopicCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/notify/topics" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":   notifyTestTopicID,
+				"name": notifyTestTopic,
+				"arn":  "arn:cloud:notify:topic-1",
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = notifyTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		createTopicCmd.Run(createTopicCmd, []string{notifyTestTopic})
+	})
+	if !strings.Contains(out, "Topic created") || !strings.Contains(out, notifyTestTopicID) {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestPublishCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/notify/topics/"+notifyTestTopicID+"/publish" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = notifyTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		publishCmd.Run(publishCmd, []string{notifyTestTopicID, "hello"})
+	})
+	if !strings.Contains(out, "Message published") {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}

--- a/cmd/cloud/queue_cli_test.go
+++ b/cmd/cloud/queue_cli_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	queueTestAPIKey = "queue-key"
+	queueTestID     = "queue-1"
+)
+
+func TestQueueListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queues" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":                 queueTestID,
+					"name":               "jobs",
+					"arn":                "arn:cloud:queue:jobs",
+					"visibility_timeout": 30,
+					"retention_days":     4,
+					"max_message_size":   262144,
+					"status":             "active",
+					"created_at":         time.Now().UTC().Format(time.RFC3339),
+					"updated_at":         time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = queueTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		listQueuesCmd.Run(listQueuesCmd, nil)
+	})
+	if !strings.Contains(out, queueTestID) {
+		t.Fatalf("expected JSON output to include queue id, got: %s", out)
+	}
+}
+
+func TestQueueCreateCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queues" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":         queueTestID,
+				"name":       "jobs",
+				"arn":        "arn:cloud:queue:jobs",
+				"status":     "active",
+				"created_at": time.Now().UTC().Format(time.RFC3339),
+				"updated_at": time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = queueTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		createQueueCmd.Run(createQueueCmd, []string{"jobs"})
+	})
+	if !strings.Contains(out, "Queue created") || !strings.Contains(out, queueTestID) {
+		t.Fatalf("expected create output, got: %s", out)
+	}
+}
+
+func TestQueueReceiveNoMessages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queues/"+queueTestID+"/messages" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = queueTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = receiveMessagesCmd.Flags().Set("max", "1")
+	out := captureStdout(t, func() {
+		receiveMessagesCmd.Run(receiveMessagesCmd, []string{queueTestID})
+	})
+	if !strings.Contains(out, "No messages available") {
+		t.Fatalf("expected no messages output, got: %s", out)
+	}
+}
+
+func TestQueueSendMessageCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queues/"+queueTestID+"/messages" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":             "msg-1",
+				"queue_id":       queueTestID,
+				"body":           "hello",
+				"receipt_handle": "handle-1",
+				"created_at":     time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = queueTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		sendMessageCmd.Run(sendMessageCmd, []string{queueTestID, "hello"})
+	})
+	if !strings.Contains(out, "Message sent") {
+		t.Fatalf("expected send message output, got: %s", out)
+	}
+}
+
+func TestQueueAckCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queues/"+queueTestID+"/messages/handle-1" || r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = queueTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		ackMessageCmd.Run(ackMessageCmd, []string{queueTestID, "handle-1"})
+	})
+	if !strings.Contains(out, "Message acknowledged") {
+		t.Fatalf("expected ack output, got: %s", out)
+	}
+}
+
+func TestQueuePurgeCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/queues/"+queueTestID+"/purge" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = queueTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		purgeQueueCmd.Run(purgeQueueCmd, []string{queueTestID})
+	})
+	if !strings.Contains(out, "Queue purged") {
+		t.Fatalf("expected purge output, got: %s", out)
+	}
+}

--- a/cmd/cloud/queue_cli_test.go
+++ b/cmd/cloud/queue_cli_test.go
@@ -16,6 +16,7 @@ const (
 
 func TestQueueListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/queues" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -60,6 +61,7 @@ func TestQueueListJSONOutput(t *testing.T) {
 
 func TestQueueCreateCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/queues" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -97,6 +99,7 @@ func TestQueueCreateCmd(t *testing.T) {
 
 func TestQueueReceiveNoMessages(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/queues/"+queueTestID+"/messages" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -128,6 +131,7 @@ func TestQueueReceiveNoMessages(t *testing.T) {
 
 func TestQueueSendMessageCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/queues/"+queueTestID+"/messages" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -164,6 +168,7 @@ func TestQueueSendMessageCmd(t *testing.T) {
 
 func TestQueueAckCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/queues/"+queueTestID+"/messages/handle-1" || r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -191,6 +196,7 @@ func TestQueueAckCmd(t *testing.T) {
 
 func TestQueuePurgeCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/queues/"+queueTestID+"/purge" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/rbac_cli_test.go
+++ b/cmd/cloud/rbac_cli_test.go
@@ -13,12 +13,13 @@ import (
 
 const (
 	rbacTestAPIKey   = "rbac-key"
-	rbacTestRoleID   = "role-1"
+	rbacTestRoleID   = "22222222-2222-2222-2222-222222222222"
 	rbacTestRoleName = "viewer"
 )
 
 func TestCreateRoleCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/rbac/roles" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -54,6 +55,7 @@ func TestCreateRoleCmd(t *testing.T) {
 
 func TestListRolesCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/rbac/roles" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -88,6 +90,7 @@ func TestListRolesCmd(t *testing.T) {
 
 func TestBindRoleCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/rbac/bindings" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -114,6 +117,7 @@ func TestBindRoleCmd(t *testing.T) {
 func TestDeleteRoleCmd(t *testing.T) {
 	roleID := uuid.New()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/rbac/roles/"+roleID.String() || r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/rbac_cli_test.go
+++ b/cmd/cloud/rbac_cli_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+)
+
+const (
+	rbacTestAPIKey   = "rbac-key"
+	rbacTestRoleID   = "role-1"
+	rbacTestRoleName = "viewer"
+)
+
+func TestCreateRoleCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rbac/roles" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":          rbacTestRoleID,
+				"name":        rbacTestRoleName,
+				"description": "read-only",
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	saveConfig(rbacTestAPIKey)
+
+	oldURL := apiURL
+	apiURL = server.URL
+	defer func() { apiURL = oldURL }()
+
+	_ = createRoleCmd.Flags().Set("description", "read-only")
+	_ = createRoleCmd.Flags().Set("permissions", string(domain.PermissionInstanceRead))
+
+	out := captureStdout(t, func() {
+		createRoleCmd.Run(createRoleCmd, []string{rbacTestRoleName})
+	})
+	if !strings.Contains(out, "Role created") || !strings.Contains(out, rbacTestRoleID) {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestListRolesCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rbac/roles" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":          rbacTestRoleID,
+					"name":        rbacTestRoleName,
+					"permissions": []string{"instance:read"},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	saveConfig(rbacTestAPIKey)
+
+	oldURL := apiURL
+	apiURL = server.URL
+	defer func() { apiURL = oldURL }()
+
+	out := captureStdout(t, func() {
+		listRolesCmd.Run(listRolesCmd, nil)
+	})
+	if !strings.Contains(out, rbacTestRoleName) {
+		t.Fatalf("expected list output to include role name, got: %s", out)
+	}
+}
+
+func TestBindRoleCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rbac/bindings" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	saveConfig(rbacTestAPIKey)
+
+	oldURL := apiURL
+	apiURL = server.URL
+	defer func() { apiURL = oldURL }()
+
+	out := captureStdout(t, func() {
+		bindRoleCmd.Run(bindRoleCmd, []string{"user@example.com", rbacTestRoleName})
+	})
+	if !strings.Contains(out, "Role") || !strings.Contains(out, rbacTestRoleName) {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestDeleteRoleCmd(t *testing.T) {
+	roleID := uuid.New()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/rbac/roles/"+roleID.String() || r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	t.Setenv("HOME", t.TempDir())
+	saveConfig(rbacTestAPIKey)
+
+	oldURL := apiURL
+	apiURL = server.URL
+	defer func() { apiURL = oldURL }()
+
+	out := captureStdout(t, func() {
+		deleteRoleCmd.Run(deleteRoleCmd, []string{roleID.String()})
+	})
+	if !strings.Contains(out, "Role") || !strings.Contains(out, roleID.String()) {
+		t.Fatalf("expected delete output, got: %s", out)
+	}
+}

--- a/cmd/cloud/secrets_cli_test.go
+++ b/cmd/cloud/secrets_cli_test.go
@@ -17,6 +17,7 @@ const (
 
 func TestSecretsListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/secrets" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -57,6 +58,7 @@ func TestSecretsListJSONOutput(t *testing.T) {
 
 func TestSecretsCreateCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/secrets" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/secrets_cli_test.go
+++ b/cmd/cloud/secrets_cli_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	secretsTestAPIKey = "secrets-key"
+	secretsTestID     = "secret-1"
+	secretsTestName   = "api-token"
+)
+
+func TestSecretsListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/secrets" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":          secretsTestID,
+					"name":        secretsTestName,
+					"description": "token",
+					"created_at":  time.Now().UTC().Format(time.RFC3339),
+					"updated_at":  time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = secretsTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		secretsListCmd.Run(secretsListCmd, nil)
+	})
+	if !strings.Contains(out, secretsTestID) {
+		t.Fatalf("expected JSON output to include secret id, got: %s", out)
+	}
+}
+
+func TestSecretsCreateCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/secrets" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": map[string]interface{}{
+				"id":          secretsTestID,
+				"name":        secretsTestName,
+				"description": "token",
+				"created_at":  time.Now().UTC().Format(time.RFC3339),
+				"updated_at":  time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = secretsTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = secretsCreateCmd.Flags().Set("name", secretsTestName)
+	_ = secretsCreateCmd.Flags().Set("value", "secret-value")
+	_ = secretsCreateCmd.Flags().Set("description", "token")
+
+	out := captureStdout(t, func() {
+		secretsCreateCmd.Run(secretsCreateCmd, nil)
+	})
+	if !strings.Contains(out, "Secret") || !strings.Contains(out, secretsTestName) {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}

--- a/cmd/cloud/snapshot_cli_test.go
+++ b/cmd/cloud/snapshot_cli_test.go
@@ -13,11 +13,12 @@ import (
 
 const (
 	snapshotTestAPIKey = "snapshot-key"
-	snapshotTestID     = "snap-1"
+	snapshotTestID     = "33333333-3333-3333-3333-333333333333"
 )
 
 func TestSnapshotListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/snapshots" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -58,6 +59,7 @@ func TestSnapshotListJSONOutput(t *testing.T) {
 func TestSnapshotCreateCmd(t *testing.T) {
 	volID := uuid.New()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/snapshots" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -95,6 +97,7 @@ func TestSnapshotCreateCmd(t *testing.T) {
 
 func TestSnapshotRestoreCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/snapshots/"+snapshotTestID+"/restore" || r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -132,6 +135,7 @@ func TestSnapshotRestoreCmd(t *testing.T) {
 
 func TestSnapshotDeleteCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/snapshots/"+snapshotTestID || r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/snapshot_cli_test.go
+++ b/cmd/cloud/snapshot_cli_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	snapshotTestAPIKey = "snapshot-key"
+	snapshotTestID     = "snap-1"
+)
+
+func TestSnapshotListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/snapshots" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := []map[string]interface{}{
+			{
+				"id":          snapshotTestID,
+				"volume_id":   uuid.New().String(),
+				"volume_name": "data",
+				"size_gb":     10,
+				"status":      "AVAILABLE",
+				"created_at":  time.Now().UTC().Format(time.RFC3339),
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = snapshotTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		snapshotListCmd.Run(snapshotListCmd, nil)
+	})
+	if !strings.Contains(out, snapshotTestID) {
+		t.Fatalf("expected JSON output to include snapshot id, got: %s", out)
+	}
+}
+
+func TestSnapshotCreateCmd(t *testing.T) {
+	volID := uuid.New()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/snapshots" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"id":          snapshotTestID,
+			"volume_id":   volID.String(),
+			"volume_name": "data",
+			"size_gb":     10,
+			"status":      "CREATING",
+			"created_at":  time.Now().UTC().Format(time.RFC3339),
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = snapshotTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = snapshotCreateCmd.Flags().Set("desc", "daily")
+
+	out := captureStdout(t, func() {
+		snapshotCreateCmd.Run(snapshotCreateCmd, []string{volID.String()})
+	})
+	if !strings.Contains(out, "Snapshot creation started") || !strings.Contains(out, snapshotTestID) {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestSnapshotRestoreCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/snapshots/"+snapshotTestID+"/restore" || r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"id":         uuid.New().String(),
+			"name":       "restore-vol",
+			"size_gb":    10,
+			"status":     "AVAILABLE",
+			"created_at": time.Now().UTC().Format(time.RFC3339),
+			"updated_at": time.Now().UTC().Format(time.RFC3339),
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = snapshotTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	_ = snapshotRestoreCmd.Flags().Set("name", "restore-vol")
+
+	out := captureStdout(t, func() {
+		snapshotRestoreCmd.Run(snapshotRestoreCmd, []string{snapshotTestID})
+	})
+	if !strings.Contains(out, "Snapshot restored") || !strings.Contains(out, "restore-vol") {
+		t.Fatalf("expected restore output, got: %s", out)
+	}
+}
+
+func TestSnapshotDeleteCmd(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/snapshots/"+snapshotTestID || r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = snapshotTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		snapshotDeleteCmd.Run(snapshotDeleteCmd, []string{snapshotTestID})
+	})
+	if !strings.Contains(out, "Snapshot") || !strings.Contains(out, snapshotTestID) {
+		t.Fatalf("expected delete output, got: %s", out)
+	}
+}

--- a/cmd/cloud/storage_cli_test.go
+++ b/cmd/cloud/storage_cli_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	storageTestAPIKey = "storage-key"
+	storageTestBucket = "images"
+)
+
+func TestStorageListBucketsJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/storage/buckets" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":                 "bucket-1",
+					"name":               storageTestBucket,
+					"is_public":          true,
+					"versioning_enabled": false,
+					"created_at":         time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = storageTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		storageListCmd.Run(storageListCmd, nil)
+	})
+	if !strings.Contains(out, storageTestBucket) {
+		t.Fatalf("expected JSON output to include bucket name, got: %s", out)
+	}
+}
+
+func TestStorageVersioningInvalidStatus(t *testing.T) {
+	out := captureStdout(t, func() {
+		storageVersioningCmd.Run(storageVersioningCmd, []string{storageTestBucket, "invalid"})
+	})
+	if !strings.Contains(out, "Invalid status") {
+		t.Fatalf("expected invalid status message, got: %s", out)
+	}
+}

--- a/cmd/cloud/storage_cli_test.go
+++ b/cmd/cloud/storage_cli_test.go
@@ -16,6 +16,7 @@ const (
 
 func TestStorageListBucketsJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/storage/buckets" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/storage_lifecycle_test.go
+++ b/cmd/cloud/storage_lifecycle_test.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+const (
+	lifecycleTestBucket    = "logs"
+	lifecycleTestContent   = "Content-Type"
+	lifecycleTestAppJSON   = "application/json"
+	lifecycleTestAPIKey    = "lifecycle-key"
+	lifecycleTestRuleID    = "rule-1"
+	lifecycleTestCreatedAt = "2024-01-01T00:00:00Z"
+)
+
+func TestLifecycleSetRejectsInvalidDays(t *testing.T) {
+	out := captureStdout(t, func() {
+		_ = lifecycleSetCmd.Flags().Set("prefix", "logs/")
+		_ = lifecycleSetCmd.Flags().Set("days", "0")
+		_ = lifecycleSetCmd.Flags().Set("enabled", "true")
+		lifecycleSetCmd.Run(lifecycleSetCmd, []string{lifecycleTestBucket})
+	})
+	if !strings.Contains(out, "--days must be at least 1") {
+		t.Fatalf("expected validation error, got: %s", out)
+	}
+}
+
+func TestLifecycleListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/storage/buckets/"+lifecycleTestBucket+"/lifecycle" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set(lifecycleTestContent, lifecycleTestAppJSON)
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":              lifecycleTestRuleID,
+					"bucket_name":     lifecycleTestBucket,
+					"prefix":          "logs/",
+					"expiration_days": 30,
+					"enabled":         true,
+					"created_at":      lifecycleTestCreatedAt,
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = lifecycleTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		lifecycleListCmd.Run(lifecycleListCmd, []string{lifecycleTestBucket})
+	})
+	if !strings.Contains(out, lifecycleTestRuleID) {
+		t.Fatalf("expected JSON output to include rule id, got: %s", out)
+	}
+}
+
+func TestLifecycleDeleteSuccess(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/storage/buckets/"+lifecycleTestBucket+"/lifecycle/"+lifecycleTestRuleID || r.Method != http.MethodDelete {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set(lifecycleTestContent, lifecycleTestAppJSON)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = lifecycleTestAPIKey
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+	}()
+
+	out := captureStdout(t, func() {
+		lifecycleDeleteCmd.Run(lifecycleDeleteCmd, []string{lifecycleTestBucket, lifecycleTestRuleID})
+	})
+	if !strings.Contains(out, "Deleted lifecycle rule") {
+		t.Fatalf("expected success output, got: %s", out)
+	}
+}

--- a/cmd/cloud/subnet_cli_test.go
+++ b/cmd/cloud/subnet_cli_test.go
@@ -17,6 +17,7 @@ const (
 func TestSubnetListJSONOutput(t *testing.T) {
 	vpcID := "vpc-1"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/vpcs/"+vpcID+"/subnets" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/subnet_cli_test.go
+++ b/cmd/cloud/subnet_cli_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	subnetTestAPIKey = "subnet-key"
+	subnetTestID     = "subnet-1"
+)
+
+func TestSubnetListJSONOutput(t *testing.T) {
+	vpcID := "vpc-1"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vpcs/"+vpcID+"/subnets" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":                subnetTestID,
+					"vpc_id":            vpcID,
+					"name":              "app",
+					"cidr_block":        "10.0.1.0/24",
+					"availability_zone": "us-east-1a",
+					"gateway_ip":        "10.0.1.1",
+					"status":            "active",
+					"created_at":        time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = subnetTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		subnetListCmd.Run(subnetListCmd, []string{vpcID})
+	})
+	if !strings.Contains(out, subnetTestID) {
+		t.Fatalf("expected JSON output to include subnet id, got: %s", out)
+	}
+}

--- a/cmd/cloud/volume_cli_test.go
+++ b/cmd/cloud/volume_cli_test.go
@@ -18,6 +18,7 @@ const (
 
 func TestVolumeListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/volumes" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/volume_cli_test.go
+++ b/cmd/cloud/volume_cli_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	volumeTestAPIKey = "volume-key"
+	volumeTestID     = "volume-1"
+)
+
+func TestVolumeListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/volumes" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":         uuid.New().String(),
+					"name":       volumeTestID,
+					"size_gb":    20,
+					"status":     "available",
+					"created_at": time.Now().UTC().Format(time.RFC3339),
+					"updated_at": time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = volumeTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		volumeListCmd.Run(volumeListCmd, nil)
+	})
+	if !strings.Contains(out, volumeTestID) {
+		t.Fatalf("expected JSON output to include volume name, got: %s", out)
+	}
+}

--- a/cmd/cloud/vpc_cli_test.go
+++ b/cmd/cloud/vpc_cli_test.go
@@ -16,6 +16,7 @@ const (
 
 func TestVPCListJSONOutput(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		if r.URL.Path != "/vpcs" || r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/vpc_cli_test.go
+++ b/cmd/cloud/vpc_cli_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	vpcTestAPIKey = "vpc-key"
+	vpcTestID     = "vpc-1"
+)
+
+func TestVPCListJSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vpcs" || r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":         vpcTestID,
+					"name":       "main",
+					"cidr_block": "10.0.0.0/16",
+					"vxlan_id":   1001,
+					"status":     "active",
+					"created_at": time.Now().UTC().Format(time.RFC3339),
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(payload)
+	}))
+	defer server.Close()
+
+	oldURL := apiURL
+	oldKey := apiKey
+	apiURL = server.URL
+	apiKey = vpcTestAPIKey
+	outputJSON = true
+	defer func() {
+		apiURL = oldURL
+		apiKey = oldKey
+		outputJSON = false
+	}()
+
+	out := captureStdout(t, func() {
+		vpcListCmd.Run(vpcListCmd, nil)
+	})
+	if !strings.Contains(out, vpcTestID) {
+		t.Fatalf("expected JSON output to include vpc id, got: %s", out)
+	}
+}

--- a/internal/handlers/ws/hub_test.go
+++ b/internal/handlers/ws/hub_test.go
@@ -1,0 +1,64 @@
+package ws
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestHubRegisterUnregister(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hub := NewHub(logger)
+	go hub.Run()
+
+	client := &Client{hub: hub, send: make(chan []byte, 1)}
+
+	hub.Register(client)
+	waitForCondition(t, func() bool { return hub.ClientCount() == 1 })
+
+	hub.Unregister(client)
+	waitForCondition(t, func() bool { return hub.ClientCount() == 0 })
+
+	select {
+	case _, ok := <-client.send:
+		if ok {
+			t.Fatal("expected client send channel to be closed")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected client send channel to be closed")
+	}
+}
+
+func TestHubBroadcast(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	hub := NewHub(logger)
+	go hub.Run()
+
+	client := &Client{hub: hub, send: make(chan []byte, 1)}
+	hub.Register(client)
+	waitForCondition(t, func() bool { return hub.ClientCount() == 1 })
+
+	payload := []byte("hello")
+	hub.broadcast <- payload
+
+	select {
+	case msg := <-client.send:
+		if string(msg) != string(payload) {
+			t.Fatalf("unexpected broadcast payload: got %s want %s", string(msg), string(payload))
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected to receive broadcast message")
+	}
+}
+
+func waitForCondition(t *testing.T, condition func() bool) {
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("condition not met before timeout")
+}

--- a/internal/platform/storage_metrics_test.go
+++ b/internal/platform/storage_metrics_test.go
@@ -1,0 +1,63 @@
+package platform
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_model/go"
+)
+
+func TestStorageMetricsRegistered(t *testing.T) {
+	StorageOperations.WithLabelValues("put", "bucket-a", "ok").Inc()
+	StorageLatency.WithLabelValues("get", "bucket-a").Observe(0.01)
+	StorageBytesTransferred.WithLabelValues("upload").Add(1)
+	StorageBucketObjects.WithLabelValues("bucket-a").Set(1)
+	StorageBucketBytes.WithLabelValues("bucket-a").Set(1)
+
+	families, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("gather metrics: %v", err)
+	}
+
+	expected := map[string][]string{
+		"storage_operations_total":           {"operation", "bucket", "status"},
+		"storage_operation_duration_seconds": {"operation", "bucket"},
+		"storage_bytes_transferred_total":    {"direction"},
+		"storage_bucket_objects_total":       {"bucket"},
+		"storage_bucket_bytes_total":         {"bucket"},
+	}
+
+	for name, labels := range expected {
+		family := findMetricFamily(families, name)
+		actualLabels := labelNames(family)
+		sortedExpected := append([]string(nil), labels...)
+		sort.Strings(sortedExpected)
+		if !reflect.DeepEqual(actualLabels, sortedExpected) {
+			t.Fatalf("metric %s labels mismatch: got %v want %v", name, actualLabels, labels)
+		}
+	}
+}
+
+func findMetricFamily(families []*io_prometheus_client.MetricFamily, name string) *io_prometheus_client.MetricFamily {
+	for _, family := range families {
+		if family.GetName() == name {
+			return family
+		}
+	}
+	return nil
+}
+
+func labelNames(family *io_prometheus_client.MetricFamily) []string {
+	if family == nil || len(family.Metric) == 0 || len(family.Metric[0].Label) == 0 {
+		return nil
+	}
+
+	labels := make([]string, 0, len(family.Metric[0].Label))
+	for _, label := range family.Metric[0].Label {
+		labels = append(labels, label.GetName())
+	}
+	sort.Strings(labels)
+	return labels
+}

--- a/internal/repositories/k8s/cni_test.go
+++ b/internal/repositories/k8s/cni_test.go
@@ -1,0 +1,83 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestInstallCNIWithServiceExecutor(t *testing.T) {
+	instSvc := new(mockInstanceService)
+	repo := new(mockClusterRepo)
+	p := newProvisioner(instSvc, repo)
+
+	clusterID := uuid.New()
+	instanceID := uuid.New()
+	masterIP := kubeMasterIP
+	cluster := &domain.Cluster{ID: clusterID}
+
+	repo.On("GetNodes", mock.Anything, clusterID).Return([]*domain.ClusterNode{{ID: uuid.New(), InstanceID: instanceID}}, nil)
+	instSvc.On("GetInstance", mock.Anything, instanceID.String()).Return(&domain.Instance{ID: instanceID, PrivateIP: masterIP}, nil)
+
+	calicoURL := fmt.Sprintf("https://raw.githubusercontent.com/projectcalico/calico/%s/manifests/calico.yaml", calicoVersion)
+	expectedCmd := []string{kubeShell, "-c", fmt.Sprintf(kubectlApply, calicoURL)}
+	instSvc.On("Exec", mock.Anything, instanceID.String(), expectedCmd).Return("ok", nil).Once()
+
+	err := p.installCNI(context.Background(), cluster, masterIP)
+	assert.NoError(t, err)
+	instSvc.AssertExpectations(t)
+	repo.AssertExpectations(t)
+}
+
+func TestPatchKubeProxyWithServiceExecutor(t *testing.T) {
+	instSvc := new(mockInstanceService)
+	repo := new(mockClusterRepo)
+	p := newProvisioner(instSvc, repo)
+
+	clusterID := uuid.New()
+	instanceID := uuid.New()
+	masterIP := kubeMasterIP
+	cluster := &domain.Cluster{ID: clusterID}
+
+	repo.On("GetNodes", mock.Anything, clusterID).Return([]*domain.ClusterNode{{ID: uuid.New(), InstanceID: instanceID}}, nil)
+	instSvc.On("GetInstance", mock.Anything, instanceID.String()).Return(&domain.Instance{ID: instanceID, PrivateIP: masterIP}, nil)
+
+	patchCmd := kubectlBase + ` -n kube-system patch configmap kube-proxy --type='json' -p='[{"op": "replace", "path": "/data/config.conf", "value": "apiVersion: kubeproxy.config.k8s.io/v1alpha1\nkind: KubeProxyConfiguration\nmode: \"\"\nconntrack:\n  maxPerCore: 0"}]'`
+	restartCmd := kubectlBase + " -n kube-system delete pod -l k8s-app=kube-proxy"
+
+	instSvc.On("Exec", mock.Anything, instanceID.String(), []string{kubeShell, "-c", patchCmd}).Return("ok", nil).Once()
+	instSvc.On("Exec", mock.Anything, instanceID.String(), []string{kubeShell, "-c", restartCmd}).Return("ok", nil).Once()
+
+	err := p.patchKubeProxy(context.Background(), cluster, masterIP)
+	assert.NoError(t, err)
+	instSvc.AssertExpectations(t)
+	repo.AssertExpectations(t)
+}
+
+func TestInstallObservabilityWithServiceExecutor(t *testing.T) {
+	instSvc := new(mockInstanceService)
+	repo := new(mockClusterRepo)
+	p := newProvisioner(instSvc, repo)
+
+	clusterID := uuid.New()
+	instanceID := uuid.New()
+	masterIP := kubeMasterIP
+	cluster := &domain.Cluster{ID: clusterID}
+
+	repo.On("GetNodes", mock.Anything, clusterID).Return([]*domain.ClusterNode{{ID: uuid.New(), InstanceID: instanceID}}, nil)
+	instSvc.On("GetInstance", mock.Anything, instanceID.String()).Return(&domain.Instance{ID: instanceID, PrivateIP: masterIP}, nil)
+
+	ksmManifest := "https://github.com/kubernetes/kube-state-metrics/releases/download/v2.10.1/standard.yaml"
+	expectedCmd := []string{kubeShell, "-c", fmt.Sprintf(kubectlApply, ksmManifest)}
+	instSvc.On("Exec", mock.Anything, instanceID.String(), expectedCmd).Return("ok", nil).Once()
+
+	err := p.installObservability(context.Background(), cluster, masterIP)
+	assert.NoError(t, err)
+	instSvc.AssertExpectations(t)
+	repo.AssertExpectations(t)
+}

--- a/internal/repositories/k8s/mock_security_group_service_test.go
+++ b/internal/repositories/k8s/mock_security_group_service_test.go
@@ -1,0 +1,60 @@
+package k8s
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockSecurityGroupService provides a mock implementation for security group operations.
+type MockSecurityGroupService struct{ mock.Mock }
+
+func (m *MockSecurityGroupService) CreateGroup(ctx context.Context, vpcID uuid.UUID, name, description string) (*domain.SecurityGroup, error) {
+	args := m.Called(ctx, vpcID, name, description)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.SecurityGroup), args.Error(1)
+}
+
+func (m *MockSecurityGroupService) GetGroup(ctx context.Context, idOrName string, vpcID uuid.UUID) (*domain.SecurityGroup, error) {
+	args := m.Called(ctx, idOrName, vpcID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.SecurityGroup), args.Error(1)
+}
+
+func (m *MockSecurityGroupService) ListGroups(ctx context.Context, vpcID uuid.UUID) ([]*domain.SecurityGroup, error) {
+	args := m.Called(ctx, vpcID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.SecurityGroup), args.Error(1)
+}
+
+func (m *MockSecurityGroupService) DeleteGroup(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+
+func (m *MockSecurityGroupService) AddRule(ctx context.Context, groupID uuid.UUID, rule domain.SecurityRule) (*domain.SecurityRule, error) {
+	args := m.Called(ctx, groupID, rule)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.SecurityRule), args.Error(1)
+}
+
+func (m *MockSecurityGroupService) RemoveRule(ctx context.Context, ruleID uuid.UUID) error {
+	return m.Called(ctx, ruleID).Error(0)
+}
+
+func (m *MockSecurityGroupService) AttachToInstance(ctx context.Context, instanceID, groupID uuid.UUID) error {
+	return m.Called(ctx, instanceID, groupID).Error(0)
+}
+
+func (m *MockSecurityGroupService) DetachFromInstance(ctx context.Context, instanceID, groupID uuid.UUID) error {
+	return m.Called(ctx, instanceID, groupID).Error(0)
+}

--- a/internal/repositories/k8s/security_test.go
+++ b/internal/repositories/k8s/security_test.go
@@ -1,0 +1,95 @@
+package k8s
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEnsureClusterSecurityGroupExists(t *testing.T) {
+	sgSvc := new(MockSecurityGroupService)
+	cluster := &domain.Cluster{Name: "dev", VpcID: uuid.New()}
+	group := &domain.SecurityGroup{ID: uuid.New()}
+
+	sgSvc.On("GetGroup", mock.Anything, "sg-"+cluster.Name, cluster.VpcID).Return(group, nil).Once()
+
+	p := &KubeadmProvisioner{sgSvc: sgSvc}
+	err := p.ensureClusterSecurityGroup(context.Background(), cluster)
+	assert.NoError(t, err)
+
+	sgSvc.AssertNotCalled(t, "CreateGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestEnsureClusterSecurityGroupCreatesRules(t *testing.T) {
+	sgSvc := new(MockSecurityGroupService)
+	cluster := &domain.Cluster{Name: "prod", VpcID: uuid.New()}
+	group := &domain.SecurityGroup{ID: uuid.New()}
+
+	sgSvc.On("GetGroup", mock.Anything, "sg-"+cluster.Name, cluster.VpcID).Return(nil, errors.New("not found")).Once()
+	sgSvc.On("CreateGroup", mock.Anything, cluster.VpcID, "sg-"+cluster.Name, "Kubernetes cluster security group").Return(group, nil).Once()
+	sgSvc.On("AddRule", mock.Anything, group.ID, mock.Anything).Return(&domain.SecurityRule{}, nil).Times(6)
+
+	p := &KubeadmProvisioner{sgSvc: sgSvc}
+	err := p.ensureClusterSecurityGroup(context.Background(), cluster)
+	assert.NoError(t, err)
+
+	sgSvc.AssertExpectations(t)
+}
+
+func TestApplyBaseSecurityNoIsolation(t *testing.T) {
+	instSvc := new(mockInstanceService)
+	repo := new(mockClusterRepo)
+	p := newProvisioner(instSvc, repo)
+
+	clusterID := uuid.New()
+	instanceID := uuid.New()
+	cluster := &domain.Cluster{ID: clusterID, NetworkIsolation: false}
+
+	repo.On("GetNodes", mock.Anything, clusterID).Return([]*domain.ClusterNode{{ID: uuid.New(), InstanceID: instanceID}}, nil)
+	instSvc.On("GetInstance", mock.Anything, instanceID.String()).Return(&domain.Instance{ID: instanceID, PrivateIP: kubeMasterIP}, nil)
+
+	err := p.applyBaseSecurity(context.Background(), cluster, kubeMasterIP)
+	assert.NoError(t, err)
+
+	instSvc.AssertNotCalled(t, "Exec", mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestApplyBaseSecurityWithIsolation(t *testing.T) {
+	instSvc := new(mockInstanceService)
+	repo := new(mockClusterRepo)
+	p := newProvisioner(instSvc, repo)
+
+	clusterID := uuid.New()
+	instanceID := uuid.New()
+	cluster := &domain.Cluster{ID: clusterID, NetworkIsolation: true}
+
+	repo.On("GetNodes", mock.Anything, clusterID).Return([]*domain.ClusterNode{{ID: uuid.New(), InstanceID: instanceID}}, nil)
+	instSvc.On("GetInstance", mock.Anything, instanceID.String()).Return(&domain.Instance{ID: instanceID, PrivateIP: kubeMasterIP}, nil)
+
+	instSvc.On("Exec", mock.Anything, instanceID.String(), mock.MatchedBy(func(cmd []string) bool {
+		return isShellCommand(cmd, "cat <<EOF > /tmp/base-security.yaml")
+	})).Return("ok", nil).Once()
+	instSvc.On("Exec", mock.Anything, instanceID.String(), mock.MatchedBy(func(cmd []string) bool {
+		return isShellCommand(cmd, kubectlBase+" apply -f /tmp/base-security.yaml")
+	})).Return("ok", nil).Once()
+
+	err := p.applyBaseSecurity(context.Background(), cluster, kubeMasterIP)
+	assert.NoError(t, err)
+	instSvc.AssertExpectations(t)
+}
+
+func isShellCommand(cmd []string, contains string) bool {
+	if len(cmd) != 3 {
+		return false
+	}
+	if cmd[0] != kubeShell || cmd[1] != "-c" {
+		return false
+	}
+	return strings.Contains(cmd[2], contains)
+}


### PR DESCRIPTION
## Summary
- add CLI tests across cloud commands (events, functions, gateway, load balancer, IaC, VPC, subnet, volume)
- add storage metrics tests
- add k8s provisioner tests for CNI/security flows
- add websocket hub tests

## Testing
- runTests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across cloud services (autoscaling, containers, cron, databases, events, functions, gateways, k8s, load balancers, notifications, queues, RBAC, secrets, snapshots, storage, subnets, volumes, VPCs).
  * Added WebSocket hub and Prometheus storage-metrics tests.
  * Added security provisioning and container networking tests with service mocks.
  * Augmented CLI end-to-end validation using mocked API endpoints to verify create/list/delete/scale/policy/workflows and output formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->