### PR TITLE
feat: implement instance types and resource limits

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: 2
 run:
   timeout: 5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
-version: 2
 run:
   timeout: 5m
 

--- a/cmd/cloud/instance.go
+++ b/cmd/cloud/instance.go
@@ -94,6 +94,7 @@ var launchCmd = &cobra.Command{
 		name, _ := cmd.Flags().GetString("name")
 		image, _ := cmd.Flags().GetString("image")
 		ports, _ := cmd.Flags().GetString("port")
+		instanceType, _ := cmd.Flags().GetString("type")
 		vpc, _ := cmd.Flags().GetString("vpc")
 		subnetID, _ := cmd.Flags().GetString("subnet")
 		volumeStrs, _ := cmd.Flags().GetStringSlice("volume")
@@ -111,7 +112,7 @@ var launchCmd = &cobra.Command{
 		}
 
 		client := getClient()
-		inst, err := client.LaunchInstance(name, image, ports, vpc, subnetID, volumes)
+		inst, err := client.LaunchInstance(name, image, ports, instanceType, vpc, subnetID, volumes)
 		if err != nil {
 			fmt.Printf(fmtErrorLog, err)
 			return
@@ -239,6 +240,7 @@ func init() {
 	launchCmd.Flags().StringP("name", "n", "", "Name of the instance (required)")
 	launchCmd.Flags().StringP("image", "i", "alpine", "Image to use")
 	launchCmd.Flags().StringP("port", "p", "", "Port mapping (host:container)")
+	launchCmd.Flags().StringP("type", "t", "basic-2", "Instance type (e.g. basic-1, standard-1)")
 	launchCmd.Flags().StringP("vpc", "v", "", "VPC ID or Name to attach to")
 	launchCmd.Flags().StringP("subnet", "s", "", "Subnet ID or Name to attach to")
 	launchCmd.Flags().StringSliceP("volume", "V", nil, "Volume attachment (vol-name:/path)")

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -178,11 +178,39 @@ This document provides a comprehensive overview of every feature currently imple
 - **Event & Audit Logging**: CREATE, ACCESS, DELETE events tracked.
 - **Production Safety**: Enforces encryption key requirement in production mode.
 
+### 12. Managed DNS (Route Cloud) 🆕
+**What it is**: Managed DNS zones and records with automatic instance registration.
+**Tech Stack**: PowerDNS, Go.
+**Implementation**:
+- **Zone Management**: Create and manage private DNS zones for VPCs.
+- **Auto-Registration**: Instances automatically register their private IP addresses in the VPC's DNS zone upon launch.
+- **Record Types**: Supports A, AAAA, CNAME, MX, and TXT records.
+- **PowerDNS Integration**: Powered by a PowerDNS backend for production-grade reliability.
+- **VPC Scoped**: Zones are scoped to VPCs for private network resolution.
+
+### 13. API Gateway 🆕
+**What it is**: Managed entry point for microservices with routing and rate limiting.
+**Tech Stack**: Go `httputil.ReverseProxy`, Redis.
+**Implementation**:
+- **Dynamic Routing**: Route external traffic to internal services based on path prefixes.
+- **Prefix Stripping**: Support for stripping path prefixes before forwarding.
+- **Rate Limiting**: Integrated rate limiting per route.
+- **Audit Logging**: Logs all route changes and gateway operations.
+
+### 14. CloudStacks (Native IaC) 🆕
+**What it is**: Declarative infrastructure management (similar to AWS CloudFormation).
+**Tech Stack**: YAML, Go, Hexagonal Orchestration.
+**Implementation**:
+- **Declarative Templates**: Define multiple resources (VPCs, Instances, Volumes) in a single YAML file.
+- **Dependency Management**: Automatically resolves references between resources (e.g., attaching a volume to an instance created in the same stack).
+- **Atomic Operations**: Support for rollback on failure during stack creation.
+- **Validation**: API endpoint for validating templates before deployment.
+
 ---
 
 ## 🧩 Platform Services
 
-### 12. Identity & Auth (IAM)
+### 15. Identity & Auth (IAM)
 **What it is**: Secure access to the platform.
 **Tech Stack**: JWT (JSON Web Tokens), BCrypt, RBAC.
 **Implementation**:
@@ -199,7 +227,7 @@ This document provides a comprehensive overview of every feature currently imple
 - **Authorization**: `Authorize()` checks user permissions before operations.
 - **Fallback Logic**: Default permissions apply if role not in DB.
 
-### 13. Observability
+### 16. Observability
 **What it is**: Monitor system health and logs.
 **Tech Stack**: Docker API, WebSockets, Prometheus, Grafana.
 **Implementation**:
@@ -211,19 +239,27 @@ This document provides a comprehensive overview of every feature currently imple
 - **Event System**: Event recording for all resource state changes.
 - **Audit Logs**: Comprehensive audit trail for compliance.
 
-### 13. CLI (Command Line Interface)
+### 17. CLI (Command Line Interface)
 **What it is**: Terminal tool to manage "The Cloud".
 **Tech Stack**: Cobra (CLI framework), Viper (Config).
 **Implementation**:
 - **Structure**: Command-based (`cloud <resource> <action>`).
 - **State**: Stateless client; talks to the Backend API via HTTP.
 
-### 14. Console (Frontend)
+### 18. Console (Frontend)
 **What it is**: Visual dashboard.
 **Tech Stack**: Next.js 14, Tailwind CSS, TypeScript.
 **Implementation**:
 - **SSR**: Server-Side Rendering for main dashboard views.
 - **Architecture**: Component-based modern React.
+
+### 19. Terraform Provider 🆕
+**What it is**: Infrastructure as Code (IaC) support via Terraform.
+**Tech Stack**: Terraform Plugin SDK v2, Go.
+**Implementation**:
+- **Custom Provider**: `terraform-provider-thecloud` allows defining resources in HCL.
+- **Supported Resources**: Lifecycle management for Instances, VPCs, DNS Zones, and Volumes.
+- **State Management**: Integrates with Terraform's state for consistent infrastructure management.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -163,6 +163,7 @@ Launch a new instance.
 {
   "name": "web-01",
   "image": "nginx",
+  "instance_type": "basic-2",
   "vpc_id": "vpc-uuid",
   "subnet_id": "subnet-uuid",
   "ports": "80:80",
@@ -170,6 +171,21 @@ Launch a new instance.
     { "volume_id": "vol-uuid", "mount_path": "/data" }
   ]
 }
+```
+
+### GET /instance-types
+List all available instance types.
+**Response:**
+```json
+[
+  {
+    "id": "basic-2",
+    "name": "Basic 2",
+    "vcpus": 1,
+    "memory_mb": 1024,
+    "disk_gb": 10
+  }
+]
 ```
 
 ### GET /instances/:id

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -183,7 +183,10 @@ List all available instance types.
     "name": "Basic 2",
     "vcpus": 1,
     "memory_mb": 1024,
-    "disk_gb": 10
+    "disk_gb": 10,
+    "network_mbps": 1000,
+    "price_per_hour": 0.02,
+    "category": "general-purpose"
   }
 ]
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,10 +78,11 @@ graph TB
 type Instance struct {
     ID        uuid.UUID
     UserID    uuid.UUID
-    Name      string
-    Image     string
-    Status    InstanceStatus
-    CreatedAt time.Time
+    Name         string
+    Image        string
+    InstanceType string
+    Status       InstanceStatus
+    CreatedAt    time.Time
 }
 
 type InstanceStatus string
@@ -93,7 +94,7 @@ const (
 ```
 
 **Key Entities**:
-- `Instance`, `Volume`, `VPC`, `LoadBalancer`
+- `Instance`, `InstanceType`, `Volume`, `VPC`, `LoadBalancer`
 - `Function`, `Queue`, `Topic`, `CronJob`
 - `User`, `Role`, `APIKey`, `Secret`
 - `ScalingGroup`, `ScalingPolicy`
@@ -105,7 +106,7 @@ const (
 **Primary Ports** (inbound - what the application offers):
 ```go
 type InstanceService interface {
-    Launch(ctx context.Context, req LaunchRequest) (*domain.Instance, error)
+    LaunchInstance(ctx context.Context, name, image, ports, instanceType string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error)
     List(ctx context.Context) ([]*domain.Instance, error)
     Stop(ctx context.Context, id uuid.UUID) error
     Terminate(ctx context.Context, id uuid.UUID) error

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -115,6 +115,7 @@ cloud instance launch --name my-server --image nginx:alpine
 |------|-------|----------|---------|-------------|
 | `--name` | `-n` | Yes | - | Instance name |
 | `--image` | `-i` | No | `alpine` | Docker image or VM template |
+| `--type` | `-t` | No | `basic-2` | Instance type (e.g., basic-1, standard-1) |
 | `--port` | `-p` | No | - | Port mapping (host:container) |
 | `--vpc` | `-v` | No | - | VPC ID or name |
 | `--subnet` | `-s` | No | - | Subnet ID or name |
@@ -125,10 +126,10 @@ cloud instance launch --name my-server --image nginx:alpine
 **Examples**:
 ```bash
 # Basic instance
-cloud instance launch --name web --image nginx:alpine
+cloud instance launch --name web --image nginx:alpine --type basic-2
 
 # With port mapping
-cloud instance launch --name api --image node:20 --port 3000:3000
+cloud instance launch --name api --image node:20 --port 3000:3000 --type standard-1
 
 # With VPC, Subnet and volume
 cloud instance launch --name db --image postgres:16 \

--- a/docs/database.md
+++ b/docs/database.md
@@ -127,6 +127,7 @@ CREATE TABLE instances (
     container_id VARCHAR(255),
     ports TEXT,
     vpc_id UUID REFERENCES vpcs(id) ON DELETE SET NULL,
+    instance_type TEXT NOT NULL DEFAULT 'basic-2',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     version INT NOT NULL DEFAULT 1
@@ -134,6 +135,23 @@ CREATE TABLE instances (
 
 CREATE INDEX idx_instances_user_id ON instances(user_id);
 CREATE INDEX idx_instances_status ON instances(status);
+
+#### `instance_types` - Predefined Instance Specs
+```sql
+CREATE TABLE instance_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    vcpus INT NOT NULL,
+    memory_mb INT NOT NULL,
+    disk_gb INT NOT NULL,
+    network_mbps INT NOT NULL DEFAULT 1000,
+    price_per_hour NUMERIC(10,4) NOT NULL DEFAULT 0.01,
+    category TEXT NOT NULL DEFAULT 'general',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+**Seeded Types**: `basic-1`, `basic-2`, `standard-1`, `performance-2`, etc.
 ```
 
 **Optimistic Locking**: `version` column prevents concurrent update conflicts

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -59,9 +59,9 @@ Located in `internal/core/ports/instance.go`.
 ### Service Interface (Business Logic)
 ```go
 type InstanceService interface {
-    LaunchInstance(ctx context.Context, name, image string, ...) (*domain.Instance, error)
-    StopInstance(ctx context.Context, id uuid.UUID) error
-    GetConsoleURL(ctx context.Context, id uuid.UUID) (string, error)
+    LaunchInstance(ctx context.Context, name, image, ports, instanceType string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error)
+    StopInstance(ctx context.Context, idOrName string) error
+    GetConsoleURL(ctx context.Context, idOrName string) (string, error)
 }
 ```
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1906,6 +1906,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/instance-types": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Gets a list of all available instance types with their resource limits and pricing",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instances"
+                ],
+                "summary": "List instance types",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.InstanceType"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/instances": {
             "get": {
                 "security": [
@@ -5034,6 +5068,42 @@ const docTemplate = `{
                 "StatusError",
                 "StatusDeleted"
             ]
+        },
+        "domain.InstanceType": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "description": "basic, standard, performance, gpu",
+                    "type": "string"
+                },
+                "disk_gb": {
+                    "description": "Root disk size",
+                    "type": "integer"
+                },
+                "id": {
+                    "description": "e.g., \"basic-1\"",
+                    "type": "string"
+                },
+                "memory_mb": {
+                    "description": "Memory in MB",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "Human-friendly name",
+                    "type": "string"
+                },
+                "network_mbps": {
+                    "description": "Network bandwidth",
+                    "type": "integer"
+                },
+                "price_per_hour": {
+                    "type": "number"
+                },
+                "vcpus": {
+                    "description": "Number of virtual CPUs",
+                    "type": "integer"
+                }
+            }
         },
         "domain.LBStatus": {
             "type": "string",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -4956,6 +4956,9 @@ const docTemplate = `{
                     "description": "Container/VM image",
                     "type": "string"
                 },
+                "instance_type": {
+                    "type": "string"
+                },
                 "name": {
                     "description": "Unique per tenant",
                     "type": "string"
@@ -5497,6 +5500,10 @@ const docTemplate = `{
                 },
                 "image": {
                     "description": "Instance image (e.g. \"nginx\")",
+                    "type": "string"
+                },
+                "instance_type": {
+                    "description": "NEW: Configuration type",
                     "type": "string"
                 },
                 "last_failure_at": {
@@ -6348,6 +6355,9 @@ const docTemplate = `{
             ],
             "properties": {
                 "image": {
+                    "type": "string"
+                },
+                "instance_type": {
                     "type": "string"
                 },
                 "name": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -4945,6 +4945,9 @@
                     "description": "Container/VM image",
                     "type": "string"
                 },
+                "instance_type": {
+                    "type": "string"
+                },
                 "name": {
                     "description": "Unique per tenant",
                     "type": "string"
@@ -5486,6 +5489,10 @@
                 },
                 "image": {
                     "description": "Instance image (e.g. \"nginx\")",
+                    "type": "string"
+                },
+                "instance_type": {
+                    "description": "NEW: Configuration type",
                     "type": "string"
                 },
                 "last_failure_at": {
@@ -6337,6 +6344,9 @@
             ],
             "properties": {
                 "image": {
+                    "type": "string"
+                },
+                "instance_type": {
                     "type": "string"
                 },
                 "name": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1895,6 +1895,40 @@
                 }
             }
         },
+        "/instance-types": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Gets a list of all available instance types with their resource limits and pricing",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instances"
+                ],
+                "summary": "List instance types",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.InstanceType"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/instances": {
             "get": {
                 "security": [
@@ -5023,6 +5057,42 @@
                 "StatusError",
                 "StatusDeleted"
             ]
+        },
+        "domain.InstanceType": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "description": "basic, standard, performance, gpu",
+                    "type": "string"
+                },
+                "disk_gb": {
+                    "description": "Root disk size",
+                    "type": "integer"
+                },
+                "id": {
+                    "description": "e.g., \"basic-1\"",
+                    "type": "string"
+                },
+                "memory_mb": {
+                    "description": "Memory in MB",
+                    "type": "integer"
+                },
+                "name": {
+                    "description": "Human-friendly name",
+                    "type": "string"
+                },
+                "network_mbps": {
+                    "description": "Network bandwidth",
+                    "type": "integer"
+                },
+                "price_per_hour": {
+                    "type": "number"
+                },
+                "vcpus": {
+                    "description": "Number of virtual CPUs",
+                    "type": "integer"
+                }
+            }
         },
         "domain.LBStatus": {
             "type": "string",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -301,6 +301,8 @@ definitions:
       image:
         description: Container/VM image
         type: string
+      instance_type:
+        type: string
       name:
         description: Unique per tenant
         type: string
@@ -721,6 +723,9 @@ definitions:
         type: string
       image:
         description: Instance image (e.g. "nginx")
+        type: string
+      instance_type:
+        description: 'NEW: Configuration type'
         type: string
       last_failure_at:
         type: string
@@ -1306,6 +1311,8 @@ definitions:
   httphandlers.LaunchRequest:
     properties:
       image:
+        type: string
+      instance_type:
         type: string
       name:
         type: string

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -358,6 +358,32 @@ definitions:
     - StatusStopped
     - StatusError
     - StatusDeleted
+  domain.InstanceType:
+    properties:
+      category:
+        description: basic, standard, performance, gpu
+        type: string
+      disk_gb:
+        description: Root disk size
+        type: integer
+      id:
+        description: e.g., "basic-1"
+        type: string
+      memory_mb:
+        description: Memory in MB
+        type: integer
+      name:
+        description: Human-friendly name
+        type: string
+      network_mbps:
+        description: Network bandwidth
+        type: integer
+      price_per_hour:
+        type: number
+      vcpus:
+        description: Number of virtual CPUs
+        type: integer
+    type: object
   domain.LBStatus:
     enum:
     - CREATING
@@ -2678,6 +2704,28 @@ paths:
       summary: Validate template
       tags:
       - IaC
+  /instance-types:
+    get:
+      description: Gets a list of all available instance types with their resource
+        limits and pricing
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.InstanceType'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: List instance types
+      tags:
+      - instances
   /instances:
     get:
       description: Gets a list of all compute instances

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -149,6 +149,7 @@ Making it enterprise-ready:
 - LVM block storage backend
 - RBAC and security
 - Prometheus/Grafana monitoring
+- Instance Types support (basic, standard, performance)
 
 ### Phase 9-10: High Availability (In Progress Q1-Q2 2026)
 Adding enterprise capabilities:

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -61,6 +61,7 @@ type Handlers struct {
 	Cluster       *httphandlers.ClusterHandler
 	Lifecycle     *httphandlers.LifecycleHandler
 	DNS           *httphandlers.DNSHandler
+	InstanceType  *httphandlers.InstanceTypeHandler
 	Ws            *ws.Handler
 }
 
@@ -102,6 +103,7 @@ func InitHandlers(svcs *Services, cfg *platform.Config, logger *slog.Logger) *Ha
 		Cluster:       httphandlers.NewClusterHandler(svcs.Cluster),
 		Lifecycle:     httphandlers.NewLifecycleHandler(svcs.Lifecycle),
 		DNS:           httphandlers.NewDNSHandler(svcs.DNS),
+		InstanceType:  httphandlers.NewInstanceTypeHandler(svcs.InstanceType),
 		Ws:            ws.NewHandler(hub, svcs.Identity, logger),
 	}
 }
@@ -230,6 +232,12 @@ func registerComputeRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		instanceGroup.GET("/:id/stats", httputil.Permission(svcs.RBAC, domain.PermissionInstanceRead), handlers.Instance.GetStats)
 		instanceGroup.GET("/:id/console", httputil.Permission(svcs.RBAC, domain.PermissionInstanceRead), handlers.Instance.GetConsole)
 		instanceGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionInstanceTerminate), handlers.Instance.Terminate)
+	}
+
+	typeGroup := r.Group("/instance-types")
+	typeGroup.Use(httputil.Auth(svcs.Identity, svcs.Tenant))
+	{
+		typeGroup.GET("", handlers.InstanceType.List)
 	}
 
 	snapshotGroup := r.Group("/snapshots")

--- a/internal/core/domain/autoscaling.go
+++ b/internal/core/domain/autoscaling.go
@@ -39,6 +39,7 @@ type ScalingGroup struct {
 	VpcID          uuid.UUID          `json:"vpc_id"`
 	LoadBalancerID *uuid.UUID         `json:"load_balancer_id,omitempty"` // Optional LB integration
 	Image          string             `json:"image"`                      // Instance image (e.g. "nginx")
+	InstanceType   string             `json:"instance_type"`              // NEW: Configuration type
 	Ports          string             `json:"ports,omitempty"`            // Ports exposed by instances
 	MinInstances   int                `json:"min_instances"`              // Floor for scaling
 	MaxInstances   int                `json:"max_instances"`              // Ceiling for scaling

--- a/internal/core/domain/container.go
+++ b/internal/core/domain/container.go
@@ -27,6 +27,7 @@ type Deployment struct {
 	UserID       uuid.UUID        `json:"user_id"`
 	Name         string           `json:"name"`          // Unique name for the deployment
 	Image        string           `json:"image"`         // Container image (e.g., "redis:alpine")
+	InstanceType string           `json:"instance_type"` // NEW: Configuration type
 	Replicas     int              `json:"replicas"`      // Desired number of replicas
 	CurrentCount int              `json:"current_count"` // Actual number of running replicas
 	Ports        string           `json:"ports"`         // Exposed ports (e.g., "80:8080")

--- a/internal/core/domain/instance.go
+++ b/internal/core/domain/instance.go
@@ -58,21 +58,22 @@ const (
 //
 // Port format: "hostPort:containerPort" (e.g., "8080:80,443:443")
 type Instance struct {
-	ID          uuid.UUID      `json:"id"`
-	UserID      uuid.UUID      `json:"user_id"` // Owner
-	TenantID    uuid.UUID      `json:"tenant_id"`
-	Name        string         `json:"name"`                   // Unique per tenant
-	Image       string         `json:"image"`                  // Container/VM image
-	ContainerID string         `json:"container_id,omitempty"` // Backend identifier
-	Status      InstanceStatus `json:"status"`
-	Ports       string         `json:"ports,omitempty"`  // "host:container" mappings
-	VpcID       *uuid.UUID     `json:"vpc_id,omitempty"` // Optional VPC attachment
-	SubnetID    *uuid.UUID     `json:"subnet_id,omitempty"`
-	PrivateIP   string         `json:"private_ip,omitempty"` // VPC private IP
-	OvsPort     string         `json:"ovs_port,omitempty"`   // OVS port name
-	Version     int            `json:"version"`              // Optimistic locking
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
+	ID           uuid.UUID      `json:"id"`
+	UserID       uuid.UUID      `json:"user_id"` // Owner
+	TenantID     uuid.UUID      `json:"tenant_id"`
+	Name         string         `json:"name"`                   // Unique per tenant
+	Image        string         `json:"image"`                  // Container/VM image
+	ContainerID  string         `json:"container_id,omitempty"` // Backend identifier
+	Status       InstanceStatus `json:"status"`
+	Ports        string         `json:"ports,omitempty"`  // "host:container" mappings
+	VpcID        *uuid.UUID     `json:"vpc_id,omitempty"` // Optional VPC attachment
+	SubnetID     *uuid.UUID     `json:"subnet_id,omitempty"`
+	PrivateIP    string         `json:"private_ip,omitempty"` // VPC private IP
+	OvsPort      string         `json:"ovs_port,omitempty"`   // OVS port name
+	InstanceType string         `json:"instance_type,omitempty"`
+	Version      int            `json:"version"` // Optimistic locking
+	CreatedAt    time.Time      `json:"created_at"`
+	UpdatedAt    time.Time      `json:"updated_at"`
 }
 
 // InstanceStats contains real-time resource usage metrics.

--- a/internal/core/domain/instance_type.go
+++ b/internal/core/domain/instance_type.go
@@ -1,0 +1,13 @@
+package domain
+
+// InstanceType represents a pre-defined resource configuration
+type InstanceType struct {
+	ID          string  `json:"id"`           // e.g., "basic-1"
+	Name        string  `json:"name"`         // Human-friendly name
+	VCPUs       int     `json:"vcpus"`        // Number of virtual CPUs
+	MemoryMB    int     `json:"memory_mb"`    // Memory in MB
+	DiskGB      int     `json:"disk_gb"`      // Root disk size
+	NetworkMbps int     `json:"network_mbps"` // Network bandwidth
+	PricePerHr  float64 `json:"price_per_hour"`
+	Category    string  `json:"category"` // basic, standard, performance, gpu
+}

--- a/internal/core/ports/compute_options.go
+++ b/internal/core/ports/compute_options.go
@@ -10,4 +10,7 @@ type CreateInstanceOptions struct {
 	VolumeBinds []string // Storage mappings (e.g., ["/host/path:/container/path"])
 	Env         []string // Environment variables (e.g., ["KEY=VALUE"])
 	Cmd         []string // Optional override command for the instance entrypoint
+	CPULimit    int64    // CPU cores (or millicores)
+	MemoryLimit int64    // Memory in bytes
+	DiskLimit   int64    // Disk in bytes
 }

--- a/internal/core/ports/instance.go
+++ b/internal/core/ports/instance.go
@@ -31,7 +31,7 @@ type InstanceRepository interface {
 // InstanceService defines the business logic for managing the lifecycle of compute instances.
 type InstanceService interface {
 	// LaunchInstance provisions and starts a new compute resource with requested networking and storage.
-	LaunchInstance(ctx context.Context, name, image, ports string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error)
+	LaunchInstance(ctx context.Context, name, image, ports, instanceType string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error)
 	// StopInstance gracefully shuts down or halts a running compute resource.
 	StopInstance(ctx context.Context, idOrName string) error
 	// ListInstances returns a slice of all compute resources accessible to the caller.

--- a/internal/core/ports/instance_type.go
+++ b/internal/core/ports/instance_type.go
@@ -1,0 +1,15 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/poyrazk/thecloud/internal/core/domain"
+)
+
+// InstanceTypeRepository handles the persistence and retrieval of instance types.
+type InstanceTypeRepository interface {
+	// List returns all available instance types.
+	List(ctx context.Context) ([]*domain.InstanceType, error)
+	// GetByID retrieves a specific instance type by its unique identifier.
+	GetByID(ctx context.Context, id string) (*domain.InstanceType, error)
+}

--- a/internal/core/ports/instance_type.go
+++ b/internal/core/ports/instance_type.go
@@ -13,3 +13,9 @@ type InstanceTypeRepository interface {
 	// GetByID retrieves a specific instance type by its unique identifier.
 	GetByID(ctx context.Context, id string) (*domain.InstanceType, error)
 }
+
+// InstanceTypeService defines the business logic for instance types.
+type InstanceTypeService interface {
+	// List returns all available instance types.
+	List(ctx context.Context) ([]*domain.InstanceType, error)
+}

--- a/internal/core/ports/instance_type.go
+++ b/internal/core/ports/instance_type.go
@@ -12,6 +12,12 @@ type InstanceTypeRepository interface {
 	List(ctx context.Context) ([]*domain.InstanceType, error)
 	// GetByID retrieves a specific instance type by its unique identifier.
 	GetByID(ctx context.Context, id string) (*domain.InstanceType, error)
+	// Create persists a new instance type.
+	Create(ctx context.Context, it *domain.InstanceType) (*domain.InstanceType, error)
+	// Update modifies an existing instance type.
+	Update(ctx context.Context, it *domain.InstanceType) (*domain.InstanceType, error)
+	// Delete removes an instance type by its ID.
+	Delete(ctx context.Context, id string) error
 }
 
 // InstanceTypeService defines the business logic for instance types.

--- a/internal/core/services/autoscaling_worker.go
+++ b/internal/core/services/autoscaling_worker.go
@@ -283,7 +283,7 @@ func (w *AutoScalingWorker) scaleOut(ctx context.Context, group *domain.ScalingG
 	// Use dynamic ports to avoid conflicts on the same host
 	dynamicPorts := toDynamicPorts(group.Ports)
 
-	inst, err := w.instanceSvc.LaunchInstance(ctx, name, group.Image, dynamicPorts, &group.VpcID, nil, nil)
+	inst, err := w.instanceSvc.LaunchInstance(ctx, name, group.Image, dynamicPorts, group.InstanceType, &group.VpcID, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/core/services/autoscaling_worker_test.go
+++ b/internal/core/services/autoscaling_worker_test.go
@@ -64,7 +64,7 @@ func TestAutoScalingWorkerEvaluateScaleOut(t *testing.T) {
 	mockRepo.On("GetAllPolicies", ctx, mock.Anything).Return(map[uuid.UUID][]*domain.ScalingPolicy{groupID: {}}, nil)
 
 	newInst := &domain.Instance{ID: uuid.New()}
-	mockInstSvc.On("LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(newInst, nil)
+	mockInstSvc.On("LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(newInst, nil)
 	mockRepo.On("AddInstanceToGroup", mock.Anything, groupID, newInst.ID).Return(nil)
 	mockEventSvc.On("RecordEvent", mock.Anything, "AUTOSCALING_SCALE_OUT", groupID.String(), "SCALING_GROUP", mock.Anything).Return(nil)
 
@@ -280,7 +280,7 @@ func TestAutoScalingWorkerRecordFailure(t *testing.T) {
 	mockRepo.On("GetAllPolicies", ctx, []uuid.UUID{groupID}).Return(map[uuid.UUID][]*domain.ScalingPolicy{}, nil)
 
 	// Simulate a failure during scale out - use context matcher to handle UserID context
-	mockInstSvc.On("LaunchInstance", mock.Anything, mock.Anything, "nginx", "0:80", mock.Anything, mock.Anything, mock.Anything).Return(nil, assert.AnError)
+	mockInstSvc.On("LaunchInstance", mock.Anything, mock.Anything, "nginx", "0:80", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, assert.AnError)
 
 	// Should record failure - use Any() matcher for context
 	mockRepo.On("UpdateGroup", mock.Anything, mock.Anything).Return(nil)
@@ -320,7 +320,7 @@ func TestAutoScalingWorkerFailureBackoffSkipsScaleOut(t *testing.T) {
 
 	worker.Evaluate(ctx)
 
-	mockInstSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockInstSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestAutoScalingWorkerAdjustDesiredBounds(t *testing.T) {
@@ -392,7 +392,7 @@ func TestAutoScalingWorkerResetFailures(t *testing.T) {
 
 	// Successful scale out should reset failures
 	newInstance := &domain.Instance{ID: uuid.New(), UserID: userID}
-	mockInstSvc.On("LaunchInstance", mock.Anything, mock.Anything, "nginx", "0:80", mock.Anything, mock.Anything, mock.Anything).Return(newInstance, nil)
+	mockInstSvc.On("LaunchInstance", mock.Anything, mock.Anything, "nginx", "0:80", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(newInstance, nil)
 	mockRepo.On("AddInstanceToGroup", mock.Anything, groupID, newInstance.ID).Return(nil)
 	mockEventSvc.On("RecordEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 

--- a/internal/core/services/benchmarks_test.go
+++ b/internal/core/services/benchmarks_test.go
@@ -98,7 +98,7 @@ func BenchmarkInstanceServiceCreate(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = svc.LaunchInstance(ctx, "test", "alpine", "80:80", nil, &subnetID, nil)
+		_, _ = svc.LaunchInstance(ctx, "test", "alpine", "80:80", "basic-2", nil, &subnetID, nil)
 	}
 }
 
@@ -152,7 +152,7 @@ func BenchmarkInstanceServiceCreateParallel(b *testing.B) {
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
-			_, _ = svc.LaunchInstance(ctx, "test-inst", "alpine", "80:80", nil, nil, nil)
+			_, _ = svc.LaunchInstance(ctx, "test-inst", "alpine", "80:80", "basic-2", nil, nil, nil)
 		}
 	})
 }

--- a/internal/core/services/container_worker.go
+++ b/internal/core/services/container_worker.go
@@ -139,7 +139,7 @@ func (w *ContainerWorker) launchContainer(ctx context.Context, dep *domain.Deplo
 
 	// Deployments usually run in a default VPC or we could add VPC support to deployments
 	// For now using nil VPC (default network)
-	inst, err := w.instanceSvc.LaunchInstance(ctx, name, dep.Image, dep.Ports, nil, nil, nil)
+	inst, err := w.instanceSvc.LaunchInstance(ctx, name, dep.Image, dep.Ports, dep.InstanceType, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/core/services/container_worker_test.go
+++ b/internal/core/services/container_worker_test.go
@@ -39,8 +39,8 @@ func TestContainerWorkerReconcile(t *testing.T) {
 		// LaunchInstance called twice
 		inst1 := &domain.Instance{ID: uuid.New(), Name: "dep-inst-1"}
 		inst2 := &domain.Instance{ID: uuid.New(), Name: "dep-inst-2"}
-		instSvc.On("LaunchInstance", mock.Anything, mock.Anything, "nginx", "", (*uuid.UUID)(nil), (*uuid.UUID)(nil), []domain.VolumeAttachment(nil)).Return(inst1, nil).Once()
-		instSvc.On("LaunchInstance", mock.Anything, mock.Anything, "nginx", "", (*uuid.UUID)(nil), (*uuid.UUID)(nil), []domain.VolumeAttachment(nil)).Return(inst2, nil).Once()
+		instSvc.On("LaunchInstance", mock.Anything, mock.Anything, "nginx", "", "", (*uuid.UUID)(nil), (*uuid.UUID)(nil), []domain.VolumeAttachment(nil)).Return(inst1, nil).Once()
+		instSvc.On("LaunchInstance", mock.Anything, mock.Anything, "nginx", "", "", (*uuid.UUID)(nil), (*uuid.UUID)(nil), []domain.VolumeAttachment(nil)).Return(inst2, nil).Once()
 
 		// AddContainer called twice
 		repo.On("AddContainer", mock.Anything, depID, inst1.ID).Return(nil)
@@ -149,7 +149,7 @@ func TestContainerWorkerLaunchError(t *testing.T) {
 
 	repo.On("ListAllDeployments", ctx).Return([]*domain.Deployment{dep}, nil)
 	repo.On("GetContainers", mock.Anything, depID).Return([]uuid.UUID{}, nil) // Launch fails
-	instSvc.On("LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	instSvc.On("LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, context.DeadlineExceeded)
 
 	// Since launch failed, replica count is 0 < 1, so status becomes SCALING

--- a/internal/core/services/instance_test.go
+++ b/internal/core/services/instance_test.go
@@ -55,12 +55,13 @@ func setupInstanceServiceTest(_ *testing.T) (*MockInstanceRepo, *MockVpcRepo, *M
 func TestLaunchInstanceSuccess(t *testing.T) {
 	repo, _, _, _, _, _, _, _, itRepo, _, svc := setupInstanceServiceTest(t)
 	defer repo.AssertExpectations(t)
+	defer itRepo.AssertExpectations(t)
 
 	name := "test-inst"
 	image := "alpine"
 	ports := testPorts
 
-	itRepo.On("GetByID", mock.Anything, defaultInstanceType).Return(&domain.InstanceType{ID: defaultInstanceType}, nil).Maybe()
+	itRepo.On("GetByID", mock.Anything, defaultInstanceType).Return(&domain.InstanceType{ID: defaultInstanceType}, nil)
 	repo.On("Create", mock.Anything, mock.AnythingOfType("*domain.Instance")).Return(nil)
 
 	inst, err := svc.LaunchInstance(context.Background(), name, image, ports, "", nil, nil, nil)

--- a/internal/core/services/instance_type.go
+++ b/internal/core/services/instance_type.go
@@ -1,0 +1,21 @@
+package services
+
+import (
+	"context"
+
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+)
+
+type instanceTypeService struct {
+	repo ports.InstanceTypeRepository
+}
+
+// NewInstanceTypeService creates a new InstanceTypeService.
+func NewInstanceTypeService(repo ports.InstanceTypeRepository) ports.InstanceTypeService {
+	return &instanceTypeService{repo: repo}
+}
+
+func (s *instanceTypeService) List(ctx context.Context) ([]*domain.InstanceType, error) {
+	return s.repo.List(ctx)
+}

--- a/internal/core/services/scale_test.go
+++ b/internal/core/services/scale_test.go
@@ -48,7 +48,7 @@ func BenchmarkRealWorldLifecycle(b *testing.B) {
 		vID := uuid.New()
 		sID := uuid.New()
 
-		inst, err := instSvc.LaunchInstance(pCtx, "test-server", "ubuntu", "22:22", &vID, &sID, nil)
+		inst, err := instSvc.LaunchInstance(pCtx, "test-server", "ubuntu", "22:22", "basic-2", &vID, &sID, nil)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -93,7 +93,7 @@ func BenchmarkRealWorldLifecycleParallel(b *testing.B) {
 			vID := uuid.New()
 			sID := uuid.New()
 
-			inst, _ := instSvc.LaunchInstance(pCtx, "test-server", "ubuntu", "22:22", &vID, &sID, nil)
+			inst, _ := instSvc.LaunchInstance(pCtx, "test-server", "ubuntu", "22:22", "basic-2", &vID, &sID, nil)
 			if inst != nil {
 				_, _ = instSvc.GetInstance(pCtx, inst.ID.String())
 				_ = instSvc.TerminateInstance(pCtx, inst.ID.String())

--- a/internal/core/services/shared_test.go
+++ b/internal/core/services/shared_test.go
@@ -185,8 +185,8 @@ func (m *MockAutoScalingRepo) GetAverageCPU(ctx context.Context, instanceIDs []u
 // MockInstanceService
 type MockInstanceService struct{ mock.Mock }
 
-func (m *MockInstanceService) LaunchInstance(ctx context.Context, name, image, ports string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error) {
-	args := m.Called(ctx, name, image, ports, vpcID, subnetID, volumes)
+func (m *MockInstanceService) LaunchInstance(ctx context.Context, name, image, ports, instanceType string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error) {
+	args := m.Called(ctx, name, image, ports, instanceType, vpcID, subnetID, volumes)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -229,6 +229,24 @@ func (m *MockInstanceService) TerminateInstance(ctx context.Context, idOrName st
 func (m *MockInstanceService) Exec(ctx context.Context, idOrName string, cmd []string) (string, error) {
 	args := m.Called(ctx, idOrName, cmd)
 	return args.String(0), args.Error(1)
+}
+
+// MockInstanceTypeRepo
+type MockInstanceTypeRepo struct{ mock.Mock }
+
+func (m *MockInstanceTypeRepo) List(ctx context.Context) ([]*domain.InstanceType, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.InstanceType), args.Error(1)
+}
+func (m *MockInstanceTypeRepo) GetByID(ctx context.Context, id string) (*domain.InstanceType, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.InstanceType), args.Error(1)
 }
 
 // MockLBService

--- a/internal/core/services/shared_test.go
+++ b/internal/core/services/shared_test.go
@@ -248,6 +248,23 @@ func (m *MockInstanceTypeRepo) GetByID(ctx context.Context, id string) (*domain.
 	}
 	return args.Get(0).(*domain.InstanceType), args.Error(1)
 }
+func (m *MockInstanceTypeRepo) Create(ctx context.Context, it *domain.InstanceType) (*domain.InstanceType, error) {
+	args := m.Called(ctx, it)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.InstanceType), args.Error(1)
+}
+func (m *MockInstanceTypeRepo) Update(ctx context.Context, it *domain.InstanceType) (*domain.InstanceType, error) {
+	args := m.Called(ctx, it)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.InstanceType), args.Error(1)
+}
+func (m *MockInstanceTypeRepo) Delete(ctx context.Context, id string) error {
+	return m.Called(ctx, id).Error(0)
+}
 
 // MockLBService
 type MockLBService struct{ mock.Mock }

--- a/internal/core/services/stack.go
+++ b/internal/core/services/stack.go
@@ -287,7 +287,7 @@ func (s *stackService) createInstance(ctx context.Context, stackID uuid.UUID, lo
 		vpcIDPtr = &vpcID
 	}
 
-	inst, err := s.instanceSvc.LaunchInstance(ctx, name, image, "80", vpcIDPtr, nil, nil)
+	inst, err := s.instanceSvc.LaunchInstance(ctx, name, image, "80", "", vpcIDPtr, nil, nil)
 	if err != nil {
 		return uuid.Nil, err
 	}

--- a/internal/core/services/stack_test.go
+++ b/internal/core/services/stack_test.go
@@ -69,7 +69,7 @@ Resources:
 
 	instID := uuid.New()
 	inst := &domain.Instance{ID: instID, Name: stackTestInst}
-	instanceSvc.On("LaunchInstance", mock.Anything, stackTestInst, "alpine", "80", &vpcID, mock.Anything, mock.Anything).Return(inst, nil)
+	instanceSvc.On("LaunchInstance", mock.Anything, stackTestInst, "alpine", "80", "", &vpcID, mock.Anything, mock.Anything).Return(inst, nil)
 	repo.On("AddResource", mock.Anything, mock.MatchedBy(func(r *domain.StackResource) bool {
 		return r.LogicalID == "MyInstance" && r.ResourceType == "Instance"
 	})).Return(nil)
@@ -152,7 +152,7 @@ Resources:
 	})).Return(nil)
 
 	// 2. Instance Fail
-	instanceSvc.On("LaunchInstance", mock.Anything, stackTestInst, "alpine", "80", &vpcID, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("launch failed"))
+	instanceSvc.On("LaunchInstance", mock.Anything, stackTestInst, "alpine", "80", "", &vpcID, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("launch failed"))
 
 	// 3. Rollback
 	repo.On("Update", mock.Anything, mock.MatchedBy(func(s *domain.Stack) bool {

--- a/internal/handlers/instance_handler.go
+++ b/internal/handlers/instance_handler.go
@@ -40,7 +40,7 @@ type VolumeAttachmentRequest struct {
 type LaunchRequest struct {
 	Name         string                    `json:"name" binding:"required"`
 	Image        string                    `json:"image" binding:"required"`
-	InstanceType string                    `json:"instance_type"`
+	InstanceType string                    `json:"instance_type,omitempty"`
 	Ports        string                    `json:"ports"`
 	VpcID        string                    `json:"vpc_id"`
 	SubnetID     string                    `json:"subnet_id"`

--- a/internal/handlers/instance_handler.go
+++ b/internal/handlers/instance_handler.go
@@ -38,12 +38,13 @@ type VolumeAttachmentRequest struct {
 
 // LaunchRequest is the payload for launching a new instance.
 type LaunchRequest struct {
-	Name     string                    `json:"name" binding:"required"`
-	Image    string                    `json:"image" binding:"required"`
-	Ports    string                    `json:"ports"`
-	VpcID    string                    `json:"vpc_id"`
-	SubnetID string                    `json:"subnet_id"`
-	Volumes  []VolumeAttachmentRequest `json:"volumes"`
+	Name         string                    `json:"name" binding:"required"`
+	Image        string                    `json:"image" binding:"required"`
+	InstanceType string                    `json:"instance_type"`
+	Ports        string                    `json:"ports"`
+	VpcID        string                    `json:"vpc_id"`
+	SubnetID     string                    `json:"subnet_id"`
+	Volumes      []VolumeAttachmentRequest `json:"volumes"`
 }
 
 // validateLaunchRequest performs custom validation beyond struct tags
@@ -124,7 +125,7 @@ func (h *InstanceHandler) Launch(c *gin.Context) {
 		return
 	}
 
-	inst, err := h.svc.LaunchInstance(c.Request.Context(), req.Name, req.Image, req.Ports, vpcUUID, subnetUUID, volumes)
+	inst, err := h.svc.LaunchInstance(c.Request.Context(), req.Name, req.Image, req.Ports, req.InstanceType, vpcUUID, subnetUUID, volumes)
 	if err != nil {
 		httputil.Error(c, err)
 		return

--- a/internal/handlers/instance_handler_test.go
+++ b/internal/handlers/instance_handler_test.go
@@ -29,8 +29,8 @@ type instanceServiceMock struct {
 	mock.Mock
 }
 
-func (m *instanceServiceMock) LaunchInstance(ctx context.Context, name, image, ports string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error) {
-	args := m.Called(ctx, name, image, ports, vpcID, subnetID, volumes)
+func (m *instanceServiceMock) LaunchInstance(ctx context.Context, name, image, ports, instanceType string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error) {
+	args := m.Called(ctx, name, image, ports, instanceType, vpcID, subnetID, volumes)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -112,7 +112,7 @@ func TestInstanceHandlerLaunchRejectsEmptyImage(t *testing.T) {
 	}
 	assert.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
 	assert.Equal(t, "INVALID_INPUT", wrapper.Error.Type)
-	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestInstanceHandlerLaunchRejectsInvalidJSON(t *testing.T) {
@@ -127,7 +127,7 @@ func TestInstanceHandlerLaunchRejectsInvalidJSON(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestInstanceHandlerLaunchRejectsInvalidNameCharacters(t *testing.T) {
@@ -143,7 +143,7 @@ func TestInstanceHandlerLaunchRejectsInvalidNameCharacters(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestInstanceHandlerLaunch(t *testing.T) {
@@ -152,7 +152,7 @@ func TestInstanceHandlerLaunch(t *testing.T) {
 	r.POST(instancesPath, handler.Launch)
 
 	inst := &domain.Instance{ID: uuid.New(), Name: testInstanceName}
-	mockSvc.On("LaunchInstance", mock.Anything, testInstanceName, "alpine", "", (*uuid.UUID)(nil), (*uuid.UUID)(nil), []domain.VolumeAttachment(nil)).Return(inst, nil)
+	mockSvc.On("LaunchInstance", mock.Anything, testInstanceName, "alpine", "", "", (*uuid.UUID)(nil), (*uuid.UUID)(nil), []domain.VolumeAttachment(nil)).Return(inst, nil)
 
 	body := `{"name":"` + testInstanceName + `","image":"alpine"}`
 	req := httptest.NewRequest(http.MethodPost, instancesPath, strings.NewReader(body))
@@ -177,7 +177,7 @@ func TestInstanceHandlerLaunchRejectsInvalidMountPath(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestInstanceHandlerList(t *testing.T) {
@@ -325,7 +325,7 @@ func TestInstanceHandlerLaunchWithVolumesAndVPC(t *testing.T) {
 		{VolumeIDOrName: volID, MountPath: "/mnt/data"},
 	}
 
-	mockSvc.On("LaunchInstance", mock.Anything, complexTestName, "ubuntu", "80:80", &vpcID, (*uuid.UUID)(nil), expectedVolumes).Return(inst, nil)
+	mockSvc.On("LaunchInstance", mock.Anything, complexTestName, "ubuntu", "80:80", "", &vpcID, (*uuid.UUID)(nil), expectedVolumes).Return(inst, nil)
 
 	body := map[string]interface{}{
 		"name":   complexTestName,
@@ -361,7 +361,7 @@ func TestInstanceHandlerLaunchRejectsInvalidVPCID(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	mockSvc.AssertNotCalled(t, "LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestInstanceHandlerGetConsole(t *testing.T) {

--- a/internal/handlers/instance_type_handler.go
+++ b/internal/handlers/instance_type_handler.go
@@ -1,0 +1,38 @@
+package httphandlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/pkg/httputil"
+)
+
+// InstanceTypeHandler handles instance type related HTTP requests.
+type InstanceTypeHandler struct {
+	svc ports.InstanceTypeService
+}
+
+// NewInstanceTypeHandler creates a new InstanceTypeHandler.
+func NewInstanceTypeHandler(svc ports.InstanceTypeService) *InstanceTypeHandler {
+	return &InstanceTypeHandler{svc: svc}
+}
+
+// List returns all available instance types.
+// @Summary List instance types
+// @Description Gets a list of all available instance types with their resource limits and pricing
+// @Tags instances
+// @Produce json
+// @Security APIKeyAuth
+// @Success 200 {array} domain.InstanceType
+// @Failure 500 {object} httputil.Response
+// @Router /instance-types [get]
+func (h *InstanceTypeHandler) List(c *gin.Context) {
+	types, err := h.svc.List(c.Request.Context())
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, types)
+}

--- a/internal/handlers/instance_type_handler_test.go
+++ b/internal/handlers/instance_type_handler_test.go
@@ -1,0 +1,60 @@
+package httphandlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/pkg/httputil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type instanceTypeServiceMock struct {
+	mock.Mock
+}
+
+func (m *instanceTypeServiceMock) List(ctx context.Context) ([]*domain.InstanceType, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.InstanceType), args.Error(1)
+}
+
+func TestInstanceTypeHandlerList(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	mockSvc := new(instanceTypeServiceMock)
+	handler := NewInstanceTypeHandler(mockSvc)
+	r := gin.New()
+	r.GET("/instance-types", handler.List)
+
+	t.Run("success", func(t *testing.T) {
+		expectedTypes := []*domain.InstanceType{
+			{ID: "basic-1", Name: "Basic Small", VCPUs: 1, MemoryMB: 1024, DiskGB: 10},
+		}
+		mockSvc.On("List", mock.Anything).Return(expectedTypes, nil).Once()
+
+		req, _ := http.NewRequest(http.MethodGet, "/instance-types", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp httputil.Response
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp.Data)
+
+		data, _ := json.Marshal(resp.Data)
+		var actualTypes []*domain.InstanceType
+		json.Unmarshal(data, &actualTypes)
+		assert.Len(t, actualTypes, 1)
+		assert.Equal(t, "basic-1", actualTypes[0].ID)
+
+		mockSvc.AssertExpectations(t)
+	})
+}

--- a/internal/handlers/instance_type_handler_test.go
+++ b/internal/handlers/instance_type_handler_test.go
@@ -51,7 +51,8 @@ func TestInstanceTypeHandlerList(t *testing.T) {
 
 		data, _ := json.Marshal(resp.Data)
 		var actualTypes []*domain.InstanceType
-		json.Unmarshal(data, &actualTypes)
+		err = json.Unmarshal(data, &actualTypes)
+		assert.NoError(t, err)
 		assert.Len(t, actualTypes, 1)
 		assert.Equal(t, "basic-1", actualTypes[0].ID)
 

--- a/internal/repositories/k8s/bootstrap.go
+++ b/internal/repositories/k8s/bootstrap.go
@@ -16,7 +16,7 @@ func (p *KubeadmProvisioner) createNode(ctx context.Context, cluster *domain.Clu
 	// Using kindest/node image for better Docker-in-Docker support (includes systemd)
 	imageName := "kindest/node:v1.29.0"
 	// Don't expose port 22 to host; we access via internal network or Exec.
-	inst, err := p.instSvc.LaunchInstance(ctx, name, imageName, "", &cluster.VpcID, nil, nil)
+	inst, err := p.instSvc.LaunchInstance(ctx, name, imageName, "", "", &cluster.VpcID, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repositories/k8s/health_test.go
+++ b/internal/repositories/k8s/health_test.go
@@ -45,8 +45,8 @@ func (m *mockClusterRepo) GetNodes(ctx context.Context, clusterID uuid.UUID) ([]
 func (m *mockClusterRepo) DeleteNode(ctx context.Context, nodeID uuid.UUID) error      { return nil }
 func (m *mockClusterRepo) UpdateNode(ctx context.Context, n *domain.ClusterNode) error { return nil }
 
-func (m *mockInstanceService) LaunchInstance(ctx context.Context, name, image, ports string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error) {
-	args := m.Called(ctx, name, image, ports, vpcID, subnetID, volumes)
+func (m *mockInstanceService) LaunchInstance(ctx context.Context, name, image, ports, instanceType string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error) {
+	args := m.Called(ctx, name, image, ports, instanceType, vpcID, subnetID, volumes)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/repositories/k8s/kubeadm_provisioner_test.go
+++ b/internal/repositories/k8s/kubeadm_provisioner_test.go
@@ -17,8 +17,8 @@ import (
 
 type MockInstanceService struct{ mock.Mock }
 
-func (m *MockInstanceService) LaunchInstance(ctx context.Context, name, image, ports string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error) {
-	args := m.Called(ctx, name, image, ports, vpcID, subnetID, volumes)
+func (m *MockInstanceService) LaunchInstance(ctx context.Context, name, image, ports, instanceType string, vpcID, subnetID *uuid.UUID, volumes []domain.VolumeAttachment) (*domain.Instance, error) {
+	args := m.Called(ctx, name, image, ports, instanceType, vpcID, subnetID, volumes)
 	return args.Get(0).(*domain.Instance), args.Error(1)
 }
 func (m *MockInstanceService) GetInstance(ctx context.Context, id string) (*domain.Instance, error) {
@@ -302,7 +302,7 @@ func TestKubeadmProvisionerProvisionHA(t *testing.T) {
 			Role:       domain.NodeRoleControlPlane,
 		})
 
-		instSvc.On("LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(instance, nil).Once()
+		instSvc.On("LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(instance, nil).Once()
 		instSvc.On("GetInstance", mock.Anything, nodeID.String()).Return(instance, nil).Maybe()
 		lbSvc.On("AddTarget", mock.Anything, lbID, nodeID, 6443, 10).Return(nil)
 	}

--- a/internal/repositories/k8s/provisioner_all_test.go
+++ b/internal/repositories/k8s/provisioner_all_test.go
@@ -56,7 +56,7 @@ func TestKubeadmProvisionerK8sOps(t *testing.T) {
 
 	t.Run("CreateNode", func(t *testing.T) {
 		p, instSvc, repo, _, sgSvc, _, _ := prepareProvisioner()
-		instSvc.On("LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&domain.Instance{ID: masterID}, nil).Once()
+		instSvc.On("LaunchInstance", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&domain.Instance{ID: masterID}, nil).Once()
 		sgSvc.On("GetGroup", mock.Anything, sgName, vpcID).Return(&domain.SecurityGroup{ID: uuid.New()}, nil).Once()
 		sgSvc.On("AttachToInstance", mock.Anything, masterID, mock.Anything).Return(nil).Once()
 		repo.On("AddNode", mock.Anything, mock.Anything).Return(nil).Once()

--- a/internal/repositories/noop/adapters.go
+++ b/internal/repositories/noop/adapters.go
@@ -36,6 +36,20 @@ func (r *NoopInstanceRepository) ListByUserID(ctx context.Context, userID uuid.U
 	return []*domain.Instance{}, nil
 }
 
+// NoopInstanceTypeRepository is a no-op instance type repository.
+type NoopInstanceTypeRepository struct{}
+
+func (r *NoopInstanceTypeRepository) List(ctx context.Context) ([]*domain.InstanceType, error) {
+	return []*domain.InstanceType{
+		{ID: "basic-1", Name: "Basic 1", VCPUs: 1, MemoryMB: 512, DiskGB: 8},
+		{ID: "basic-2", Name: "Basic 2", VCPUs: 1, MemoryMB: 1024, DiskGB: 10},
+	}, nil
+}
+
+func (r *NoopInstanceTypeRepository) GetByID(ctx context.Context, id string) (*domain.InstanceType, error) {
+	return &domain.InstanceType{ID: id, Name: id, VCPUs: 1, MemoryMB: 1024, DiskGB: 10}, nil
+}
+
 // NoopVpcRepository is a no-op VPC repository.
 type NoopVpcRepository struct{}
 

--- a/internal/repositories/noop/adapters.go
+++ b/internal/repositories/noop/adapters.go
@@ -50,6 +50,18 @@ func (r *NoopInstanceTypeRepository) GetByID(ctx context.Context, id string) (*d
 	return &domain.InstanceType{ID: id, Name: id, VCPUs: 1, MemoryMB: 1024, DiskGB: 10}, nil
 }
 
+func (r *NoopInstanceTypeRepository) Create(ctx context.Context, it *domain.InstanceType) (*domain.InstanceType, error) {
+	return it, nil
+}
+
+func (r *NoopInstanceTypeRepository) Update(ctx context.Context, it *domain.InstanceType) (*domain.InstanceType, error) {
+	return it, nil
+}
+
+func (r *NoopInstanceTypeRepository) Delete(ctx context.Context, id string) error {
+	return nil
+}
+
 // NoopVpcRepository is a no-op VPC repository.
 type NoopVpcRepository struct{}
 

--- a/internal/repositories/postgres/instance_repo.go
+++ b/internal/repositories/postgres/instance_repo.go
@@ -26,12 +26,12 @@ func NewInstanceRepository(db DB) *InstanceRepository {
 // Create inserts a new instance record into the database.
 func (r *InstanceRepository) Create(ctx context.Context, inst *domain.Instance) error {
 	query := `
-		INSERT INTO instances (id, user_id, tenant_id, name, image, container_id, status, ports, vpc_id, subnet_id, private_ip, ovs_port, version, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULLIF($11, '')::inet, $12, $13, $14, $15)
+		INSERT INTO instances (id, user_id, tenant_id, name, image, container_id, status, ports, vpc_id, subnet_id, private_ip, ovs_port, instance_type, version, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NULLIF($11, '')::inet, $12, $13, $14, $15, $16)
 	`
 	_, err := r.db.Exec(ctx, query,
 		inst.ID, inst.UserID, inst.TenantID, inst.Name, inst.Image, inst.ContainerID, string(inst.Status), inst.Ports, inst.VpcID, inst.SubnetID,
-		inst.PrivateIP, inst.OvsPort, inst.Version, inst.CreatedAt, inst.UpdatedAt,
+		inst.PrivateIP, inst.OvsPort, inst.InstanceType, inst.Version, inst.CreatedAt, inst.UpdatedAt,
 	)
 	if err != nil {
 		return errors.Wrap(errors.Internal, "failed to create instance", err)
@@ -43,7 +43,7 @@ func (r *InstanceRepository) Create(ctx context.Context, inst *domain.Instance) 
 func (r *InstanceRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.Instance, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	query := `
-		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), version, created_at, updated_at
+		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), COALESCE(instance_type, ''), version, created_at, updated_at
 		FROM instances
 		WHERE id = $1 AND tenant_id = $2
 	`
@@ -54,7 +54,7 @@ func (r *InstanceRepository) scanInstance(row pgx.Row) (*domain.Instance, error)
 	var inst domain.Instance
 	var status string
 	err := row.Scan(
-		&inst.ID, &inst.UserID, &inst.TenantID, &inst.Name, &inst.Image, &inst.ContainerID, &status, &inst.Ports, &inst.VpcID, &inst.SubnetID, &inst.PrivateIP, &inst.OvsPort, &inst.Version, &inst.CreatedAt, &inst.UpdatedAt,
+		&inst.ID, &inst.UserID, &inst.TenantID, &inst.Name, &inst.Image, &inst.ContainerID, &status, &inst.Ports, &inst.VpcID, &inst.SubnetID, &inst.PrivateIP, &inst.OvsPort, &inst.InstanceType, &inst.Version, &inst.CreatedAt, &inst.UpdatedAt,
 	)
 	if err != nil {
 		if err == pgx.ErrNoRows {
@@ -70,7 +70,7 @@ func (r *InstanceRepository) scanInstance(row pgx.Row) (*domain.Instance, error)
 func (r *InstanceRepository) GetByName(ctx context.Context, name string) (*domain.Instance, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	query := `
-		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), version, created_at, updated_at
+		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), COALESCE(instance_type, ''), version, created_at, updated_at
 		FROM instances
 		WHERE name = $1 AND tenant_id = $2
 	`
@@ -81,7 +81,7 @@ func (r *InstanceRepository) GetByName(ctx context.Context, name string) (*domai
 func (r *InstanceRepository) List(ctx context.Context) ([]*domain.Instance, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	query := `
-		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), version, created_at, updated_at
+		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), COALESCE(instance_type, ''), version, created_at, updated_at
 		FROM instances
 		WHERE tenant_id = $1
 		ORDER BY created_at DESC
@@ -95,7 +95,7 @@ func (r *InstanceRepository) List(ctx context.Context) ([]*domain.Instance, erro
 
 func (r *InstanceRepository) ListAll(ctx context.Context) ([]*domain.Instance, error) {
 	query := `
-		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), version, created_at, updated_at
+		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), COALESCE(instance_type, ''), version, created_at, updated_at
 		FROM instances
 		ORDER BY created_at DESC
 	`
@@ -111,11 +111,11 @@ func (r *InstanceRepository) Update(ctx context.Context, inst *domain.Instance) 
 	// Implements Optimistic Locking via 'version'
 	query := `
 		UPDATE instances
-		SET name = $1, status = $2, version = version + 1, updated_at = $3, container_id = $4, ports = $5, vpc_id = $6, subnet_id = $7, private_ip = NULLIF($8, '')::inet, ovs_port = $9
-		WHERE id = $10 AND version = $11 AND tenant_id = $12
+		SET name = $1, status = $2, version = version + 1, updated_at = $3, container_id = $4, ports = $5, vpc_id = $6, subnet_id = $7, private_ip = NULLIF($8, '')::inet, ovs_port = $9, instance_type = $10
+		WHERE id = $11 AND version = $12 AND tenant_id = $13
 	`
 	now := time.Now()
-	cmd, err := r.db.Exec(ctx, query, inst.Name, string(inst.Status), now, inst.ContainerID, inst.Ports, inst.VpcID, inst.SubnetID, inst.PrivateIP, inst.OvsPort, inst.ID, inst.Version, inst.TenantID)
+	cmd, err := r.db.Exec(ctx, query, inst.Name, string(inst.Status), now, inst.ContainerID, inst.Ports, inst.VpcID, inst.SubnetID, inst.PrivateIP, inst.OvsPort, inst.InstanceType, inst.ID, inst.Version, inst.TenantID)
 	if err != nil {
 		return errors.Wrap(errors.Internal, "failed to update instance", err)
 	}
@@ -133,7 +133,7 @@ func (r *InstanceRepository) Update(ctx context.Context, inst *domain.Instance) 
 func (r *InstanceRepository) ListBySubnet(ctx context.Context, subnetID uuid.UUID) ([]*domain.Instance, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	query := `
-		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), version, created_at, updated_at
+		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), COALESCE(instance_type, ''), version, created_at, updated_at
 		FROM instances
 		WHERE subnet_id = $1 AND tenant_id = $2
 		ORDER BY created_at DESC

--- a/internal/repositories/postgres/instance_repo_test.go
+++ b/internal/repositories/postgres/instance_repo_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	testInstanceName = "inst-1"
 	testInstanceImg  = "ubuntu:latest"
+	testInstanceType = "basic-2"
 	selectQuery      = "(?s)SELECT.+FROM instances.*"
 )
 
@@ -30,25 +31,26 @@ func TestInstanceRepositoryCreate(t *testing.T) {
 
 		repo := NewInstanceRepository(mock)
 		inst := &domain.Instance{
-			ID:          uuid.New(),
-			UserID:      uuid.New(),
-			TenantID:    uuid.New(),
-			Name:        testInstanceName,
-			Image:       testInstanceImg,
-			ContainerID: "cid-1",
-			Status:      domain.StatusRunning,
-			Ports:       "80:80",
-			VpcID:       nil,
-			SubnetID:    nil,
-			PrivateIP:   testutil.TestIPHost,
-			OvsPort:     "ovs-1",
-			Version:     1,
-			CreatedAt:   time.Now(),
-			UpdatedAt:   time.Now(),
+			ID:           uuid.New(),
+			UserID:       uuid.New(),
+			TenantID:     uuid.New(),
+			Name:         testInstanceName,
+			Image:        testInstanceImg,
+			ContainerID:  "cid-1",
+			Status:       domain.StatusRunning,
+			Ports:        "80:80",
+			VpcID:        nil,
+			SubnetID:     nil,
+			PrivateIP:    testutil.TestIPHost,
+			OvsPort:      "ovs-1",
+			InstanceType: testInstanceType,
+			Version:      1,
+			CreatedAt:    time.Now(),
+			UpdatedAt:    time.Now(),
 		}
 
 		mock.ExpectExec("(?s)INSERT INTO instances.*").
-			WithArgs(inst.ID, inst.UserID, inst.TenantID, inst.Name, inst.Image, inst.ContainerID, string(inst.Status), inst.Ports, inst.VpcID, inst.SubnetID, inst.PrivateIP, inst.OvsPort, inst.Version, inst.CreatedAt, inst.UpdatedAt).
+			WithArgs(inst.ID, inst.UserID, inst.TenantID, inst.Name, inst.Image, inst.ContainerID, string(inst.Status), inst.Ports, inst.VpcID, inst.SubnetID, inst.PrivateIP, inst.OvsPort, inst.InstanceType, inst.Version, inst.CreatedAt, inst.UpdatedAt).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
 		err = repo.Create(context.Background(), inst)
@@ -86,8 +88,8 @@ func TestInstanceRepositoryGetByID(t *testing.T) {
 
 		mock.ExpectQuery(selectQuery).
 			WithArgs(id, tenantID).
-			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "version", "created_at", "updated_at"}).
-				AddRow(id, userID, tenantID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", 1, now, now))
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "instance_type", "version", "created_at", "updated_at"}).
+				AddRow(id, userID, tenantID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", testInstanceType, 1, now, now))
 
 		inst, err := repo.GetByID(ctx, id)
 		assert.NoError(t, err)
@@ -137,8 +139,8 @@ func TestInstanceRepositoryGetByName(t *testing.T) {
 
 		mock.ExpectQuery(selectQuery).
 			WithArgs(name, tenantID).
-			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "version", "created_at", "updated_at"}).
-				AddRow(id, userID, tenantID, name, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", 1, now, now))
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "instance_type", "version", "created_at", "updated_at"}).
+				AddRow(id, userID, tenantID, name, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", testInstanceType, 1, now, now))
 
 		inst, err := repo.GetByName(ctx, name)
 		assert.NoError(t, err)
@@ -186,8 +188,8 @@ func TestInstanceRepositoryList(t *testing.T) {
 
 		mock.ExpectQuery(selectQuery).
 			WithArgs(tenantID).
-			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "version", "created_at", "updated_at"}).
-				AddRow(uuid.New(), userID, tenantID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", 1, now, now))
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "instance_type", "version", "created_at", "updated_at"}).
+				AddRow(uuid.New(), userID, tenantID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", testInstanceType, 1, now, now))
 
 		list, err := repo.List(ctx)
 		assert.NoError(t, err)
@@ -229,8 +231,8 @@ func TestInstanceRepositoryListBySubnet(t *testing.T) {
 
 		mock.ExpectQuery(selectQuery).
 			WithArgs(subnetID, tenantID).
-			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "version", "created_at", "updated_at"}).
-				AddRow(uuid.New(), userID, tenantID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", 1, now, now))
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "instance_type", "version", "created_at", "updated_at"}).
+				AddRow(uuid.New(), userID, tenantID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", "basic-2", 1, now, now))
 
 		list, err := repo.ListBySubnet(ctx, subnetID)
 		assert.NoError(t, err)
@@ -246,19 +248,20 @@ func TestInstanceRepositoryUpdate(t *testing.T) {
 
 		repo := NewInstanceRepository(mock)
 		inst := &domain.Instance{
-			ID:          uuid.New(),
-			UserID:      uuid.New(),
-			TenantID:    uuid.New(),
-			Name:        "inst-1-updated",
-			Status:      domain.StatusStopped,
-			ContainerID: "cid-1",
-			Ports:       "80:80",
-			Version:     1,
-			UpdatedAt:   time.Now(),
+			ID:           uuid.New(),
+			UserID:       uuid.New(),
+			TenantID:     uuid.New(),
+			Name:         "inst-1-updated",
+			Status:       domain.StatusStopped,
+			ContainerID:  "cid-1",
+			Ports:        "80:80",
+			InstanceType: testInstanceType,
+			Version:      1,
+			UpdatedAt:    time.Now(),
 		}
 
 		mock.ExpectExec("(?s)UPDATE instances.*").
-			WithArgs(inst.Name, string(inst.Status), pgxmock.AnyArg(), inst.ContainerID, inst.Ports, inst.VpcID, inst.SubnetID, inst.PrivateIP, inst.OvsPort, inst.ID, inst.Version, inst.TenantID).
+			WithArgs(inst.Name, string(inst.Status), pgxmock.AnyArg(), inst.ContainerID, inst.Ports, inst.VpcID, inst.SubnetID, inst.PrivateIP, inst.OvsPort, testInstanceType, inst.ID, inst.Version, inst.TenantID).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 		err = repo.Update(context.Background(), inst)
@@ -273,15 +276,16 @@ func TestInstanceRepositoryUpdate(t *testing.T) {
 
 		repo := NewInstanceRepository(mock)
 		inst := &domain.Instance{
-			ID:       uuid.New(),
-			UserID:   uuid.New(),
-			TenantID: uuid.New(),
-			Status:   domain.StatusStopped,
-			Version:  1,
+			ID:           uuid.New(),
+			UserID:       uuid.New(),
+			TenantID:     uuid.New(),
+			Status:       domain.StatusStopped,
+			InstanceType: testInstanceType,
+			Version:      1,
 		}
 
 		mock.ExpectExec("(?s)UPDATE instances.*").
-			WithArgs(inst.Name, string(inst.Status), pgxmock.AnyArg(), inst.ContainerID, inst.Ports, inst.VpcID, inst.SubnetID, inst.PrivateIP, inst.OvsPort, inst.ID, inst.Version, inst.TenantID).
+			WithArgs(inst.Name, string(inst.Status), pgxmock.AnyArg(), inst.ContainerID, inst.Ports, inst.VpcID, inst.SubnetID, inst.PrivateIP, inst.OvsPort, testInstanceType, inst.ID, inst.Version, inst.TenantID).
 			WillReturnResult(pgxmock.NewResult("UPDATE", 0))
 
 		err = repo.Update(context.Background(), inst)

--- a/internal/repositories/postgres/instance_type_repo.go
+++ b/internal/repositories/postgres/instance_type_repo.go
@@ -1,0 +1,68 @@
+// Package postgres provides PostgreSQL-backed repository implementations.
+package postgres
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/errors"
+)
+
+// InstanceTypeRepository provides a PostgreSQL implementation for instance types.
+type InstanceTypeRepository struct {
+	db DB
+}
+
+// NewInstanceTypeRepository creates a new InstanceTypeRepository.
+func NewInstanceTypeRepository(db DB) *InstanceTypeRepository {
+	return &InstanceTypeRepository{db: db}
+}
+
+// List returns all available instance types.
+func (r *InstanceTypeRepository) List(ctx context.Context) ([]*domain.InstanceType, error) {
+	query := `
+		SELECT id, name, vcpus, memory_mb, disk_gb, network_mbps, price_per_hour, category
+		FROM instance_types
+		ORDER BY vcpus ASC, memory_mb ASC
+	`
+	rows, err := r.db.Query(ctx, query)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list instance types", err)
+	}
+	defer rows.Close()
+
+	var types []*domain.InstanceType
+	for rows.Next() {
+		t, err := r.scanInstanceType(rows)
+		if err != nil {
+			return nil, err
+		}
+		types = append(types, t)
+	}
+	return types, nil
+}
+
+// GetByID retrieves an instance type by its ID.
+func (r *InstanceTypeRepository) GetByID(ctx context.Context, id string) (*domain.InstanceType, error) {
+	query := `
+		SELECT id, name, vcpus, memory_mb, disk_gb, network_mbps, price_per_hour, category
+		FROM instance_types
+		WHERE id = $1
+	`
+	return r.scanInstanceType(r.db.QueryRow(ctx, query, id))
+}
+
+func (r *InstanceTypeRepository) scanInstanceType(row pgx.Row) (*domain.InstanceType, error) {
+	var t domain.InstanceType
+	err := row.Scan(
+		&t.ID, &t.Name, &t.VCPUs, &t.MemoryMB, &t.DiskGB, &t.NetworkMbps, &t.PricePerHr, &t.Category,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, errors.New(errors.NotFound, "instance type not found")
+		}
+		return nil, errors.Wrap(errors.Internal, "failed to scan instance type", err)
+	}
+	return &t, nil
+}

--- a/internal/repositories/postgres/migrations/075_add_instance_type.down.sql
+++ b/internal/repositories/postgres/migrations/075_add_instance_type.down.sql
@@ -1,0 +1,3 @@
+-- +goose Down
+DROP TABLE IF EXISTS instance_types;
+ALTER TABLE instances DROP COLUMN IF EXISTS instance_type;

--- a/internal/repositories/postgres/migrations/075_add_instance_type.up.sql
+++ b/internal/repositories/postgres/migrations/075_add_instance_type.up.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- Add instance_type column with default for backward compatibility
+ALTER TABLE instances ADD COLUMN IF NOT EXISTS instance_type TEXT DEFAULT 'basic-2';
+
+-- Create instance_types reference table
+CREATE TABLE instance_types (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    vcpus INT NOT NULL,
+    memory_mb INT NOT NULL,
+    disk_gb INT NOT NULL,
+    network_mbps INT NOT NULL DEFAULT 1000,
+    price_per_hour NUMERIC(10,4) NOT NULL DEFAULT 0.01,
+    category TEXT NOT NULL DEFAULT 'general',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Seed default instance types
+INSERT INTO instance_types (id, name, vcpus, memory_mb, disk_gb, category, price_per_hour) VALUES
+    ('basic-1',       'Basic 1',       1,   512,  8,  'basic',       0.005),
+    ('basic-2',       'Basic 2',       1,  1024, 10,  'basic',       0.01),
+    ('standard-1',    'Standard 1',    2,  2048, 20,  'standard',    0.02),
+    ('standard-2',    'Standard 2',    2,  4096, 40,  'standard',    0.04),
+    ('standard-4',    'Standard 4',    4,  8192, 80,  'standard',    0.08),
+    ('performance-1', 'Performance 1', 4, 16384, 160, 'performance', 0.16),
+    ('performance-2', 'Performance 2', 8, 32768, 320, 'performance', 0.32);

--- a/internal/workers/provision_worker_test.go
+++ b/internal/workers/provision_worker_test.go
@@ -101,16 +101,17 @@ func TestProvisionWorkerRun(t *testing.T) {
 			}
 
 			instSvc := services.NewInstanceService(services.InstanceServiceParams{
-				Repo:       &noop.NoopInstanceRepository{},
-				VpcRepo:    &noop.NoopVpcRepository{},
-				SubnetRepo: &noop.NoopSubnetRepository{},
-				VolumeRepo: &noop.NoopVolumeRepository{},
-				Compute:    compute,
-				Network:    noop.NewNoopNetworkAdapter(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))),
-				EventSvc:   &noop.NoopEventService{},
-				AuditSvc:   &noop.NoopAuditService{},
-				TaskQueue:  nil,
-				Logger:     slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+				Repo:             &noop.NoopInstanceRepository{},
+				VpcRepo:          &noop.NoopVpcRepository{},
+				SubnetRepo:       &noop.NoopSubnetRepository{},
+				VolumeRepo:       &noop.NoopVolumeRepository{},
+				InstanceTypeRepo: &noop.NoopInstanceTypeRepository{},
+				Compute:          compute,
+				Network:          noop.NewNoopNetworkAdapter(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))),
+				EventSvc:         &noop.NoopEventService{},
+				AuditSvc:         &noop.NoopAuditService{},
+				TaskQueue:        nil,
+				Logger:           slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
 			})
 
 			var buf bytes.Buffer
@@ -140,16 +141,17 @@ func TestProvisionWorkerRunDequeueError(t *testing.T) {
 	}
 
 	instSvc := services.NewInstanceService(services.InstanceServiceParams{
-		Repo:       &noop.NoopInstanceRepository{},
-		VpcRepo:    &noop.NoopVpcRepository{},
-		SubnetRepo: &noop.NoopSubnetRepository{},
-		VolumeRepo: &noop.NoopVolumeRepository{},
-		Compute:    &noop.NoopComputeBackend{},
-		Network:    noop.NewNoopNetworkAdapter(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))),
-		EventSvc:   &noop.NoopEventService{},
-		AuditSvc:   &noop.NoopAuditService{},
-		TaskQueue:  nil,
-		Logger:     slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		Repo:             &noop.NoopInstanceRepository{},
+		VpcRepo:          &noop.NoopVpcRepository{},
+		SubnetRepo:       &noop.NoopSubnetRepository{},
+		VolumeRepo:       &noop.NoopVolumeRepository{},
+		InstanceTypeRepo: &noop.NoopInstanceTypeRepository{},
+		Compute:          &noop.NoopComputeBackend{},
+		Network:          noop.NewNoopNetworkAdapter(slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))),
+		EventSvc:         &noop.NoopEventService{},
+		AuditSvc:         &noop.NoopAuditService{},
+		TaskQueue:        nil,
+		Logger:           slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
 	})
 
 	var buf bytes.Buffer

--- a/pkg/sdk/compute.go
+++ b/pkg/sdk/compute.go
@@ -47,14 +47,15 @@ type VolumeAttachmentInput struct {
 }
 
 // LaunchInstance provisions a new instance with optional volume attachments.
-func (c *Client) LaunchInstance(name, image, ports string, vpcID, subnetID string, volumes []VolumeAttachmentInput) (*Instance, error) {
+func (c *Client) LaunchInstance(name, image, ports, instanceType string, vpcID, subnetID string, volumes []VolumeAttachmentInput) (*Instance, error) {
 	body := map[string]interface{}{
-		"name":      name,
-		"image":     image,
-		"ports":     ports,
-		"vpc_id":    vpcID,
-		"subnet_id": subnetID,
-		"volumes":   volumes,
+		"name":          name,
+		"image":         image,
+		"ports":         ports,
+		"instance_type": instanceType,
+		"vpc_id":        vpcID,
+		"subnet_id":     subnetID,
+		"volumes":       volumes,
 	}
 	var res Response[Instance]
 	if err := c.post("/instances", body, &res); err != nil {

--- a/pkg/sdk/compute.go
+++ b/pkg/sdk/compute.go
@@ -8,18 +8,19 @@ import (
 
 // Instance describes a compute instance.
 type Instance struct {
-	ID          string    `json:"id"`
-	Name        string    `json:"name"`
-	Image       string    `json:"image"`
-	Status      string    `json:"status"`
-	Ports       string    `json:"ports"`
-	VpcID       string    `json:"vpc_id,omitempty"`
-	SubnetID    string    `json:"subnet_id,omitempty"`
-	PrivateIP   string    `json:"private_ip,omitempty"`
-	ContainerID string    `json:"container_id"`
-	Version     int       `json:"version"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	Image        string    `json:"image"`
+	InstanceType string    `json:"instance_type,omitempty"`
+	Status       string    `json:"status"`
+	Ports        string    `json:"ports"`
+	VpcID        string    `json:"vpc_id,omitempty"`
+	SubnetID     string    `json:"subnet_id,omitempty"`
+	PrivateIP    string    `json:"private_ip,omitempty"`
+	ContainerID  string    `json:"container_id"`
+	Version      int       `json:"version"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
 }
 
 // ListInstances returns all instances visible to the API key.

--- a/pkg/sdk/compute_test.go
+++ b/pkg/sdk/compute_test.go
@@ -93,7 +93,7 @@ func TestClientLaunchInstance(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, computeAPIKey)
-	instance, err := client.LaunchInstance(computeNewInstance, "nginx", "80:80", "", "", nil)
+	instance, err := client.LaunchInstance(computeNewInstance, "nginx", "80:80", "basic-2", "", "", nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, computeInstanceID, instance.ID)
@@ -212,7 +212,7 @@ func TestClientLaunchInstanceError(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, computeAPIKey)
-	_, err := client.LaunchInstance("name", "img", "80", "", "", nil)
+	_, err := client.LaunchInstance("name", "img", "80", "basic-2", "", "", nil)
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
This PR introduces support for instance types and resource limits across the platform.

### Key Changes:
- **Core**: Added InstanceType domain model and repository.
- **Service**: InstanceService now resolves instance types to set CPU, Memory, and Disk limits during provisioning.
- **Database**: Added instance_types table and seeded default types (basic, standard, performance).
- **SDK/CLI**: Added instanceType support to the Go SDK and a --type flag to the CLI.
- **API**: Updated the launch endpoint to accept instance_type.
- **Docs**: Fully updated API/CLI references, architecture, and database documentation.

All tests passed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added instance type selection for instance launches. Users can now specify instance types (basic-1, basic-2, standard-1, etc.) when creating instances.
  * Added `--type` (`-t`) CLI flag to the instance launch command (default: basic-2).
  * Added `GET /instance-types` API endpoint to list available instance types with resource specifications and pricing.

* **Documentation**
  * Updated CLI and API reference documentation to reflect instance type configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->