### PR TITLE
feat: ARM64 and UEFI support for Libvirt with Lima dev environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -393,6 +396,8 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
           tags: |
             ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:staging
             ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:${{ steps.repo_name.outputs.REF_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,9 +372,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -396,7 +393,6 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
           provenance: false
           tags: |
             ghcr.io/${{ steps.repo_name.outputs.REPO_LC }}:staging

--- a/internal/repositories/libvirt/adapter.go
+++ b/internal/repositories/libvirt/adapter.go
@@ -226,11 +226,11 @@ func (a *LibvirtAdapter) LaunchInstanceWithOptions(ctx context.Context, opts por
 		vcpu = int(opts.CPULimit)
 	}
 
-	consoleLog := a.getLogPath(name)
-	if os.Getenv("CI") != "" {
-		consoleLog = "" // Disable in CI to avoid permission issues with /tmp or other system paths
+	arch := ""
+	if os.Getenv("GOARCH") == "arm64" || strings.Contains(diskPath, "arm64") {
+		arch = "aarch64"
 	}
-	domainXML := generateDomainXML(name, diskPath, networkID, isoPath, memMB, vcpu, additionalDisks, allocatedPorts, consoleLog)
+	domainXML := generateDomainXML(name, diskPath, networkID, isoPath, memMB, vcpu, additionalDisks, allocatedPorts, arch)
 	dom, err := a.client.DomainDefineXML(ctx, domainXML)
 	if err != nil {
 		a.cleanupCreateFailure(ctx, vol, isoPath)

--- a/internal/repositories/libvirt/adapter.go
+++ b/internal/repositories/libvirt/adapter.go
@@ -1098,14 +1098,3 @@ func (a *LibvirtAdapter) isNotFound(err error) bool {
 	}
 	return strings.Contains(strings.ToLower(err.Error()), "not found")
 }
-
-func (a *LibvirtAdapter) getLogPath(id string) string {
-	// Use home directory for logs to avoid permission issues in CI /tmp
-	home := os.Getenv("HOME")
-	if home == "" {
-		home = "/tmp"
-	}
-	logDir := filepath.Join(home, ".cache", "thecloud", "logs")
-	_ = os.MkdirAll(logDir, 0755)
-	return filepath.Join(logDir, id+"-console.log")
-}

--- a/setup-lima-env.sh
+++ b/setup-lima-env.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# setup-lima-env.sh - Run this INSIDE the Lima VM
+set -e
+
+# Change to the project directory
+cd /Users/poyrazk/dev/Cloud/thecloud
+
+echo "Starting background services via Docker Compose..."
+docker compose up -d postgres redis jaeger powerdns
+
+echo "Waiting for Postgres to be ready..."
+# We use the service name from docker-compose
+until docker compose exec postgres pg_isready -U cloud -d cloud; do
+  echo "Still waiting for postgres..."
+  sleep 2
+done
+
+echo "Running migrations..."
+export DATABASE_URL=postgres://cloud:cloud@localhost:5433/cloud?sslmode=disable
+go run cmd/api/main.go --migrate-only
+
+echo "--------------------------------------------------------"
+echo "Ready! To run The Cloud with the Libvirt backend:"
+echo "--------------------------------------------------------"
+echo "export COMPUTE_BACKEND=libvirt"
+echo "export NETWORK_BACKEND=ovs"
+echo "export DATABASE_URL=postgres://cloud:cloud@localhost:5433/cloud?sslmode=disable"
+echo "export REDIS_URL=localhost:6379"
+echo "export POWERDNS_API_URL=http://localhost:8081"
+echo "go run cmd/api/main.go"
+echo "--------------------------------------------------------"

--- a/thecloud-lima.yaml
+++ b/thecloud-lima.yaml
@@ -1,0 +1,63 @@
+# thecloud-lima.yaml
+# Optimized Lima configuration for running "The Cloud" on M3 Mac with libvirt/KVM
+images:
+- location: "https://cloud-images.ubuntu.com/releases/24.04/release/ubuntu-24.04-server-cloudimg-arm64.img"
+  arch: "aarch64"
+
+cpus: 4
+memory: "8GiB"
+disk: "50GiB"
+
+mounts:
+- location: "~"
+  writable: true
+
+# Use standard Docker setup within Lima for background services
+containerd:
+  system: false
+  user: false
+
+provision:
+- mode: system
+  script: |
+    # Install all dependencies for The Cloud
+    apt-get update
+    apt-get install -y \
+      qemu-kvm \
+      libvirt-daemon-system \
+      libvirt-clients \
+      bridge-utils \
+      genisoimage \
+      qemu-utils \
+      openvswitch-switch \
+      docker.io \
+      docker-compose-v2 \
+      golang-go \
+      build-essential \
+      pkg-config \
+      libvirt-dev \
+      acl \
+      git \
+      curl
+
+    # Group permissions
+    usermod -aG libvirt,docker,kvm $USER
+    
+    # Enable and start services
+    systemctl enable --now libvirtd
+    systemctl enable --now openvswitch-switch
+    systemctl enable --now docker
+
+    # Set up default storage pool for libvirt
+    virsh pool-define-as default dir --target /var/lib/libvirt/images || true
+    virsh pool-start default || true
+    virsh pool-autostart default || true
+
+    # Give the user permission to access OVS socket
+    setfacl -m u:$USER:rw /var/run/openvswitch/db.sock
+
+    # Setup the data directory
+    mkdir -p /var/lib/thecloud/data
+    chown -R $USER:$USER /var/lib/thecloud/data
+
+    echo "Lima VM is fully provisioned and ready for The Cloud."


### PR DESCRIPTION
This PR adds native ARM64 and UEFI support to the libvirt compute backend, enabling development and testing on Apple Silicon (M1/M2/M3) via Lima.

### Changes:
- **libvirt/adapter.go**: Fixed a bug where the console log path was incorrectly passed as the architecture string.
- **libvirt/templates.go**: 
    - Added UEFI loader support (AAVMF) for aarch64 architectures.
    - Removed a hardcoded -serial argument that caused permission issues in certain environments.
- **thecloud-lima.yaml**: Added a specialized Lima configuration for spinning up a Linux VM on macOS with all dependencies (libvirtd, OVS, Docker) pre-installed.
- **setup-lima-env.sh**: Added a helper script to initialize background services and run migrations inside the Lima environment.

Verified by successfully launching an Ubuntu 22.04 cloud image on an M3 MacBook Pro.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ARM64 (aarch64) architecture support for virtual machine instances with proper UEFI firmware configuration.
  * Added Lima VM environment setup for Apple Silicon Macs with Docker service orchestration and automated database initialization.

* **Chores**
  * Updated CI/CD configuration for image build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->