### PR TITLE
fix(ci): add buildx setup to deploy jobs for cache support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Lowercase Repo Name
         id: repo_name
         run: |
@@ -326,6 +329,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Lowercase Repo Name
         id: repo_name


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow by initializing Docker Buildx in staging and production jobs, ensuring Docker build and push operations execute with proper configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->