### PR TITLE
feat(rds): implement persistent volume integration for managed databases

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -115,7 +115,9 @@ This document provides a comprehensive overview of every feature currently imple
 **Implementation**:
 - **Multi-Engine Support**: PostgreSQL and MySQL with configurable versions.
 - **Provisioning**: Spawns Docker containers using official images (`postgres:<version>-alpine`, `mysql:<version>`).
-- **Read Replicas**: Support for creating read-only replicas linked to a primary instance. Replicas are automatically configured to follow the primary via engine-specific environment variables.
+- **Data Persistence**: Automatically provisions and attaches 10GB persistent block volumes to every database instance. Data is stored on durable block devices, ensuring survival across container lifecycles.
+- **Read Replicas**: Support for creating read-only replicas linked to a primary instance. Replicas are automatically configured to follow the primary via engine-specific environment variables. Replicas also utilize persistent volumes.
+- **Automated Cleanup**: Deleting a database automatically triggers the removal of associated persistent volumes to prevent storage leaks.
 - **Automated Failover**: A dedicated `DatabaseFailoverWorker` performs periodic TCP health checks on primary instances. If a primary becomes unreachable, the worker automatically selects and promotes the most suitable replica to the primary role.
 - **Manual Promotion**: API support for manually promoting a replica to primary status for maintenance or planned transitions.
 - **Credentials**: Auto-generates secure passwords (16-char random) and default usernames.

--- a/docs/adr/ADR-015-database-data-persistence.md
+++ b/docs/adr/ADR-015-database-data-persistence.md
@@ -1,0 +1,48 @@
+# ADR 015: Managed Database Data Persistence
+
+## Status
+Accepted
+
+## Context
+The Managed Database Service (RDS) initially launched with ephemeral storage. When a database container was restarted or recreated, all data was lost. This made the service unsuitable for production workloads that require high durability and data integrity across container lifecycles.
+
+We needed a solution that:
+1.  **Ensures Data Durability**: Data must survive container crashes, restarts, and manual deletions/recreations.
+2.  **Integrates with Existing Infrastructure**: Leverage the existing `VolumeService` and block storage backends.
+3.  **Supports Replication**: Ensure both primary and replica instances have persistent storage.
+4.  **Automates Lifecycle**: Volumes should be provisioned automatically during DB creation and cleaned up during DB deletion to prevent storage leaks.
+
+## Decision
+We implemented automated persistent volume integration for the Managed Database Service.
+
+### 1. Automated Provisioning
+The `DatabaseService` was updated to interact with the `VolumeService`:
+-   **On Create**: Every new database (Primary or Replica) automatically provisions a 10GB persistent block volume.
+-   **Naming Convention**: Volumes are named with a predictable prefix `db-vol-<db_id_prefix>` or `db-replica-vol-<db_id_prefix>` for easier identification.
+
+### 2. Volume Binding
+The provisioned block volume is mounted into the database container at the engine-specific data directory:
+-   **PostgreSQL**: `/var/lib/postgresql/data`
+-   **MySQL**: `/var/lib/mysql`
+
+This ensures that the database engine's internal state is stored entirely on the persistent block device.
+
+### 3. Lifecycle Management
+-   **Cleanup on Delete**: When a `domain.Database` is deleted via the API, the service now performs an automated lookup for associated volumes and triggers their deletion.
+-   **Error Handling**: If volume creation fails, the database provisioning is rolled back. If container launch fails, the provisioned volume is automatically deleted to maintain system hygiene.
+
+### 4. Integration & Testing
+-   **Dependency Injection**: `VolumeService` was injected into the `DatabaseService`.
+-   **E2E Validation**: A new E2E test suite (`tests/database_persistence_e2e_test.go`) was added to verify the end-to-end lifecycle of persistent databases.
+
+## Consequences
+
+### Positive
+-   **Production Readiness**: Managed databases can now safely host critical data as they are no longer ephemeral.
+-   **Resource Efficiency**: Automated cleanup ensures that storage resources are released when databases are decommissioned.
+-   **Architectural Alignment**: Reuses the core platform's storage abstractions rather than implementing engine-specific hacks.
+
+### Negative
+-   **Provisioning Latency**: Database creation now takes slightly longer as it involves a synchronous block volume provisioning step.
+-   **Storage Costs**: Every database now consumes at least 10GB of block storage, increasing the infrastructure footprint per instance.
+-   **Fixed Sizing**: The initial implementation uses a hardcoded 10GB size; dynamic sizing and volume expansion are deferred to a future version.

--- a/docs/database.md
+++ b/docs/database.md
@@ -312,6 +312,23 @@ CREATE TABLE databases (
 **Engines**: `postgres`, `mysql`  
 **Roles**: `PRIMARY`, `REPLICA`
 
+### Managed Database Persistence
+
+Managed databases in The Cloud platform utilize persistent block storage to ensure data durability across container lifecycles.
+
+#### Storage Architecture
+When a managed database is provisioned, the service automatically:
+1.  **Creates a Block Volume**: A 10GB persistent volume is provisioned via the `VolumeService`.
+2.  **Mounts the Volume**: The volume is attached to the compute instance and mounted to the appropriate data directory:
+    -   **PostgreSQL**: `/var/lib/postgresql/data`
+    -   **MySQL**: `/var/lib/mysql`
+
+This integration ensures that all database state (tables, indexes, logs) is stored on durable block storage rather than the container's ephemeral layer.
+
+#### Volume Lifecycle
+-   **Automated Provisioning**: Volumes are created synchronously during the `CreateDatabase` and `CreateReplica` calls.
+-   **Automated Cleanup**: When a database is deleted via the API, the service identifies and deletes the associated block volumes to prevent storage leaks.
+
 ### Database Replication
 
 The Cloud platform supports asynchronous replication for managed databases to provide high availability and read scaling.

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -260,12 +260,13 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 	}
 
 	databaseSvc := services.NewDatabaseService(services.DatabaseServiceParams{
-		Repo:     c.Repos.Database,
-		Compute:  c.Compute,
-		VpcRepo:  c.Repos.Vpc,
-		EventSvc: eventSvc,
-		AuditSvc: auditSvc,
-		Logger:   c.Logger,
+		Repo:      c.Repos.Database,
+		Compute:   c.Compute,
+		VpcRepo:   c.Repos.Vpc,
+		VolumeSvc: volumeSvc,
+		EventSvc:  eventSvc,
+		AuditSvc:  auditSvc,
+		Logger:    c.Logger,
 	})
 	secretSvc := services.NewSecretService(c.Repos.Secret, eventSvc, auditSvc, c.Logger, c.Config.SecretsEncryptionKey, c.Config.Environment)
 	fnSvc := services.NewFunctionService(c.Repos.Function, c.Compute, fileStore, auditSvc, c.Logger)

--- a/internal/core/services/database_test.go
+++ b/internal/core/services/database_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/poyrazk/thecloud/internal/repositories/docker"
+	"github.com/poyrazk/thecloud/internal/repositories/noop"
 	"github.com/poyrazk/thecloud/internal/repositories/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,15 +40,20 @@ func setupDatabaseServiceTest(t *testing.T) (ports.DatabaseService, ports.Databa
 	auditRepo := postgres.NewAuditRepository(db)
 	auditSvc := services.NewAuditService(auditRepo)
 
+	volRepo := postgres.NewVolumeRepository(db)
+	storage := noop.NewNoopStorageBackend()
+	volumeSvc := services.NewVolumeService(volRepo, storage, eventSvc, auditSvc, slog.Default())
+
 	logger := slog.Default()
 
 	svc := services.NewDatabaseService(services.DatabaseServiceParams{
-		Repo:     repo,
-		Compute:  compute,
-		VpcRepo:  vpcRepo,
-		EventSvc: eventSvc,
-		AuditSvc: auditSvc,
-		Logger:   logger,
+		Repo:      repo,
+		Compute:   compute,
+		VpcRepo:   vpcRepo,
+		VolumeSvc: volumeSvc,
+		EventSvc:  eventSvc,
+		AuditSvc:  auditSvc,
+		Logger:    logger,
 	})
 
 	return svc, repo, compute, vpcRepo, ctx

--- a/tests/database_persistence_e2e_test.go
+++ b/tests/database_persistence_e2e_test.go
@@ -15,6 +15,27 @@ import (
 	"github.com/poyrazk/thecloud/pkg/testutil"
 )
 
+const (
+	dbSuffixMod  = 1000
+	dbPrefixLen  = 8
+	pollInterval = 200 * time.Millisecond
+	pollTimeout  = 5 * time.Second
+)
+
+func safePrefix(id string, n int) string {
+	if len(id) < n {
+		return id
+	}
+	return id[:n]
+}
+
+func closeBody(t *testing.T, resp *http.Response) {
+	if resp != nil && resp.Body != nil {
+		err := resp.Body.Close()
+		require.NoError(t, err, "failed to close response body")
+	}
+}
+
 func TestDatabasePersistenceE2E(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database persistence E2E test in short mode")
@@ -27,76 +48,93 @@ func TestDatabasePersistenceE2E(t *testing.T) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	token := registerAndLogin(t, client, "db-persistence@thecloud.local", "Persistence Tester")
 
-	var dbID string
-	dbName := fmt.Sprintf("e2e-persistent-db-%d", time.Now().UnixNano()%1000)
+	testCases := []struct {
+		engine  string
+		version string
+	}{
+		{"postgres", "16"},
+		{"mysql", "8.0"},
+	}
 
-	// 1. Create Database
-	t.Run("CreateDatabase_ProvisionsVolume", func(t *testing.T) {
-		payload := map[string]string{
-			"name":    dbName,
-			"engine":  "postgres",
-			"version": "16",
-		}
-		resp := postRequest(t, client, testutil.TestBaseURL+"/databases", token, payload)
-		defer func() { _ = resp.Body.Close() }()
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Engine/%s", tc.engine), func(t *testing.T) {
+			var dbID string
+			dbName := fmt.Sprintf("e2e-persistent-%s-%d", tc.engine, time.Now().UnixNano()%dbSuffixMod)
 
-		require.Equal(t, http.StatusCreated, resp.StatusCode)
+			// 1. Create Database
+			t.Run("CreateDatabase_ProvisionsVolume", func(t *testing.T) {
+				payload := map[string]string{
+					"name":    dbName,
+					"engine":  tc.engine,
+					"version": tc.version,
+				}
+				resp := postRequest(t, client, testutil.TestBaseURL+"/databases", token, payload)
+				defer closeBody(t, resp)
 
-		var res struct {
-			Data domain.Database `json:"data"`
-		}
-		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
-		dbID = res.Data.ID.String()
-		assert.NotEmpty(t, dbID)
+				require.Equal(t, http.StatusCreated, resp.StatusCode)
 
-		// 2. Verify Volume exists
-		respVols := getRequest(t, client, testutil.TestBaseURL+"/volumes", token)
-		defer func() { _ = respVols.Body.Close() }()
-		require.Equal(t, http.StatusOK, respVols.StatusCode)
+				var res struct {
+					Data domain.Database `json:"data"`
+				}
+				require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+				dbID = res.Data.ID.String()
+				assert.NotEmpty(t, dbID)
 
-		var volsRes struct {
-			Data []domain.Volume `json:"data"`
-		}
-		require.NoError(t, json.NewDecoder(respVols.Body).Decode(&volsRes))
+				// 2. Verify Volume exists
+				respVols := getRequest(t, client, testutil.TestBaseURL+"/volumes", token)
+				defer closeBody(t, respVols)
+				require.Equal(t, http.StatusOK, respVols.StatusCode)
 
-		found := false
-		expectedPrefix := fmt.Sprintf("db-vol-%s", dbID[:8])
-		for _, v := range volsRes.Data {
-			if strings.HasPrefix(v.Name, expectedPrefix) {
-				found = true
-				break
-			}
-		}
-		assert.True(t, found, "Expected volume with prefix %s not found", expectedPrefix)
-	})
+				var volsRes struct {
+					Data []domain.Volume `json:"data"`
+				}
+				require.NoError(t, json.NewDecoder(respVols.Body).Decode(&volsRes))
 
-	// 3. Delete Database and verify Volume cleanup
-	t.Run("DeleteDatabase_CleansUpVolume", func(t *testing.T) {
-		resp := deleteRequest(t, client, fmt.Sprintf("%s/databases/%s", testutil.TestBaseURL, dbID), token)
-		defer func() { _ = resp.Body.Close() }()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
+				found := false
+				expectedPrefix := fmt.Sprintf("db-vol-%s", safePrefix(dbID, dbPrefixLen))
+				for _, v := range volsRes.Data {
+					if strings.HasPrefix(v.Name, expectedPrefix) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Expected volume with prefix %s not found", expectedPrefix)
+			})
 
-		// Wait a bit for async cleanup if any
-		time.Sleep(1 * time.Second)
+			// 3. Delete Database and verify Volume cleanup
+			t.Run("DeleteDatabase_CleansUpVolume", func(t *testing.T) {
+				if dbID == "" {
+					t.Skip("skipping delete test as dbID is empty")
+				}
 
-		// Verify Volume is gone
-		respVols := getRequest(t, client, testutil.TestBaseURL+"/volumes", token)
-		defer func() { _ = respVols.Body.Close() }()
-		require.Equal(t, http.StatusOK, respVols.StatusCode)
+				resp := deleteRequest(t, client, fmt.Sprintf("%s/databases/%s", testutil.TestBaseURL, dbID), token)
+				defer closeBody(t, resp)
+				require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		var volsRes struct {
-			Data []domain.Volume `json:"data"`
-		}
-		require.NoError(t, json.NewDecoder(respVols.Body).Decode(&volsRes))
+				// Polling verify Volume is gone
+				require.Eventually(t, func() bool {
+					respVols := getRequest(t, client, testutil.TestBaseURL+"/volumes", token)
+					defer closeBody(t, respVols)
+					if respVols.StatusCode != http.StatusOK {
+						return false
+					}
 
-		found := false
-		expectedPrefix := fmt.Sprintf("db-vol-%s", dbID[:8])
-		for _, v := range volsRes.Data {
-			if strings.HasPrefix(v.Name, expectedPrefix) {
-				found = true
-				break
-			}
-		}
-		assert.False(t, found, "Volume with prefix %s should have been deleted", expectedPrefix)
-	})
+					var volsRes struct {
+						Data []domain.Volume `json:"data"`
+					}
+					if err := json.NewDecoder(respVols.Body).Decode(&volsRes); err != nil {
+						return false
+					}
+
+					expectedPrefix := fmt.Sprintf("db-vol-%s", safePrefix(dbID, dbPrefixLen))
+					for _, v := range volsRes.Data {
+						if strings.HasPrefix(v.Name, expectedPrefix) {
+							return false
+						}
+					}
+					return true
+				}, pollTimeout, pollInterval, "Volume with prefix db-vol-%s should have been deleted", safePrefix(dbID, dbPrefixLen))
+			})
+		})
+	}
 }

--- a/tests/database_persistence_e2e_test.go
+++ b/tests/database_persistence_e2e_test.go
@@ -30,6 +30,7 @@ func safePrefix(id string, n int) string {
 }
 
 func closeBody(t *testing.T, resp *http.Response) {
+	t.Helper()
 	if resp != nil && resp.Body != nil {
 		err := resp.Body.Close()
 		require.NoError(t, err, "failed to close response body")

--- a/tests/database_persistence_e2e_test.go
+++ b/tests/database_persistence_e2e_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/pkg/testutil"
+)
+
+func TestDatabasePersistenceE2E(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database persistence E2E test in short mode")
+	}
+
+	if err := waitForServer(); err != nil {
+		t.Fatalf("Failing Database Persistence E2E test: %v", err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	token := registerAndLogin(t, client, "db-persistence@thecloud.local", "Persistence Tester")
+
+	var dbID string
+	dbName := fmt.Sprintf("e2e-persistent-db-%d", time.Now().UnixNano()%1000)
+
+	// 1. Create Database
+	t.Run("CreateDatabase_ProvisionsVolume", func(t *testing.T) {
+		payload := map[string]string{
+			"name":    dbName,
+			"engine":  "postgres",
+			"version": "16",
+		}
+		resp := postRequest(t, client, testutil.TestBaseURL+"/databases", token, payload)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		var res struct {
+			Data domain.Database `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		dbID = res.Data.ID.String()
+		assert.NotEmpty(t, dbID)
+
+		// 2. Verify Volume exists
+		respVols := getRequest(t, client, testutil.TestBaseURL+"/volumes", token)
+		defer func() { _ = respVols.Body.Close() }()
+		require.Equal(t, http.StatusOK, respVols.StatusCode)
+
+		var volsRes struct {
+			Data []domain.Volume `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(respVols.Body).Decode(&volsRes))
+
+		found := false
+		expectedPrefix := fmt.Sprintf("db-vol-%s", dbID[:8])
+		for _, v := range volsRes.Data {
+			if strings.HasPrefix(v.Name, expectedPrefix) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, fmt.Sprintf("Expected volume with prefix %s not found", expectedPrefix))
+	})
+
+	// 3. Delete Database and verify Volume cleanup
+	t.Run("DeleteDatabase_CleansUpVolume", func(t *testing.T) {
+		resp := deleteRequest(t, client, fmt.Sprintf("%s/databases/%s", testutil.TestBaseURL, dbID), token)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// Wait a bit for async cleanup if any
+		time.Sleep(1 * time.Second)
+
+		// Verify Volume is gone
+		respVols := getRequest(t, client, testutil.TestBaseURL+"/volumes", token)
+		defer func() { _ = respVols.Body.Close() }()
+		require.Equal(t, http.StatusOK, respVols.StatusCode)
+
+		var volsRes struct {
+			Data []domain.Volume `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(respVols.Body).Decode(&volsRes))
+
+		found := false
+		expectedPrefix := fmt.Sprintf("db-vol-%s", dbID[:8])
+		for _, v := range volsRes.Data {
+			if strings.HasPrefix(v.Name, expectedPrefix) {
+				found = true
+				break
+			}
+		}
+		assert.False(t, found, fmt.Sprintf("Volume with prefix %s should have been deleted", expectedPrefix))
+	})
+}

--- a/tests/database_persistence_e2e_test.go
+++ b/tests/database_persistence_e2e_test.go
@@ -67,7 +67,7 @@ func TestDatabasePersistenceE2E(t *testing.T) {
 				break
 			}
 		}
-		assert.True(t, found, fmt.Sprintf("Expected volume with prefix %s not found", expectedPrefix))
+		assert.True(t, found, "Expected volume with prefix %s not found", expectedPrefix)
 	})
 
 	// 3. Delete Database and verify Volume cleanup
@@ -97,6 +97,6 @@ func TestDatabasePersistenceE2E(t *testing.T) {
 				break
 			}
 		}
-		assert.False(t, found, fmt.Sprintf("Volume with prefix %s should have been deleted", expectedPrefix))
+		assert.False(t, found, "Volume with prefix %s should have been deleted", expectedPrefix)
 	})
 }


### PR DESCRIPTION
This PR implements data persistence for the Managed Database Service by integrating it with the VolumeService.

### Changes:
- **internal/core/services/database.go**: Added logic to provision a 10GB persistent block volume for every new database (primary and replica). The volumes are mounted to /var/lib/postgresql/data (Postgres) or /var/lib/mysql (MySQL).
- **internal/api/setup/dependencies.go**: Injected VolumeService into the DatabaseService constructor.
- **tests/database_persistence_e2e_test.go**: Added a new E2E test suite to verify that volumes are correctly provisioned during DB creation and cleaned up during DB deletion.
- **Unit/Integration Tests**: Updated existing tests to handle the new dependency and verify the persistent volume lifecycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Databases and read replicas now get automatically provisioned persistent block volumes (10GB) and have them mounted for durable storage.
* **Bug Fixes**
  * Volumes created during provisioning are cleaned up on failures and removed when databases/replicas are deleted to avoid orphaned storage.
* **Tests**
  * Added unit and end-to-end tests covering volume provisioning, attachment, and cleanup.
* **Documentation**
  * Docs and design ADR updated to describe persistence behavior, mounts, and lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->