### PR TITLE
feat: implement test isolation and fix port conflicts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:staging
-            ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:${{ github.ref_name }}
             ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -354,7 +353,6 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:latest
-            ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:${{ github.ref_name }}
             ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,9 @@ jobs:
       - name: Run Unit Tests
         env:
           DATABASE_URL: postgres://cloud:cloud@localhost:5433/cloud?sslmode=disable
+          TEST_DOCKER_NETWORK: cloud-network
         run: |
-          docker network create cloud-network || true
+          docker network create ${TEST_DOCKER_NETWORK} || true
           go test -p 1 -v ./cmd/... ./internal/... ./pkg/...
 
   race-detection:
@@ -101,9 +102,10 @@ jobs:
       - name: Run Race Detection (${{ matrix.package }})
         env:
           DATABASE_URL: postgres://cloud:cloud@localhost:5433/cloud?sslmode=disable
+          TEST_DOCKER_NETWORK: cloud-network
         run: |
           set -o pipefail
-          docker network create cloud-network || true
+          docker network create ${TEST_DOCKER_NETWORK} || true
           go test -race -p 1 -v ${{ matrix.package }}
 
   integration-tests:
@@ -232,8 +234,9 @@ jobs:
       - name: Run Libvirt Unit Tests
         env:
           DATABASE_URL: postgres://cloud:cloud@localhost:5433/cloud?sslmode=disable
+          TEST_DOCKER_NETWORK: cloud-network
         run: |
-          docker network create cloud-network || true
+          docker network create ${TEST_DOCKER_NETWORK} || true
           go test -v ./internal/repositories/libvirt/...
 
       - name: Run Libvirt Integration Test
@@ -249,7 +252,8 @@ jobs:
           go run ./cmd/api -migrate-only
           
           # Test with Docker backend (default)
-          docker network create cloud-network || true
+          export TEST_DOCKER_NETWORK=cloud-network
+          docker network create ${TEST_DOCKER_NETWORK} || true
           export COMPUTE_BACKEND=docker
           go test -v -run TestInstanceService ./internal/core/services/...
           

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -72,6 +72,7 @@ jobs:
           export TRACING_ENABLED="${TRACING_ENABLED}"
           export DB_PORT_MAPPING="${DB_PORT_MAPPING}"
           export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}"
+          export DOCKER_DEFAULT_NETWORK="${DOCKER_DEFAULT_NETWORK}"
 
           # Ensure Docker socket has proper permissions for API to create containers
           sudo chmod 666 /var/run/docker.sock
@@ -90,13 +91,13 @@ jobs:
           # Check if API is running
           docker compose ps
 
-          
       - name: Run E2E Tests
         env:
           # The tests run on the HOST, connecting to the API at localhost:8080
           # So we use the mapped DB port 5433 for direct DB tests if any
           DATABASE_URL: postgres://cloud:cloud@localhost:5433/cloud?sslmode=disable
           TEST_DOCKER_NETWORK: thecloud-${{ github.run_id }}_cloud-network
+          COMPOSE_PROJECT_NAME: thecloud-${{ github.run_id }}
         run: |
           # Run tests in parallel to achieve maximum speed.
           # The 'sync.Once' logic in helpers_test.go ensures they won't all wait redundantly.
@@ -107,6 +108,15 @@ jobs:
           # 2. Run chaos tests sequentially (uses package path to include helpers)
           # Note: Chaos tests are destructive and restart containers, so they run last
           go test -v -tags=chaos -timeout 5m ./tests/...
+
+      - name: Show API Logs on Failure
+        if: failure()
+        env:
+          COMPOSE_PROJECT_NAME: thecloud-${{ github.run_id }}
+        run: |
+          docker compose logs api
+          docker network ls
+          docker ps -a
 
 
       - name: Debug Logs on Failure

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,8 +27,9 @@ jobs:
 
       - name: Setup Infrastructure
         env:
-          DB_PORT_MAPPING: 5433:5432 # Keep consistent with local tests
-          SECRETS_ENCRYPTION_KEY: abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789 # 32 bytes (64 hex chars)
+          DB_PORT_MAPPING: 5433:5432
+          COMPOSE_PROJECT_NAME: thecloud-${{ github.run_id }}
+          SECRETS_ENCRYPTION_KEY: abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
           JWT_SECRET: e2e-test-secret-key-that-is-long-enough-for-32-chars
           DATABASE_READ_URL: postgres://cloud:cloud@postgres:5432/cloud?sslmode=disable
         run: |
@@ -57,7 +58,9 @@ jobs:
       - name: Start API
         env:
           DB_PORT_MAPPING: 5433:5432
-          SECRETS_ENCRYPTION_KEY: abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789 # 32 bytes (64 hex chars)
+          COMPOSE_PROJECT_NAME: thecloud-${{ github.run_id }}
+          DOCKER_DEFAULT_NETWORK: thecloud-${{ github.run_id }}_cloud-network
+          SECRETS_ENCRYPTION_KEY: abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789
           JWT_SECRET: e2e-test-secret-key-that-is-long-enough-for-32-chars
           DATABASE_READ_URL: postgres://cloud:cloud@postgres:5432/cloud?sslmode=disable
           TRACING_ENABLED: false
@@ -68,6 +71,7 @@ jobs:
           export DATABASE_READ_URL="${DATABASE_READ_URL}"
           export TRACING_ENABLED="${TRACING_ENABLED}"
           export DB_PORT_MAPPING="${DB_PORT_MAPPING}"
+          export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME}"
 
           # Ensure Docker socket has proper permissions for API to create containers
           sudo chmod 666 /var/run/docker.sock
@@ -92,6 +96,7 @@ jobs:
           # The tests run on the HOST, connecting to the API at localhost:8080
           # So we use the mapped DB port 5433 for direct DB tests if any
           DATABASE_URL: postgres://cloud:cloud@localhost:5433/cloud?sslmode=disable
+          TEST_DOCKER_NETWORK: thecloud-${{ github.run_id }}_cloud-network
         run: |
           # Run tests in parallel to achieve maximum speed.
           # The 'sync.Once' logic in helpers_test.go ensures they won't all wait redundantly.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -35,8 +35,8 @@ jobs:
           # Start internal dependencies
           docker compose up -d postgres redis jaeger
           
-          # Wait for Postgres to be healthy using its container name
-          until docker exec cloud-db pg_isready -U cloud; do
+          # Wait for Postgres to be healthy
+          until docker compose exec -T postgres pg_isready -U cloud; do
             echo "Waiting for postgres..."
             sleep 2
           done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,7 @@ services:
       - JAEGER_ENDPOINT=http://jaeger:4318
       - POWERDNS_API_URL=http://powerdns:8081
       - POWERDNS_API_KEY=${POWERDNS_API_KEY:-thecloud-dns-secret}
+      - DOCKER_DEFAULT_NETWORK=${DOCKER_DEFAULT_NETWORK:-cloud-network}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/openvswitch:/var/run/openvswitch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     image: postgres:16-alpine
-    container_name: cloud-db
+    # container_name: cloud-db
     environment:
       POSTGRES_USER: ${DB_USER:-cloud}
       POSTGRES_PASSWORD: ${DB_PASSWORD:-cloud}
@@ -20,9 +20,9 @@ services:
 
   redis:
     image: redis:7-alpine
-    container_name: cloud-redis
+    # container_name: cloud-redis
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 5s
@@ -33,7 +33,7 @@ services:
 
   jaeger:
     image: jaegertracing/all-in-one:1.54
-    container_name: cloud-jaeger
+    # container_name: cloud-jaeger
     ports:
       - "16686:16686" # Web UI
       - "4317:4317" # OTLP gRPC
@@ -45,12 +45,12 @@ services:
 
   powerdns:
     image: powerdns/pdns-auth-49:latest
-    container_name: thecloud-powerdns
+    # container_name: thecloud-powerdns
     restart: unless-stopped
     ports:
-      - "5354:53/udp" # DNS queries (non-standard to avoid conflict)
-      - "5354:53/tcp"
-      - "8081:8081" # REST API
+      - "${DNS_PORT:-5354}:53/udp" # DNS queries (non-standard to avoid conflict)
+      - "${DNS_PORT:-5354}:53/tcp"
+      - "${POWERDNS_PORT:-8081}:8081" # REST API
     environment:
       - PDNS_AUTH_API=yes
       - PDNS_AUTH_API_KEY=${POWERDNS_API_KEY:-thecloud-dns-secret}
@@ -119,5 +119,4 @@ volumes:
 
 
 networks:
-  cloud-network:
-    name: cloud-network
+  cloud-network: # name: cloud-network

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -33,13 +33,21 @@ This document provides a comprehensive overview of every feature currently imple
 - **Backend Selection**: Set via `COMPUTE_BACKEND` environment variable (`docker` or `libvirt`).
 - **Lifecycle**: The `InstanceService` manages the backend API to Create, Start, Stop, and Remove instances.
 
-### 2. Networking (VPC)
-**What it is**: Isolated virtual networks to secure resources.
-**Tech Stack**: Docker Networks (Bridge) or Open vSwitch (OVS).
-**Implementation**:
+### 2. Networking (VPC & Elastic IPs)
+**What it is**: Isolated virtual networks and static public IP addresses.
+**Tech Stack**: Docker Networks, Open vSwitch (OVS), pgx.
+
+**VPC Implementation**:
 - **Docker Mode**: A "VPC" maps directly to a **Docker Bridge Network**.
 - **Libvirt Mode**: Uses **Open vSwitch (OVS)** bridges and VXLANs for tenant isolation.
-- **Isolation**: strict traffic segregation rules enforced by generic or OVS flow rules.
+
+**Elastic IP Implementation**:
+- **Static Reservation**: Reserve static IPv4 addresses from a public pool (simulated via 100.64.0.0/10).
+- **Dynamic Association**: Attach/detach IPs to any compute instance without changing the instance's private setup.
+- **Persistence**: IPs remain reserved to the tenant even when not associated with a resource.
+- **Constraints**: Enforces one Elastic IP per instance via partial unique database indexes.
+
+**Isolation**: strict traffic segregation rules enforced by generic or OVS flow rules.
 
 ### 3. Block Storage (Volumes)
 **What it is**: Persistent disks that can be attached/detached from instances.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -316,6 +316,47 @@ Delete a subnet.
 
 ---
 
+## Elastic IPs (Static IPs) 🆕
+
+**Headers Required:** `X-API-Key: <your-api-key>`
+
+### GET /elastic-ips
+List all allocated elastic IPs for the tenant.
+
+### POST /elastic-ips
+Allocate a new elastic IP. No body required.
+**Response:**
+```json
+{
+  "data": {
+    "id": "uuid",
+    "public_ip": "100.64.x.y",
+    "status": "allocated",
+    "arn": "arn:thecloud:vpc:local:tenant:eip/uuid"
+  }
+}
+```
+
+### GET /elastic-ips/:id
+Get details of a specific elastic IP.
+
+### DELETE /elastic-ips/:id
+Release an elastic IP back to the pool. Failed if still associated.
+
+### POST /elastic-ips/:id/associate
+Associate an elastic IP with a compute instance.
+**Request:**
+```json
+{
+  "instance_id": "inst-uuid"
+}
+```
+
+### POST /elastic-ips/:id/disassociate
+Disassociate an elastic IP from its current instance.
+
+---
+
 ## Volumes
 
 **Headers Required:** `X-API-Key: <your-api-key>`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -156,6 +156,7 @@ type StorageBackend interface {
 - `InstanceService` - Compute lifecycle
 - `VolumeService` - Block storage
 - `VPCService` - Network isolation
+- `ElasticIPService` - Static IP management 🆕
 - `LoadBalancerService` - Traffic distribution (Regional)
 - `GlobalLBService` - Multi-region traffic steering (DNS-based) 🆕
 - `AutoScalingService` - Dynamic scaling

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -61,6 +61,7 @@ internal/
 - `InstanceService` - Compute instance lifecycle management
 - `VolumeService` - Block storage operations
 - `VPCService` - Network isolation and management
+- `ElasticIPService` - Static IP management 🆕
 - `LoadBalancerService` - Layer 7 traffic distribution
 - `AutoScalingService` - Dynamic resource scaling
 - `RBACService` - Role-based access control (100% coverage)
@@ -79,6 +80,7 @@ internal/
 
 **REST API Endpoints:**
 - `/instances` - Compute management
+- `/elastic-ips` - Static IP management 🆕
 - `/volumes` - Block storage
 - `/vpcs` - Networking
 - `/loadbalancers` - Load balancing

--- a/docs/database.md
+++ b/docs/database.md
@@ -202,6 +202,26 @@ CREATE TABLE vpcs (
 CREATE INDEX idx_vpcs_user_id ON vpcs(user_id);
 ```
 
+#### `elastic_ips` - Static/Elastic IPs
+```sql
+CREATE TABLE elastic_ips (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    tenant_id UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    instance_id UUID REFERENCES instances(id) ON DELETE SET NULL,
+    vpc_id UUID REFERENCES vpcs(id) ON DELETE SET NULL,
+    public_ip VARCHAR(45) NOT NULL UNIQUE,
+    status VARCHAR(50) NOT NULL DEFAULT 'allocated',
+    arn VARCHAR(255) NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_elastic_ips_instance_id_unique 
+ON elastic_ips(instance_id) 
+WHERE instance_id IS NOT NULL;
+CREATE INDEX idx_elastic_ips_tenant_id ON elastic_ips(tenant_id);
+```
 #### `load_balancers` - Load Balancers
 ```sql
 CREATE TABLE load_balancers (

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1724,6 +1724,196 @@ const docTemplate = `{
                 }
             }
         },
+        "/elastic-ips": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "List Elastic IPs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.ElasticIP"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Allocate an Elastic IP",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ElasticIP"
+                        }
+                    }
+                }
+            }
+        },
+        "/elastic-ips/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Get Elastic IP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "EIP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ElasticIP"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Release Elastic IP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "EIP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/elastic-ips/{id}/associate": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Associate Elastic IP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "EIP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Association Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "instance_id": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ElasticIP"
+                        }
+                    }
+                }
+            }
+        },
+        "/elastic-ips/{id}/disassociate": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Disassociate Elastic IP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "EIP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ElasticIP"
+                        }
+                    }
+                }
+            }
+        },
         "/gateway/routes": {
             "get": {
                 "security": [
@@ -5289,6 +5479,55 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.ElasticIP": {
+            "type": "object",
+            "properties": {
+                "arn": {
+                    "description": "arn:thecloud:vpc:{region}:{user}:eip/{id}",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "instance_id": {
+                    "type": "string"
+                },
+                "public_ip": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.ElasticIPStatus"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.ElasticIPStatus": {
+            "type": "string",
+            "enum": [
+                "allocated",
+                "associated",
+                "released"
+            ],
+            "x-enum-varnames": [
+                "EIPStatusAllocated",
+                "EIPStatusAssociated",
+                "EIPStatusReleased"
+            ]
+        },
         "domain.Event": {
             "type": "object",
             "properties": {
@@ -5937,6 +6176,10 @@ const docTemplate = `{
                 "vpc:delete",
                 "vpc:read",
                 "vpc:update",
+                "eip:allocate",
+                "eip:release",
+                "eip:read",
+                "eip:associate",
                 "volume:create",
                 "volume:delete",
                 "volume:read",
@@ -6006,6 +6249,10 @@ const docTemplate = `{
                 "PermissionVpcDelete",
                 "PermissionVpcRead",
                 "PermissionVpcUpdate",
+                "PermissionEipAllocate",
+                "PermissionEipRelease",
+                "PermissionEipRead",
+                "PermissionEipAssociate",
                 "PermissionVolumeCreate",
                 "PermissionVolumeDelete",
                 "PermissionVolumeRead",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1716,6 +1716,196 @@
                 }
             }
         },
+        "/elastic-ips": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "List Elastic IPs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.ElasticIP"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Allocate an Elastic IP",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ElasticIP"
+                        }
+                    }
+                }
+            }
+        },
+        "/elastic-ips/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Get Elastic IP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "EIP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ElasticIP"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Release Elastic IP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "EIP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/elastic-ips/{id}/associate": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Associate Elastic IP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "EIP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Association Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object",
+                            "properties": {
+                                "instance_id": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ElasticIP"
+                        }
+                    }
+                }
+            }
+        },
+        "/elastic-ips/{id}/disassociate": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "elastic-ips"
+                ],
+                "summary": "Disassociate Elastic IP",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "EIP ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.ElasticIP"
+                        }
+                    }
+                }
+            }
+        },
         "/gateway/routes": {
             "get": {
                 "security": [
@@ -5281,6 +5471,55 @@
                 }
             }
         },
+        "domain.ElasticIP": {
+            "type": "object",
+            "properties": {
+                "arn": {
+                    "description": "arn:thecloud:vpc:{region}:{user}:eip/{id}",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "instance_id": {
+                    "type": "string"
+                },
+                "public_ip": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.ElasticIPStatus"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.ElasticIPStatus": {
+            "type": "string",
+            "enum": [
+                "allocated",
+                "associated",
+                "released"
+            ],
+            "x-enum-varnames": [
+                "EIPStatusAllocated",
+                "EIPStatusAssociated",
+                "EIPStatusReleased"
+            ]
+        },
         "domain.Event": {
             "type": "object",
             "properties": {
@@ -5929,6 +6168,10 @@
                 "vpc:delete",
                 "vpc:read",
                 "vpc:update",
+                "eip:allocate",
+                "eip:release",
+                "eip:read",
+                "eip:associate",
                 "volume:create",
                 "volume:delete",
                 "volume:read",
@@ -5998,6 +6241,10 @@
                 "PermissionVpcDelete",
                 "PermissionVpcRead",
                 "PermissionVpcUpdate",
+                "PermissionEipAllocate",
+                "PermissionEipRelease",
+                "PermissionEipRead",
+                "PermissionEipAssociate",
                 "PermissionVolumeCreate",
                 "PermissionVolumeDelete",
                 "PermissionVolumeRead",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -228,6 +228,40 @@ definitions:
       summary:
         $ref: '#/definitions/domain.ResourceSummary'
     type: object
+  domain.ElasticIP:
+    properties:
+      arn:
+        description: arn:thecloud:vpc:{region}:{user}:eip/{id}
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      instance_id:
+        type: string
+      public_ip:
+        type: string
+      status:
+        $ref: '#/definitions/domain.ElasticIPStatus'
+      tenant_id:
+        type: string
+      updated_at:
+        type: string
+      user_id:
+        type: string
+      vpc_id:
+        type: string
+    type: object
+  domain.ElasticIPStatus:
+    enum:
+    - allocated
+    - associated
+    - released
+    type: string
+    x-enum-varnames:
+    - EIPStatusAllocated
+    - EIPStatusAssociated
+    - EIPStatusReleased
   domain.Event:
     properties:
       action:
@@ -680,6 +714,10 @@ definitions:
     - vpc:delete
     - vpc:read
     - vpc:update
+    - eip:allocate
+    - eip:release
+    - eip:read
+    - eip:associate
     - volume:create
     - volume:delete
     - volume:read
@@ -749,6 +787,10 @@ definitions:
     - PermissionVpcDelete
     - PermissionVpcRead
     - PermissionVpcUpdate
+    - PermissionEipAllocate
+    - PermissionEipRelease
+    - PermissionEipRead
+    - PermissionEipAssociate
     - PermissionVolumeCreate
     - PermissionVolumeDelete
     - PermissionVolumeRead
@@ -2835,6 +2877,121 @@ paths:
       summary: Create a new DNS record
       tags:
       - dns
+  /elastic-ips:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.ElasticIP'
+            type: array
+      security:
+      - APIKeyAuth: []
+      summary: List Elastic IPs
+      tags:
+      - elastic-ips
+    post:
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.ElasticIP'
+      security:
+      - APIKeyAuth: []
+      summary: Allocate an Elastic IP
+      tags:
+      - elastic-ips
+  /elastic-ips/{id}:
+    delete:
+      parameters:
+      - description: EIP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Release Elastic IP
+      tags:
+      - elastic-ips
+    get:
+      parameters:
+      - description: EIP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.ElasticIP'
+      security:
+      - APIKeyAuth: []
+      summary: Get Elastic IP
+      tags:
+      - elastic-ips
+  /elastic-ips/{id}/associate:
+    post:
+      parameters:
+      - description: EIP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Association Request
+        in: body
+        name: request
+        required: true
+        schema:
+          properties:
+            instance_id:
+              type: string
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.ElasticIP'
+      security:
+      - APIKeyAuth: []
+      summary: Associate Elastic IP
+      tags:
+      - elastic-ips
+  /elastic-ips/{id}/disassociate:
+    post:
+      parameters:
+      - description: EIP ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.ElasticIP'
+      security:
+      - APIKeyAuth: []
+      summary: Disassociate Elastic IP
+      tags:
+      - elastic-ips
   /gateway/routes:
     get:
       description: Gets a list of all registered API gateway routes

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -156,6 +156,7 @@ Adding enterprise capabilities:
 - Multi-node clustering
 - Database replication
 - Security groups
+- Elastic IP Management 🆕
 - Multi-tenancy
 
 ### Phase 11-12: Developer Experience (📋 Planned Q3 2026)

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -60,6 +60,7 @@ type Repositories struct {
 	DNS           ports.DNSRepository
 	InstanceType  ports.InstanceTypeRepository
 	GlobalLB      ports.GlobalLBRepository
+	ElasticIP     ports.ElasticIPRepository
 }
 
 // InitRepositories constructs repositories using the provided database clients.
@@ -99,6 +100,7 @@ func InitRepositories(db postgres.DB, rdb *redisv9.Client) *Repositories {
 		DNS:           postgres.NewDNSRepository(db),
 		InstanceType:  postgres.NewInstanceTypeRepository(db),
 		GlobalLB:      postgres.NewGlobalLBRepository(db),
+		ElasticIP:     postgres.NewElasticIPRepository(db),
 	}
 }
 
@@ -140,6 +142,7 @@ type Services struct {
 	DNS           ports.DNSService
 	InstanceType  ports.InstanceTypeService
 	GlobalLB      ports.GlobalLBService
+	ElasticIP     ports.ElasticIPService
 }
 
 // Workers struct to return background workers
@@ -270,6 +273,7 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 		InstanceType: services.NewInstanceTypeService(c.Repos.InstanceType),
 		GlobalLB:     glbSvc,
 		DNS:          dnsSvc,
+		ElasticIP:    services.NewElasticIPService(c.Repos.ElasticIP, c.Repos.Instance, auditSvc, c.Logger),
 	}
 
 	// 7. High Availability & Monitoring

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -205,7 +205,9 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 	instSvcConcrete := services.NewInstanceService(services.InstanceServiceParams{
 		Repo: c.Repos.Instance, VpcRepo: c.Repos.Vpc, SubnetRepo: c.Repos.Subnet, VolumeRepo: c.Repos.Volume,
 		InstanceTypeRepo: c.Repos.InstanceType,
-		Compute:          c.Compute, Network: c.Network, EventSvc: eventSvc, AuditSvc: auditSvc, DNSSvc: dnsSvc, TaskQueue: c.Repos.TaskQueue, Logger: c.Logger,
+		Compute:          c.Compute, Network: c.Network, EventSvc: eventSvc, AuditSvc: auditSvc, DNSSvc: dnsSvc, TaskQueue: c.Repos.TaskQueue,
+		DockerNetwork: c.Config.DockerDefaultNetwork,
+		Logger:        c.Logger,
 	})
 	sgSvc := services.NewSecurityGroupService(c.Repos.SecurityGroup, c.Repos.Vpc, c.Network, auditSvc, c.Logger)
 

--- a/internal/core/domain/elastic_ip.go
+++ b/internal/core/domain/elastic_ip.go
@@ -1,0 +1,54 @@
+// Package domain defines core business entities.
+package domain
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ElasticIPStatus represents the lifecycle state of an Elastic IP.
+type ElasticIPStatus string
+
+const (
+	// EIPStatusAllocated indicates the IP is reserved by a user but not attached to any resource.
+	EIPStatusAllocated ElasticIPStatus = "allocated"
+
+	// EIPStatusAssociated indicates the IP is currently mapped to a compute instance.
+	EIPStatusAssociated ElasticIPStatus = "associated"
+
+	// EIPStatusReleased indicates the IP has been returned to the pool (soft delete state).
+	EIPStatusReleased ElasticIPStatus = "released"
+)
+
+// ElasticIP represents a static public IP address that can be remapped between instances.
+type ElasticIP struct {
+	ID         uuid.UUID       `json:"id"`
+	UserID     uuid.UUID       `json:"user_id"`
+	TenantID   uuid.UUID       `json:"tenant_id"`
+	PublicIP   string          `json:"public_ip"`
+	InstanceID *uuid.UUID      `json:"instance_id,omitempty"`
+	VpcID      *uuid.UUID      `json:"vpc_id,omitempty"`
+	Status     ElasticIPStatus `json:"status"`
+	ARN        string          `json:"arn"` // arn:thecloud:vpc:{region}:{user}:eip/{id}
+	CreatedAt  time.Time       `json:"created_at"`
+	UpdatedAt  time.Time       `json:"updated_at"`
+}
+
+// Validate checks if the Elastic IP model is valid.
+func (e *ElasticIP) Validate() error {
+	if e.UserID == uuid.Nil {
+		return errors.New("user ID is required")
+	}
+	if e.TenantID == uuid.Nil {
+		return errors.New("tenant ID is required")
+	}
+	if e.PublicIP == "" {
+		return errors.New("public IP address is required")
+	}
+	if e.Status == "" {
+		return errors.New("status is required")
+	}
+	return nil
+}

--- a/internal/core/domain/rbac.go
+++ b/internal/core/domain/rbac.go
@@ -23,6 +23,12 @@ const (
 	PermissionVpcRead   Permission = "vpc:read"
 	PermissionVpcUpdate Permission = "vpc:update"
 
+	// Elastic IP Permissions
+	PermissionEipAllocate  Permission = "eip:allocate"
+	PermissionEipRelease   Permission = "eip:release"
+	PermissionEipRead      Permission = "eip:read"
+	PermissionEipAssociate Permission = "eip:associate"
+
 	// Storage Permissions
 	PermissionVolumeCreate Permission = "volume:create"
 	PermissionVolumeDelete Permission = "volume:delete"

--- a/internal/core/ports/elastic_ip.go
+++ b/internal/core/ports/elastic_ip.go
@@ -1,0 +1,43 @@
+// Package ports defines service and repository interfaces.
+package ports
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+)
+
+// ElasticIPRepository handles the persistence and retrieval of Elastic IP metadata.
+type ElasticIPRepository interface {
+	// Create saves a new Elastic IP record.
+	Create(ctx context.Context, eip *domain.ElasticIP) error
+	// GetByID retrieves an Elastic IP by its unique UUID.
+	GetByID(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error)
+	// GetByPublicIP retrieves an Elastic IP by its public address.
+	GetByPublicIP(ctx context.Context, publicIP string) (*domain.ElasticIP, error)
+	// GetByInstanceID retrieves the Elastic IP associated with a specific instance.
+	GetByInstanceID(ctx context.Context, instanceID uuid.UUID) (*domain.ElasticIP, error)
+	// List returns Elastic IPs authorized for the current operational context.
+	List(ctx context.Context) ([]*domain.ElasticIP, error)
+	// Update modifies an existing Elastic IP's metadata or status.
+	Update(ctx context.Context, eip *domain.ElasticIP) error
+	// Delete removes an Elastic IP record from persistent storage.
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+// ElasticIPService defines the business logic for managing the lifecycle of Elastic IPs.
+type ElasticIPService interface {
+	// AllocateIP reserves a new Elastic IP for the current user.
+	AllocateIP(ctx context.Context) (*domain.ElasticIP, error)
+	// ReleaseIP returns an Elastic IP back to the pool.
+	ReleaseIP(ctx context.Context, id uuid.UUID) error
+	// AssociateIP maps an Elastic IP to a specific compute instance.
+	AssociateIP(ctx context.Context, id uuid.UUID, instanceID uuid.UUID) (*domain.ElasticIP, error)
+	// DisassociateIP removes the mapping between an Elastic IP and an instance.
+	DisassociateIP(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error)
+	// ListElasticIPs returns a slice of all Elastic IPs accessible to the caller.
+	ListElasticIPs(ctx context.Context) ([]*domain.ElasticIP, error)
+	// GetElasticIP retrieves detailed information about a specific Elastic IP.
+	GetElasticIP(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error)
+}

--- a/internal/core/services/elastic_ip.go
+++ b/internal/core/services/elastic_ip.go
@@ -87,7 +87,7 @@ func (s *elasticIPService) ReleaseIP(ctx context.Context, id uuid.UUID) error {
 func (s *elasticIPService) AssociateIP(ctx context.Context, id uuid.UUID, instanceID uuid.UUID) (*domain.ElasticIP, error) {
 	eip, err := s.repo.GetByID(ctx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// 1. Check if instance exists and is not terminated
@@ -126,7 +126,7 @@ func (s *elasticIPService) AssociateIP(ctx context.Context, id uuid.UUID, instan
 func (s *elasticIPService) DisassociateIP(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error) {
 	eip, err := s.repo.GetByID(ctx, id)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if eip.Status != domain.EIPStatusAssociated {

--- a/internal/core/services/elastic_ip.go
+++ b/internal/core/services/elastic_ip.go
@@ -1,0 +1,168 @@
+// Package services implements core business logic.
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
+)
+
+type elasticIPService struct {
+	repo         ports.ElasticIPRepository
+	instanceRepo ports.InstanceRepository
+	auditSvc     ports.AuditService
+	logger       *slog.Logger
+}
+
+// NewElasticIPService constructs an ElasticIPService.
+func NewElasticIPService(repo ports.ElasticIPRepository, instanceRepo ports.InstanceRepository, auditSvc ports.AuditService, logger *slog.Logger) ports.ElasticIPService {
+	return &elasticIPService{
+		repo:         repo,
+		instanceRepo: instanceRepo,
+		auditSvc:     auditSvc,
+		logger:       logger,
+	}
+}
+
+func (s *elasticIPService) AllocateIP(ctx context.Context) (*domain.ElasticIP, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	id := uuid.New()
+
+	// Simulate public IP allocation from CGNAT range 100.64.0.0/10 for demo/simulation
+	// In a real system, this would come from an IP pool manager or provider SDK
+	publicIP := s.generateDeterministicIP(id)
+
+	eip := &domain.ElasticIP{
+		ID:        id,
+		UserID:    userID,
+		TenantID:  tenantID,
+		PublicIP:  publicIP,
+		Status:    domain.EIPStatusAllocated,
+		ARN:       fmt.Sprintf("arn:thecloud:vpc:local:%s:eip/%s", userID, id),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if err := s.repo.Create(ctx, eip); err != nil {
+		return nil, err
+	}
+
+	_ = s.auditSvc.Log(ctx, userID, "eip.allocate", "eip", id.String(), map[string]interface{}{
+		"public_ip": publicIP,
+	})
+
+	return eip, nil
+}
+
+func (s *elasticIPService) ReleaseIP(ctx context.Context, id uuid.UUID) error {
+	eip, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if eip.Status == domain.EIPStatusAssociated {
+		return errors.New(errors.Conflict, "cannot release an associated elastic ip; disassociate it first")
+	}
+
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return err
+	}
+
+	_ = s.auditSvc.Log(ctx, eip.UserID, "eip.release", "eip", id.String(), map[string]interface{}{
+		"public_ip": eip.PublicIP,
+	})
+
+	return nil
+}
+
+func (s *elasticIPService) AssociateIP(ctx context.Context, id uuid.UUID, instanceID uuid.UUID) (*domain.ElasticIP, error) {
+	eip, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	// 1. Check if instance exists and is not terminated
+	inst, err := s.instanceRepo.GetByID(ctx, instanceID)
+	if err != nil {
+		return nil, err
+	}
+	if inst.Status == domain.StatusDeleted {
+		return nil, errors.New(errors.InvalidInput, "cannot associate ip to a deleted instance")
+	}
+
+	// 2. Check if instance already has an EIP
+	existing, _ := s.repo.GetByInstanceID(ctx, instanceID)
+	if existing != nil && existing.ID != id {
+		return nil, errors.New(errors.Conflict, "instance already has an associated elastic ip")
+	}
+
+	// 3. Update EIP mapping
+	eip.InstanceID = &instanceID
+	eip.VpcID = inst.VpcID
+	eip.Status = domain.EIPStatusAssociated
+	eip.UpdatedAt = time.Now()
+
+	if err := s.repo.Update(ctx, eip); err != nil {
+		return nil, err
+	}
+
+	_ = s.auditSvc.Log(ctx, eip.UserID, "eip.associate", "eip", id.String(), map[string]interface{}{
+		"instance_id": instanceID,
+		"public_ip":   eip.PublicIP,
+	})
+
+	return eip, nil
+}
+
+func (s *elasticIPService) DisassociateIP(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error) {
+	eip, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if eip.Status != domain.EIPStatusAssociated {
+		return nil, errors.New(errors.InvalidInput, "elastic ip is not associated")
+	}
+
+	oldInstanceID := eip.InstanceID
+
+	eip.InstanceID = nil
+	eip.VpcID = nil
+	eip.Status = domain.EIPStatusAllocated
+	eip.UpdatedAt = time.Now()
+
+	if err := s.repo.Update(ctx, eip); err != nil {
+		return nil, err
+	}
+
+	_ = s.auditSvc.Log(ctx, eip.UserID, "eip.disassociate", "eip", id.String(), map[string]interface{}{
+		"instance_id": oldInstanceID,
+		"public_ip":   eip.PublicIP,
+	})
+
+	return eip, nil
+}
+
+func (s *elasticIPService) ListElasticIPs(ctx context.Context) ([]*domain.ElasticIP, error) {
+	return s.repo.List(ctx)
+}
+
+func (s *elasticIPService) GetElasticIP(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error) {
+	return s.repo.GetByID(ctx, id)
+}
+
+// generateDeterministicIP creates a consistent "public" IP for a given UUID within the 100.64.0.0/10 range.
+func (s *elasticIPService) generateDeterministicIP(u uuid.UUID) string {
+	// 100.64.0.0 + bytes 12-15 of UUID
+	ip := net.IPv4(100, 64+u[12]%64, u[13], u[14])
+	return ip.String()
+}

--- a/internal/core/services/elastic_ip_test.go
+++ b/internal/core/services/elastic_ip_test.go
@@ -1,0 +1,102 @@
+package services_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/poyrazk/thecloud/internal/repositories/postgres"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupElasticIPServiceTest(t *testing.T) (ports.ElasticIPService, ports.ElasticIPRepository, ports.InstanceRepository, context.Context) {
+	db := setupDB(t)
+	cleanDB(t, db)
+	ctx := setupTestUser(t, db)
+
+	eipRepo := postgres.NewElasticIPRepository(db)
+	instRepo := postgres.NewInstanceRepository(db)
+	auditRepo := postgres.NewAuditRepository(db)
+	auditSvc := services.NewAuditService(auditRepo)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	svc := services.NewElasticIPService(eipRepo, instRepo, auditSvc, logger)
+	return svc, eipRepo, instRepo, ctx
+}
+
+func TestElasticIPAllocateSuccess(t *testing.T) {
+	svc, repo, _, ctx := setupElasticIPServiceTest(t)
+
+	eip, err := svc.AllocateIP(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, eip)
+	assert.Equal(t, domain.EIPStatusAllocated, eip.Status)
+	assert.NotEmpty(t, eip.PublicIP)
+
+	// Verify in DB
+	fetched, err := repo.GetByID(ctx, eip.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, eip.ID, fetched.ID)
+}
+
+func TestElasticIPAssociateSuccess(t *testing.T) {
+	svc, _, instRepo, ctx := setupElasticIPServiceTest(t)
+
+	// 1. Setup instance
+	inst := &domain.Instance{
+		ID:        uuid.New(),
+		UserID:    appcontext.UserIDFromContext(ctx),
+		TenantID:  appcontext.TenantIDFromContext(ctx),
+		Name:      "test-instance",
+		Status:    domain.StatusRunning,
+		CreatedAt: time.Now(),
+	}
+	err := instRepo.Create(ctx, inst)
+	require.NoError(t, err)
+
+	// 2. Allocate EIP
+	eip, err := svc.AllocateIP(ctx)
+	require.NoError(t, err)
+
+	// 3. Associate
+	associated, err := svc.AssociateIP(ctx, eip.ID, inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.EIPStatusAssociated, associated.Status)
+	assert.Equal(t, &inst.ID, associated.InstanceID)
+
+	// 4. Disassociate
+	disassociated, err := svc.DisassociateIP(ctx, eip.ID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.EIPStatusAllocated, disassociated.Status)
+	assert.Nil(t, disassociated.InstanceID)
+}
+
+func TestElasticIPReleaseFailureAssociated(t *testing.T) {
+	svc, _, instRepo, ctx := setupElasticIPServiceTest(t)
+
+	inst := &domain.Instance{
+		ID:        uuid.New(),
+		UserID:    appcontext.UserIDFromContext(ctx),
+		TenantID:  appcontext.TenantIDFromContext(ctx),
+		Name:      "test",
+		Status:    domain.StatusRunning,
+		CreatedAt: time.Now(),
+	}
+	_ = instRepo.Create(ctx, inst)
+
+	eip, _ := svc.AllocateIP(ctx)
+	_, _ = svc.AssociateIP(ctx, eip.ID, inst.ID)
+
+	// Should fail release because associated
+	err := svc.ReleaseIP(ctx, eip.ID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "disassociate it first")
+}

--- a/internal/core/services/elastic_ip_test.go
+++ b/internal/core/services/elastic_ip_test.go
@@ -100,3 +100,33 @@ func TestElasticIPReleaseFailureAssociated(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "disassociate it first")
 }
+
+func TestElasticIPReleaseSuccess(t *testing.T) {
+	svc, repo, _, ctx := setupElasticIPServiceTest(t)
+	eip, _ := svc.AllocateIP(ctx)
+
+	err := svc.ReleaseIP(ctx, eip.ID)
+	assert.NoError(t, err)
+
+	_, err = repo.GetByID(ctx, eip.ID)
+	assert.Error(t, err)
+}
+
+func TestElasticIPListSuccess(t *testing.T) {
+	svc, _, _, ctx := setupElasticIPServiceTest(t)
+	_, _ = svc.AllocateIP(ctx)
+	_, _ = svc.AllocateIP(ctx)
+
+	eips, err := svc.ListElasticIPs(ctx)
+	assert.NoError(t, err)
+	assert.Len(t, eips, 2)
+}
+
+func TestElasticIPGetSuccess(t *testing.T) {
+	svc, _, _, ctx := setupElasticIPServiceTest(t)
+	eip, _ := svc.AllocateIP(ctx)
+
+	fetched, err := svc.GetElasticIP(ctx, eip.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, eip.ID, fetched.ID)
+}

--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -40,6 +40,7 @@ type InstanceService struct {
 	auditSvc         ports.AuditService
 	dnsSvc           ports.DNSService
 	taskQueue        ports.TaskQueue
+	dockerNetwork    string
 	logger           *slog.Logger
 }
 
@@ -57,6 +58,7 @@ type InstanceServiceParams struct {
 	AuditSvc         ports.AuditService
 	DNSSvc           ports.DNSService
 	TaskQueue        ports.TaskQueue // Optional
+	DockerNetwork    string          // Optional
 	Logger           *slog.Logger
 }
 
@@ -74,6 +76,7 @@ func NewInstanceService(params InstanceServiceParams) *InstanceService {
 		auditSvc:         params.AuditSvc,
 		dnsSvc:           params.DNSSvc,
 		taskQueue:        params.TaskQueue,
+		dockerNetwork:    params.DockerNetwork,
 		logger:           params.Logger,
 	}
 }
@@ -788,6 +791,9 @@ func (s *InstanceService) resolveNetworkConfig(ctx context.Context, vpcID, subne
 	// because 'br-vpc-xxx' OVS bridge doesn't exist as a Docker network.
 	if s.compute.Type() == "docker" {
 		networkID = "cloud-network"
+		if s.dockerNetwork != "" {
+			networkID = s.dockerNetwork
+		}
 
 		// If no subnet is configured, we let the backend assign an IP (dynamic).
 		// We return empty string here, and LaunchInstance should fetch the real IP later.

--- a/internal/core/services/instance_test.go
+++ b/internal/core/services/instance_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -128,7 +129,11 @@ func TestLaunchInstanceSuccess(t *testing.T) {
 	_, svc, compute, repo, _, _, ctx := setupInstanceServiceTest(t)
 	name := "test-inst-launch"
 	image := testImage
-	portsStr := "8888:80"
+	testPort := os.Getenv("TEST_INSTANCE_PORT")
+	if testPort == "" {
+		testPort = "8888"
+	}
+	portsStr := fmt.Sprintf("%s:80", testPort)
 
 	// 1. Launch (Enqueue)
 	inst, err := svc.LaunchInstance(ctx, coreports.LaunchParams{

--- a/internal/core/services/instance_test.go
+++ b/internal/core/services/instance_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/repositories/docker"
 	"github.com/poyrazk/thecloud/internal/repositories/noop"
 	"github.com/poyrazk/thecloud/internal/repositories/postgres"
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,10 +78,10 @@ func setupInstanceServiceTest(t *testing.T) (*pgxpool.Pool, *services.InstanceSe
 	compute, err := docker.NewDockerAdapter(slog.Default())
 	require.NoError(t, err)
 
-	// In integration tests, we frequently rely on a shared Docker network named 'cloud-network'.
+	// In integration tests, we frequently rely on a shared Docker network.
 	// We ensure it exists here so that Provisioning (which uses it as a fallback) succeeds.
 	if compute.Type() == "docker" {
-		_, _ = compute.CreateNetwork(ctx, "cloud-network")
+		_, _ = compute.CreateNetwork(ctx, testutil.TestDockerNetwork)
 		// Pre-pull test image to prevent flakes in CI environments with slow registries or restrictive daemons
 		_, _ = compute.LaunchInstanceWithOptions(ctx, coreports.CreateInstanceOptions{
 			Name:      "pre-pull-image",

--- a/internal/core/services/setup_test.go
+++ b/internal/core/services/setup_test.go
@@ -111,6 +111,7 @@ func cleanDB(t *testing.T, db *pgxpool.Pool) {
 		"deployments",
 		"global_lb_endpoints",
 		"global_load_balancers",
+		"elastic_ips",
 	}
 
 	for _, table := range tables {

--- a/internal/handlers/elastic_ip_handler.go
+++ b/internal/handlers/elastic_ip_handler.go
@@ -1,0 +1,154 @@
+// Package httphandlers provides HTTP handlers for the API.
+package httphandlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
+	"github.com/poyrazk/thecloud/pkg/httputil"
+)
+
+// ElasticIPHandler handles HTTP requests for Elastic IPs.
+type ElasticIPHandler struct {
+	svc ports.ElasticIPService
+}
+
+// NewElasticIPHandler creates a new ElasticIPHandler.
+func NewElasticIPHandler(svc ports.ElasticIPService) *ElasticIPHandler {
+	return &ElasticIPHandler{svc: svc}
+}
+
+// Allocate reserves a new Elastic IP.
+// @Summary Allocate an Elastic IP
+// @Tags elastic-ips
+// @Security APIKeyAuth
+// @Produce json
+// @Success 201 {object} domain.ElasticIP
+// @Router /elastic-ips [post]
+func (h *ElasticIPHandler) Allocate(c *gin.Context) {
+	eip, err := h.svc.AllocateIP(c.Request.Context())
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusCreated, eip)
+}
+
+// List returns all Elastic IPs for the tenant.
+// @Summary List Elastic IPs
+// @Tags elastic-ips
+// @Security APIKeyAuth
+// @Produce json
+// @Success 200 {array} domain.ElasticIP
+// @Router /elastic-ips [get]
+func (h *ElasticIPHandler) List(c *gin.Context) {
+	eips, err := h.svc.ListElasticIPs(c.Request.Context())
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, eips)
+}
+
+// Get retrieves a specific Elastic IP.
+// @Summary Get Elastic IP
+// @Tags elastic-ips
+// @Security APIKeyAuth
+// @Param id path string true "EIP ID"
+// @Produce json
+// @Success 200 {object} domain.ElasticIP
+// @Router /elastic-ips/{id} [get]
+func (h *ElasticIPHandler) Get(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid elastic ip id"))
+		return
+	}
+
+	eip, err := h.svc.GetElasticIP(c.Request.Context(), id)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, eip)
+}
+
+// Release returns an Elastic IP to the pool.
+// @Summary Release Elastic IP
+// @Tags elastic-ips
+// @Security APIKeyAuth
+// @Param id path string true "EIP ID"
+// @Success 200 {object} httputil.Response
+// @Router /elastic-ips/{id} [delete]
+func (h *ElasticIPHandler) Release(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid elastic ip id"))
+		return
+	}
+
+	if err := h.svc.ReleaseIP(c.Request.Context(), id); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, gin.H{"message": "elastic ip released"})
+}
+
+// Associate maps an Elastic IP to an instance.
+// @Summary Associate Elastic IP
+// @Tags elastic-ips
+// @Security APIKeyAuth
+// @Param id path string true "EIP ID"
+// @Param request body object{instance_id=string} true "Association Request"
+// @Produce json
+// @Success 200 {object} domain.ElasticIP
+// @Router /elastic-ips/{id}/associate [post]
+func (h *ElasticIPHandler) Associate(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid elastic ip id"))
+		return
+	}
+
+	var req struct {
+		InstanceID string `json:"instance_id" binding:"required,uuid"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid instance_id"))
+		return
+	}
+
+	instID := uuid.MustParse(req.InstanceID)
+	eip, err := h.svc.AssociateIP(c.Request.Context(), id, instID)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, eip)
+}
+
+// Disassociate removes an Elastic IP mapping.
+// @Summary Disassociate Elastic IP
+// @Tags elastic-ips
+// @Security APIKeyAuth
+// @Param id path string true "EIP ID"
+// @Produce json
+// @Success 200 {object} domain.ElasticIP
+// @Router /elastic-ips/{id}/disassociate [post]
+func (h *ElasticIPHandler) Disassociate(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid elastic ip id"))
+		return
+	}
+
+	eip, err := h.svc.DisassociateIP(c.Request.Context(), id)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, eip)
+}

--- a/internal/handlers/elastic_ip_handler_test.go
+++ b/internal/handlers/elastic_ip_handler_test.go
@@ -1,0 +1,116 @@
+package httphandlers
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+type mockElasticIPService struct {
+	mock.Mock
+}
+
+func (m *mockElasticIPService) AllocateIP(ctx context.Context) (*domain.ElasticIP, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.ElasticIP), args.Error(1)
+}
+
+func (m *mockElasticIPService) ReleaseIP(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *mockElasticIPService) AssociateIP(ctx context.Context, id uuid.UUID, instanceID uuid.UUID) (*domain.ElasticIP, error) {
+	args := m.Called(ctx, id, instanceID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.ElasticIP), args.Error(1)
+}
+
+func (m *mockElasticIPService) DisassociateIP(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.ElasticIP), args.Error(1)
+}
+
+func (m *mockElasticIPService) ListElasticIPs(ctx context.Context) ([]*domain.ElasticIP, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.ElasticIP), args.Error(1)
+}
+
+func (m *mockElasticIPService) GetElasticIP(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.ElasticIP), args.Error(1)
+}
+
+func setupElasticIPHandlerTest() (*mockElasticIPService, *ElasticIPHandler, *gin.Engine) {
+	gin.SetMode(gin.TestMode)
+	svc := new(mockElasticIPService)
+	handler := NewElasticIPHandler(svc)
+	r := gin.New()
+	return svc, handler, r
+}
+
+func TestElasticIPHandlerAllocate(t *testing.T) {
+	svc, handler, r := setupElasticIPHandlerTest()
+	r.POST("/elastic-ips", handler.Allocate)
+
+	eip := &domain.ElasticIP{ID: uuid.New(), PublicIP: "1.2.3.4"}
+	svc.On("AllocateIP", mock.Anything).Return(eip, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/elastic-ips", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestElasticIPHandlerList(t *testing.T) {
+	svc, handler, r := setupElasticIPHandlerTest()
+	r.GET("/elastic-ips", handler.List)
+
+	svc.On("ListElasticIPs", mock.Anything).Return([]*domain.ElasticIP{}, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/elastic-ips", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestElasticIPHandlerAssociate(t *testing.T) {
+	svc, handler, r := setupElasticIPHandlerTest()
+	r.POST("/elastic-ips/:id/associate", handler.Associate)
+
+	eipID := uuid.New()
+	instID := uuid.New()
+	svc.On("AssociateIP", mock.Anything, eipID, instID).Return(&domain.ElasticIP{}, nil)
+
+	body, _ := json.Marshal(map[string]string{"instance_id": instID.String()})
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/elastic-ips/"+eipID.String()+"/associate", bytes.NewBuffer(body))
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -26,13 +26,14 @@ type Config struct {
 	RateLimitAuth        string
 	StorageBackend       string
 	// StorageSecret is the secret key used for signing presigned URLs
-	StorageSecret      string
-	LvmVgName          string
-	ObjectStorageMode  string
-	ObjectStorageNodes string
-	PowerDNSAPIURL     string
-	PowerDNSAPIKey     string
-	PowerDNSServerID   string
+	StorageSecret        string
+	LvmVgName            string
+	ObjectStorageMode    string
+	ObjectStorageNodes   string
+	PowerDNSAPIURL       string
+	PowerDNSAPIKey       string
+	PowerDNSServerID     string
+	DockerDefaultNetwork string
 }
 
 // NewConfig loads configuration from the environment with defaults.
@@ -60,10 +61,11 @@ func NewConfig() (*Config, error) {
 		LvmVgName:            getEnv("LVM_VG_NAME", "thecloud-vg"),
 		ObjectStorageMode:    getEnv("OBJECT_STORAGE_MODE", "local"),
 
-		ObjectStorageNodes: getEnv("OBJECT_STORAGE_NODES", ""),
-		PowerDNSAPIURL:     getEnv("POWERDNS_API_URL", "http://localhost:8081"),
-		PowerDNSAPIKey:     getEnv("POWERDNS_API_KEY", "thecloud-dns-secret"),
-		PowerDNSServerID:   getEnv("POWERDNS_SERVER_ID", "localhost"),
+		ObjectStorageNodes:   getEnv("OBJECT_STORAGE_NODES", ""),
+		PowerDNSAPIURL:       getEnv("POWERDNS_API_URL", "http://localhost:8081"),
+		PowerDNSAPIKey:       getEnv("POWERDNS_API_KEY", "thecloud-dns-secret"),
+		PowerDNSServerID:     getEnv("POWERDNS_SERVER_ID", "localhost"),
+		DockerDefaultNetwork: getEnv("DOCKER_DEFAULT_NETWORK", "cloud-network"),
 	}, nil
 }
 

--- a/internal/repositories/postgres/elastic_ip_repo.go
+++ b/internal/repositories/postgres/elastic_ip_repo.go
@@ -1,0 +1,152 @@
+// Package postgres provides PostgreSQL-backed repository implementations.
+package postgres
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/errors"
+)
+
+// ElasticIPRepository provides a PostgreSQL implementation for managing Elastic IP metadata.
+type ElasticIPRepository struct {
+	db DB
+}
+
+// NewElasticIPRepository creates a new ElasticIPRepository with the given database pool.
+func NewElasticIPRepository(db DB) *ElasticIPRepository {
+	return &ElasticIPRepository{db: db}
+}
+
+// Create inserts a new Elastic IP record into the database.
+func (r *ElasticIPRepository) Create(ctx context.Context, eip *domain.ElasticIP) error {
+	query := `
+		INSERT INTO elastic_ips (id, user_id, tenant_id, public_ip, instance_id, vpc_id, status, arn, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	`
+	_, err := r.db.Exec(ctx, query,
+		eip.ID, eip.UserID, eip.TenantID, eip.PublicIP,
+		eip.InstanceID, eip.VpcID, eip.Status, eip.ARN,
+		eip.CreatedAt, eip.UpdatedAt,
+	)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to create elastic ip", err)
+	}
+	return nil
+}
+
+// GetByID retrieves a single Elastic IP by its UUID.
+func (r *ElasticIPRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		SELECT id, user_id, tenant_id, public_ip, instance_id, vpc_id, status, arn, created_at, updated_at 
+		FROM elastic_ips 
+		WHERE id = $1 AND tenant_id = $2
+	`
+	return r.scanElasticIP(r.db.QueryRow(ctx, query, id, tenantID))
+}
+
+// GetByPublicIP retrieves a single Elastic IP by its public address.
+func (r *ElasticIPRepository) GetByPublicIP(ctx context.Context, publicIP string) (*domain.ElasticIP, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		SELECT id, user_id, tenant_id, public_ip, instance_id, vpc_id, status, arn, created_at, updated_at 
+		FROM elastic_ips 
+		WHERE public_ip = $1 AND tenant_id = $2
+	`
+	return r.scanElasticIP(r.db.QueryRow(ctx, query, publicIP, tenantID))
+}
+
+// GetByInstanceID retrieves the Elastic IP associated with a specific instance.
+func (r *ElasticIPRepository) GetByInstanceID(ctx context.Context, instanceID uuid.UUID) (*domain.ElasticIP, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		SELECT id, user_id, tenant_id, public_ip, instance_id, vpc_id, status, arn, created_at, updated_at 
+		FROM elastic_ips 
+		WHERE instance_id = $1 AND tenant_id = $2
+	`
+	return r.scanElasticIP(r.db.QueryRow(ctx, query, instanceID, tenantID))
+}
+
+// List returns all Elastic IPs belonging to the authenticated tenant.
+func (r *ElasticIPRepository) List(ctx context.Context) ([]*domain.ElasticIP, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		SELECT id, user_id, tenant_id, public_ip, instance_id, vpc_id, status, arn, created_at, updated_at 
+		FROM elastic_ips 
+		WHERE tenant_id = $1 
+		ORDER BY created_at DESC
+	`
+	rows, err := r.db.Query(ctx, query, tenantID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list elastic ips", err)
+	}
+	return r.scanElasticIPs(rows)
+}
+
+// Update modifies an existing Elastic IP's metadata or status.
+func (r *ElasticIPRepository) Update(ctx context.Context, eip *domain.ElasticIP) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		UPDATE elastic_ips 
+		SET instance_id = $1, vpc_id = $2, status = $3, updated_at = $4 
+		WHERE id = $5 AND tenant_id = $6
+	`
+	cmd, err := r.db.Exec(ctx, query,
+		eip.InstanceID, eip.VpcID, eip.Status, eip.UpdatedAt,
+		eip.ID, tenantID,
+	)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to update elastic ip", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "elastic ip not found")
+	}
+	return nil
+}
+
+// Delete removes an Elastic IP record from the database.
+func (r *ElasticIPRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `DELETE FROM elastic_ips WHERE id = $1 AND tenant_id = $2`
+	cmd, err := r.db.Exec(ctx, query, id, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to delete elastic ip", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "elastic ip not found")
+	}
+	return nil
+}
+
+func (r *ElasticIPRepository) scanElasticIP(row pgx.Row) (*domain.ElasticIP, error) {
+	var eip domain.ElasticIP
+	err := row.Scan(
+		&eip.ID, &eip.UserID, &eip.TenantID, &eip.PublicIP,
+		&eip.InstanceID, &eip.VpcID, &eip.Status, &eip.ARN,
+		&eip.CreatedAt, &eip.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return nil, errors.New(errors.NotFound, "elastic ip not found")
+		}
+		return nil, errors.Wrap(errors.Internal, "failed to scan elastic ip", err)
+	}
+	return &eip, nil
+}
+
+func (r *ElasticIPRepository) scanElasticIPs(rows pgx.Rows) ([]*domain.ElasticIP, error) {
+	defer rows.Close()
+	var eips []*domain.ElasticIP
+	for rows.Next() {
+		eip, err := r.scanElasticIP(rows)
+		if err != nil {
+			return nil, err
+		}
+		eips = append(eips, eip)
+	}
+	return eips, nil
+}

--- a/internal/repositories/postgres/migrations/060_create_elastic_ips.down.sql
+++ b/internal/repositories/postgres/migrations/060_create_elastic_ips.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_elastic_ips_instance_unique;
+DROP INDEX IF EXISTS idx_elastic_ips_instance_id;
+DROP INDEX IF EXISTS idx_elastic_ips_tenant_id;
+DROP TABLE IF EXISTS elastic_ips;

--- a/internal/repositories/postgres/migrations/060_create_elastic_ips.up.sql
+++ b/internal/repositories/postgres/migrations/060_create_elastic_ips.up.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS elastic_ips (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id),
+    tenant_id UUID NOT NULL,
+    public_ip VARCHAR(45) NOT NULL UNIQUE,
+    instance_id UUID REFERENCES instances(id) ON DELETE SET NULL,
+    vpc_id UUID REFERENCES vpcs(id) ON DELETE SET NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'allocated',
+    arn VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Optimization indexes
+CREATE INDEX idx_elastic_ips_tenant_id ON elastic_ips(tenant_id);
+CREATE INDEX idx_elastic_ips_instance_id ON elastic_ips(instance_id);
+
+-- Business rule: An instance can have at most one Elastic IP
+CREATE UNIQUE INDEX idx_elastic_ips_instance_unique 
+    ON elastic_ips(instance_id) 
+    WHERE instance_id IS NOT NULL;

--- a/pkg/testutil/constants.go
+++ b/pkg/testutil/constants.go
@@ -107,4 +107,6 @@ var (
 	TestRouteDNSRecords = "/dns/records"
 	// TestRouteFormat is the default template for specific resource routes.
 	TestRouteFormat = "%s%s/%s"
+	// TestDockerNetwork is the name of the Docker network used in tests.
+	TestDockerNetwork = getEnvVar("TEST_DOCKER_NETWORK", "cloud-network")
 )

--- a/pkg/testutil/constants.go
+++ b/pkg/testutil/constants.go
@@ -1,7 +1,18 @@
 // Package testutil provides shared constants and helpers for testing.
 package testutil
 
-const (
+import (
+	"os"
+)
+
+func getEnvVar(key, fallback string) string {
+	if val := os.Getenv(key); val != "" {
+		return val
+	}
+	return fallback
+}
+
+var (
 	// TestIPLocalhost is the loopback address used in tests.
 	TestIPLocalhost = "127.0.0.1"
 	// TestIPHost is a sample host IP used in tests.
@@ -57,14 +68,14 @@ const (
 	TestEmail = "test@example.com"
 	// TestUserAgent is a sample user agent string.
 	TestUserAgent = "test-agent"
-	// TestBaseURL is a sample API base URL.
-	TestBaseURL = "http://localhost:8080"
+	// TestBaseURL is the API base URL used in tests.
+	TestBaseURL = getEnvVar("TEST_BASE_URL", "http://localhost:8080")
 	// TestHeaderAPIKey is the header name used for API keys.
 	TestHeaderAPIKey = "X-API-Key"
 	// TestContentTypeAppJSON is the JSON content type used in tests.
 	TestContentTypeAppJSON = "application/json"
-	// TestDatabaseURL is a sample local database URL.
-	TestDatabaseURL = "postgres://cloud:cloud@localhost:5433/thecloud"
+	// TestDatabaseURL is the local database URL used in tests.
+	TestDatabaseURL = getEnvVar("TEST_DATABASE_URL", "postgres://cloud:cloud@localhost:5433/thecloud")
 	// TestProdDatabaseURL is a sample production database URL.
 	TestProdDatabaseURL = "postgres://test:test@localhost:5432/testdb"
 	// TestEnvDev is the development environment name.
@@ -72,9 +83,9 @@ const (
 	// TestEnvProd is the production environment name.
 	TestEnvProd = "production"
 	// TestPort is a default port used in tests.
-	TestPort = "8080"
+	TestPort = getEnvVar("TEST_PORT", "8080")
 	// TestProdPort is a production port used in tests.
-	TestProdPort = "9090"
+	TestProdPort = getEnvVar("TEST_PROD_PORT", "9090")
 	// TestCacheID is a default cache ID used in tests.
 	TestCacheID = "cache-1"
 	// TestQueueID is a default queue ID used in tests.

--- a/pkg/testutil/container.go
+++ b/pkg/testutil/container.go
@@ -36,7 +36,7 @@ func SetupPostgresContainer(t *testing.T) (*PostgresContainer, func()) {
 		testcontainers.WithWaitStrategy(
 			wait.ForLog("database system is ready to accept connections").
 				WithOccurrence(2).
-				WithStartupTimeout(10*time.Second)),
+				WithStartupTimeout(60*time.Second)),
 	)
 	if err != nil {
 		t.Fatalf("failed to start postgres container: %v", err)

--- a/tests/chaos_test.go
+++ b/tests/chaos_test.go
@@ -32,14 +32,14 @@ func TestChaos(t *testing.T) {
 
 		// 2. Kill Redis
 		t.Log("Killing Redis container...")
-		cmd := exec.Command("docker", "stop", "cloud-redis")
+		cmd := exec.Command("docker", "compose", "stop", "redis")
 		err := cmd.Run()
 		require.NoError(t, err, "Failed to stop Redis container")
 
 		// Ensure Redis is stopped
 		defer func() {
 			t.Log("Restarting Redis container...")
-			_ = exec.Command("docker", "start", "cloud-redis").Run()
+			_ = exec.Command("docker", "compose", "start", "redis").Run()
 			// Wait for Redis to be ready again
 			time.Sleep(2 * time.Second)
 		}()
@@ -85,7 +85,7 @@ func TestChaos(t *testing.T) {
 
 		// 2. Sudden Restart
 		t.Log("Restarting API container mid-operation...")
-		cmd := exec.Command("docker", "restart", "thecloud-api-1")
+		cmd := exec.Command("docker", "compose", "restart", "api")
 		err := cmd.Run()
 		require.NoError(t, err, "Failed to restart API container")
 

--- a/tests/elastic_ip_e2e_test.go
+++ b/tests/elastic_ip_e2e_test.go
@@ -1,0 +1,150 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/pkg/testutil"
+)
+
+func TestElasticIPE2E(t *testing.T) {
+	t.Parallel()
+	if err := waitForServer(); err != nil {
+		t.Fatalf("Failing Elastic IP E2E test: %v", err)
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	token := registerAndLogin(t, client, "eip-tester@thecloud.local", "EIP Tester")
+
+	var eipID string
+	var publicIP string
+
+	// 1. Allocate Elastic IP
+	t.Run("AllocateIP", func(t *testing.T) {
+		resp := postRequest(t, client, testutil.TestBaseURL+"/elastic-ips", token, nil)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		var res struct {
+			Data domain.ElasticIP `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		eipID = res.Data.ID.String()
+		publicIP = res.Data.PublicIP
+		assert.NotEmpty(t, eipID)
+		assert.NotEmpty(t, publicIP)
+		assert.Equal(t, domain.EIPStatusAllocated, res.Data.Status)
+	})
+
+	// 2. List Elastic IPs
+	t.Run("ListIPs", func(t *testing.T) {
+		resp := getRequest(t, client, testutil.TestBaseURL+"/elastic-ips", token)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var res struct {
+			Data []domain.ElasticIP `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+
+		found := false
+		for _, eip := range res.Data {
+			if eip.ID.String() == eipID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "allocated EIP not found in list")
+	})
+
+	// 3. Get Elastic IP
+	t.Run("GetIP", func(t *testing.T) {
+		resp := getRequest(t, client, testutil.TestBaseURL+"/elastic-ips/"+eipID, token)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var res struct {
+			Data domain.ElasticIP `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		assert.Equal(t, eipID, res.Data.ID.String())
+	})
+
+	// 4. Launch Instance and Associate
+	t.Run("AssociateIP", func(t *testing.T) {
+		// Launch instance
+		instanceName := fmt.Sprintf("eip-inst-%d-%s", time.Now().UnixNano()%1000, uuid.New().String()[:8])
+		payload := map[string]string{
+			"name":  instanceName,
+			"image": "nginx:alpine",
+		}
+		resp := postRequest(t, client, testutil.TestBaseURL+testutil.TestRouteInstances, token, payload)
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode != http.StatusAccepted {
+			t.Skip("Skipping association test: failed to launch instance (Docker might be unavailable)")
+			return
+		}
+
+		var instRes struct {
+			Data struct {
+				ID string `json:"id"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&instRes))
+		instanceID := instRes.Data.ID
+
+		// Wait briefly for instance record to be available (E2E async launch)
+		time.Sleep(2 * time.Second)
+
+		// Associate EIP
+		assocPayload := map[string]string{
+			"instance_id": instanceID,
+		}
+		resp = postRequest(t, client, testutil.TestBaseURL+"/elastic-ips/"+eipID+"/associate", token, assocPayload)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var eipRes struct {
+			Data domain.ElasticIP `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&eipRes))
+		assert.Equal(t, domain.EIPStatusAssociated, eipRes.Data.Status)
+		require.NotNil(t, eipRes.Data.InstanceID)
+		assert.Equal(t, instanceID, eipRes.Data.InstanceID.String())
+
+		// Disassociate
+		resp = postRequest(t, client, testutil.TestBaseURL+"/elastic-ips/"+eipID+"/disassociate", token, nil)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Cleanup: terminate instance
+		termResp := deleteRequest(t, client, testutil.TestBaseURL+testutil.TestRouteInstances+"/"+instanceID, token)
+		_ = termResp.Body.Close()
+	})
+
+	// 5. Release Elastic IP
+	t.Run("ReleaseIP", func(t *testing.T) {
+		resp := deleteRequest(t, client, testutil.TestBaseURL+"/elastic-ips/"+eipID, token)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Verify deleted
+		resp = getRequest(t, client, testutil.TestBaseURL+"/elastic-ips/"+eipID, token)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+}

--- a/tests/helpers/helpers_test.go
+++ b/tests/helpers/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -96,10 +97,10 @@ func TestSendWithContentType(t *testing.T) {
 
 func TestGetBaseURL(t *testing.T) {
 	url := GetBaseURL()
-	assert.Equal(t, "http://localhost:8080", url)
+	assert.Equal(t, testutil.TestBaseURL, url)
 }
 
 func TestFormatURL(t *testing.T) {
 	url := FormatURL("/users")
-	assert.Equal(t, "http://localhost:8080/users", url)
+	assert.Equal(t, testutil.TestBaseURL+"/users", url)
 }


### PR DESCRIPTION
This PR introduces several changes to improve test reliability and isolation:
- Parameterized ports in docker-compose.yml (REDIS_PORT, POWERDNS_PORT, DNS_PORT) and removed hardcoded container names to allow multiple concurrent infrastructure runs.
- Updated pkg/testutil/constants.go to support environment variable overrides for test URLs and ports.
- Fixed port conflicts in internal/core/services/instance_test.go by making the test instance port configurable via TEST_INSTANCE_PORT.
- Updated helper tests to use the dynamic TestBaseURL.

These changes combined allow running the full test suite in an isolated environment without manual configuration or port conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Elastic IPs: allocate, list, get, associate, disassociate, and release static public IPs; API endpoints and RBAC permissions added.

* **Documentation**
  * Docs, API reference, architecture and vision updated to describe Elastic IP behavior, types and permissions.

* **Tests**
  * New unit, integration and end-to-end tests covering Elastic IP workflows.

* **Chores**
  * Docker/CI: configurable compose ports and network via environment variables; compose orchestration updated for CI/e2e.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->