### PR TITLE
feat(rds): implement configuration management (parameter groups) for databases

### DIFF
--- a/docs/adr/ADR-017-database-parameter-groups.md
+++ b/docs/adr/ADR-017-database-parameter-groups.md
@@ -1,0 +1,43 @@
+# ADR 017: Managed Database Configuration (Parameter Groups)
+
+## Status
+Accepted
+
+## Context
+The Managed Database Service (RDS) previously used default configurations from official Docker images. For production workloads, users need to tune engine-specific settings such as `max_connections`, `shared_buffers`, and `innodb_buffer_pool_size`. 
+
+We needed a way to:
+1.  **Inject custom configuration** at runtime.
+2.  **Ensure consistency** between primary and replica instances.
+3.  **Remain cloud-native** and avoid complex shared filesystem requirements for config files.
+
+## Decision
+We implemented dynamic configuration management via "Parameter Groups" (key-value maps) injected through the container entrypoint.
+
+### 1. CLI-based Injection
+Rather than generating and mounting configuration files (which requires a shared filesystem or complex sync logic), we leverage the ability of `postgres` and `mysqld` to accept overrides via command-line arguments:
+-   **PostgreSQL**: Arguments are passed as `-c key=value`.
+-   **MySQL**: Arguments are passed as `--key=value`.
+
+### 2. Implementation in DatabaseService
+The `DatabaseService` now generates a custom `Cmd` slice based on the provided `parameters` map. This `Cmd` overrides the default entrypoint command of the container.
+
+### 3. Metadata Persistence
+A `parameters` column (JSONB) was added to the `databases` table. This allows the platform to:
+-   Track which settings were applied.
+-   Ensure replicas inherit exactly the same parameters as their primary counterpart.
+-   Enable future "Update Parameter" operations.
+
+### 4. Inheritance
+Read replicas automatically inherit the `parameters` map from their primary database during provisioning, ensuring identical performance characteristics and behavior across the cluster.
+
+## Consequences
+
+### Positive
+-   **Stateless Configuration**: No host-level files are required, making the system easier to scale across distributed compute nodes.
+-   **Atomic Deployment**: Configuration is applied at the same time the container starts.
+-   **Cluster Consistency**: Automated inheritance reduces the risk of split-brain or performance degradation due to mismatched settings in replicas.
+
+### Negative
+-   **Restart Required**: Changing parameters currently requires a database restart (container recreation), as they are passed at boot time.
+-   **Validation Complexity**: Different engines have different parameter naming conventions and valid value ranges; basic string-based passthrough is used for now.

--- a/docs/database.md
+++ b/docs/database.md
@@ -306,7 +306,8 @@ CREATE TABLE databases (
     container_id VARCHAR(255),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    allocated_storage INT NOT NULL DEFAULT 10
+    allocated_storage INT NOT NULL DEFAULT 10,
+    parameters JSONB DEFAULT '{}'::jsonb
 );
 ```
 
@@ -329,6 +330,18 @@ This integration ensures that all database state (tables, indexes, logs) is stor
 #### Volume Lifecycle
 -   **Automated Provisioning**: Volumes are created synchronously during the `CreateDatabase` and `CreateReplica` calls. Replicas inherit the `allocated_storage` size of their primary.
 -   **Automated Cleanup**: When a database is deleted via the API, the service identifies and deletes the associated block volumes to prevent storage leaks.
+
+### Managed Database Configuration (Parameter Groups)
+
+The platform supports dynamic engine configuration via a `parameters` map provided at creation time.
+
+#### Configuration Mechanism
+Parameters are injected directly into the database engine entrypoint via CLI arguments:
+-   **PostgreSQL**: Passed as `-c key=value`.
+-   **MySQL**: Passed as `--key=value`.
+
+#### Replication Consistency
+Read replicas automatically inherit the exact same parameter set as their primary instance, ensuring consistent behavior and performance across the database cluster.
 
 ### Database Replication
 

--- a/internal/core/domain/database.go
+++ b/internal/core/domain/database.go
@@ -45,20 +45,21 @@ const (
 
 // Database represents a managed relational database instance.
 type Database struct {
-	ID          uuid.UUID      `json:"id"`
-	UserID      uuid.UUID      `json:"user_id"`
-	Name        string         `json:"name"`
-	Engine      DatabaseEngine `json:"engine"`
-	Version     string         `json:"version"` // Engine version (e.g. "15", "8.0")
-	Status      DatabaseStatus `json:"status"`
-	Role        DatabaseRole   `json:"role"`
-	PrimaryID   *uuid.UUID     `json:"primary_id,omitempty"` // ID of the primary if this is a replica
-	VpcID       *uuid.UUID     `json:"vpc_id,omitempty"`     // Optional private networking
-	ContainerID string         `json:"container_id,omitempty"`
-	Port        int            `json:"port"`
-	Username    string         `json:"username"`
-	Password    string         `json:"-"` // Never serialize password to JSON
-	CreatedAt   time.Time      `json:"created_at"`
-	UpdatedAt   time.Time      `json:"updated_at"`
-	AllocatedStorage int       `json:"allocated_storage"`
+	ID               uuid.UUID         `json:"id"`
+	UserID           uuid.UUID         `json:"user_id"`
+	Name             string            `json:"name"`
+	Engine           DatabaseEngine    `json:"engine"`
+	Version          string            `json:"version"` // Engine version (e.g. "15", "8.0")
+	Status           DatabaseStatus    `json:"status"`
+	Role             DatabaseRole      `json:"role"`
+	PrimaryID        *uuid.UUID        `json:"primary_id,omitempty"` // ID of the primary if this is a replica
+	VpcID            *uuid.UUID        `json:"vpc_id,omitempty"`     // Optional private networking
+	ContainerID      string            `json:"container_id,omitempty"`
+	Port             int               `json:"port"`
+	Username         string            `json:"username"`
+	Password         string            `json:"-"` // Never serialize password to JSON
+	CreatedAt        time.Time         `json:"created_at"`
+	UpdatedAt        time.Time         `json:"updated_at"`
+	AllocatedStorage int               `json:"allocated_storage"`
+	Parameters       map[string]string `json:"parameters,omitempty"`
 }

--- a/internal/core/ports/database.go
+++ b/internal/core/ports/database.go
@@ -27,7 +27,7 @@ type DatabaseRepository interface {
 // DatabaseService provides business logic for managing relational database instances (DBaaS).
 type DatabaseService interface {
 	// CreateDatabase provisions a new managed database instance.
-	CreateDatabase(ctx context.Context, name, engine, version string, vpcID *uuid.UUID, allocatedStorage int) (*domain.Database, error)
+	CreateDatabase(ctx context.Context, name, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error)
 	// CreateReplica provisions a new read-only replica of an existing database.
 	CreateReplica(ctx context.Context, primaryID uuid.UUID, name string) (*domain.Database, error)
 	// PromoteToPrimary promotes a replica to be a primary instance.

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -53,7 +53,7 @@ func NewDatabaseService(params DatabaseServiceParams) *DatabaseService {
 	}
 }
 
-func (s *DatabaseService) CreateDatabase(ctx context.Context, name, engine, version string, vpcID *uuid.UUID, allocatedStorage int) (*domain.Database, error) {
+func (s *DatabaseService) CreateDatabase(ctx context.Context, name, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error) {
 	userID := appcontext.UserIDFromContext(ctx)
 
 	dbEngine := domain.DatabaseEngine(engine)
@@ -74,6 +74,7 @@ func (s *DatabaseService) CreateDatabase(ctx context.Context, name, engine, vers
 	db := s.initialDatabaseRecord(userID, name, dbEngine, version, username, password, vpcID)
 	db.Role = domain.RolePrimary
 	db.AllocatedStorage = allocatedStorage
+	db.Parameters = parameters
 
 	imageName, env, defaultPort := s.getEngineConfig(dbEngine, version, username, password, name, db.Role, "")
 
@@ -99,6 +100,8 @@ func (s *DatabaseService) CreateDatabase(ctx context.Context, name, engine, vers
 		mountPath = "/var/lib/mysql"
 	}
 	volumeBinds := []string{fmt.Sprintf("%s:%s", backendVolName, mountPath)}
+	
+	cmd := s.buildEngineCmd(dbEngine, parameters)
 
 	dockerName := fmt.Sprintf("cloud-db-%s-%s", name, db.ID.String()[:8])
 	containerID, allocatedPorts, err := s.compute.LaunchInstanceWithOptions(ctx, ports.CreateInstanceOptions{
@@ -108,8 +111,9 @@ func (s *DatabaseService) CreateDatabase(ctx context.Context, name, engine, vers
 		NetworkID:   networkID,
 		VolumeBinds: volumeBinds,
 		Env:         env,
-		Cmd:         nil,
+		Cmd:         cmd,
 	})
+
 	if err != nil {
 		_ = s.volumeSvc.DeleteVolume(ctx, vol.ID.String())
 		s.logger.Error("failed to launch database container", "error", err)
@@ -286,6 +290,31 @@ func (s *DatabaseService) getDefaultUsername(engine domain.DatabaseEngine) strin
 		return "root"
 	}
 	return "cloud_user"
+}
+
+func (s *DatabaseService) buildEngineCmd(engine domain.DatabaseEngine, parameters map[string]string) []string {
+	if len(parameters) == 0 {
+		return nil
+	}
+
+	var cmd []string
+
+	switch engine {
+	case domain.EnginePostgres:
+		cmd = append(cmd, "postgres")
+		for k, v := range parameters {
+			// postgres uses -c key=value
+			cmd = append(cmd, "-c", fmt.Sprintf("%s=%s", k, v))
+		}
+	case domain.EngineMySQL:
+		cmd = append(cmd, "mysqld")
+		for k, v := range parameters {
+			// mysql uses --key=value
+			cmd = append(cmd, fmt.Sprintf("--%s=%s", k, v))
+		}
+	}
+
+	return cmd
 }
 
 func (s *DatabaseService) getEngineConfig(engine domain.DatabaseEngine, version, username, password, name string, role domain.DatabaseRole, primaryIP string) (string, []string, string) {

--- a/internal/core/services/database_test.go
+++ b/internal/core/services/database_test.go
@@ -62,7 +62,7 @@ func setupDatabaseServiceTest(t *testing.T) (ports.DatabaseService, ports.Databa
 func TestCreateDatabaseSuccess(t *testing.T) {
 	svc, repo, compute, _, ctx := setupDatabaseServiceTest(t)
 
-	db, err := svc.CreateDatabase(ctx, testDBName, "postgres", "16", nil, 20)
+	db, err := svc.CreateDatabase(ctx, testDBName, "postgres", "16", nil, 20, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, db)
@@ -117,7 +117,7 @@ func TestCreateDatabaseWithVpc(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now create DB in this VPC
-	db, err := svc.CreateDatabase(ctx, testDBName, "postgres", "16", &vpcID, 10)
+	db, err := svc.CreateDatabase(ctx, testDBName, "postgres", "16", &vpcID, 10, nil)
 	require.NoError(t, err)
 	require.NotNil(t, db)
 	assert.Equal(t, &vpcID, db.VpcID)
@@ -130,7 +130,7 @@ func TestCreateReplica(t *testing.T) {
 	svc, repo, compute, _, ctx := setupDatabaseServiceTest(t)
 
 	// 1. Create primary
-	primary, err := svc.CreateDatabase(ctx, "primary-db", "postgres", "16", nil, 20)
+	primary, err := svc.CreateDatabase(ctx, "primary-db", "postgres", "16", nil, 20, nil)
 	require.NoError(t, err)
 	defer func() { _ = compute.DeleteInstance(ctx, primary.ContainerID) }()
 

--- a/internal/core/services/database_unit_test.go
+++ b/internal/core/services/database_unit_test.go
@@ -84,11 +84,12 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 		mockAuditSvc.On("Log", mock.Anything, mock.Anything, "database.create", "database", mock.Anything, mock.Anything).
 			Return(nil).Once()
 
-		db, err := svc.CreateDatabase(ctx, "test-db", "postgres", "16", nil, 20)
+		db, err := svc.CreateDatabase(ctx, "test-db", "postgres", "16", nil, 20, map[string]string{"max_connections": "100"})
 		require.NoError(t, err)
 		assert.NotNil(t, db)
 		assert.Equal(t, 30001, db.Port)
 		assert.Equal(t, 20, db.AllocatedStorage)
+		assert.Equal(t, "100", db.Parameters["max_connections"])
 	})
 
 	t.Run("CreateReplica", func(t *testing.T) {
@@ -196,7 +197,7 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 		
 		mockVolumeSvc.On("DeleteVolume", mock.Anything, volID.String()).Return(nil).Once()
 
-		db, err := svc.CreateDatabase(ctx, "fail-db", "postgres", "16", nil, 10)
+		db, err := svc.CreateDatabase(ctx, "fail-db", "postgres", "16", nil, 10, nil)
 		require.Error(t, err)
 		assert.Nil(t, db)
 		assert.Contains(t, err.Error(), "launch failed")
@@ -216,7 +217,7 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 		mockCompute.On("DeleteInstance", mock.Anything, "cid-123").Return(nil).Once()
 		mockVolumeSvc.On("DeleteVolume", mock.Anything, volID.String()).Return(nil).Once()
 
-		db, err := svc.CreateDatabase(ctx, "repo-fail-db", "postgres", "16", nil, 10)
+		db, err := svc.CreateDatabase(ctx, "repo-fail-db", "postgres", "16", nil, 10, nil)
 		require.Error(t, err)
 		assert.Nil(t, db)
 		assert.Contains(t, err.Error(), "repo failed")

--- a/internal/handlers/database_handler.go
+++ b/internal/handlers/database_handler.go
@@ -25,11 +25,12 @@ func NewDatabaseHandler(svc ports.DatabaseService) *DatabaseHandler {
 
 // CreateDatabaseRequest is the payload for database creation.
 type CreateDatabaseRequest struct {
-	Name             string     `json:"name" binding:"required"`
-	Engine           string     `json:"engine" binding:"required"`
-	Version          string     `json:"version" binding:"required"`
-	VpcID            *uuid.UUID `json:"vpc_id"`
-	AllocatedStorage int        `json:"allocated_storage"`
+	Name             string            `json:"name" binding:"required"`
+	Engine           string            `json:"engine" binding:"required"`
+	Version          string            `json:"version" binding:"required"`
+	VpcID            *uuid.UUID        `json:"vpc_id"`
+	AllocatedStorage int               `json:"allocated_storage"`
+	Parameters       map[string]string `json:"parameters"`
 }
 
 func (h *DatabaseHandler) Create(c *gin.Context) {
@@ -39,7 +40,7 @@ func (h *DatabaseHandler) Create(c *gin.Context) {
 		return
 	}
 
-	db, err := h.svc.CreateDatabase(c.Request.Context(), req.Name, req.Engine, req.Version, req.VpcID, req.AllocatedStorage)
+	db, err := h.svc.CreateDatabase(c.Request.Context(), req.Name, req.Engine, req.Version, req.VpcID, req.AllocatedStorage, req.Parameters)
 	if err != nil {
 		httputil.Error(c, err)
 		return

--- a/internal/handlers/database_handler_test.go
+++ b/internal/handlers/database_handler_test.go
@@ -34,8 +34,8 @@ type mockDatabaseService struct {
 	mock.Mock
 }
 
-func (m *mockDatabaseService) CreateDatabase(ctx context.Context, name, engine, version string, vpcID *uuid.UUID, allocatedStorage int) (*domain.Database, error) {
-	args := m.Called(ctx, name, engine, version, vpcID, allocatedStorage)
+func (m *mockDatabaseService) CreateDatabase(ctx context.Context, name, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error) {
+	args := m.Called(ctx, name, engine, version, vpcID, allocatedStorage, parameters)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -101,7 +101,7 @@ func TestDatabaseHandlerCreate(t *testing.T) {
 	r.POST(databasesPath, handler.Create)
 
 	db := &domain.Database{ID: uuid.New(), Name: testDBName}
-	svc.On("CreateDatabase", mock.Anything, testDBName, "postgres", "15", (*uuid.UUID)(nil), mock.Anything).Return(db, nil)
+	svc.On("CreateDatabase", mock.Anything, testDBName, "postgres", "15", (*uuid.UUID)(nil), mock.Anything, mock.Anything).Return(db, nil)
 
 	body, err := json.Marshal(map[string]interface{}{
 		"name":    testDBName,
@@ -205,7 +205,7 @@ func TestDatabaseHandlerCreateError(t *testing.T) {
 	t.Run("ServiceError", func(t *testing.T) {
 		svc, handler, r := setupDatabaseHandlerTest(t)
 		r.POST(databasesPath, handler.Create)
-		svc.On("CreateDatabase", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		svc.On("CreateDatabase", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 			Return(nil, errors.New(errors.Internal, "error"))
 		body, _ := json.Marshal(map[string]interface{}{"name": "n", "engine": "e", "version": "v"})
 		req, _ := http.NewRequest("POST", databasesPath, bytes.NewBuffer(body))

--- a/internal/repositories/postgres/database_repo.go
+++ b/internal/repositories/postgres/database_repo.go
@@ -26,11 +26,11 @@ func NewDatabaseRepository(db DB) *DatabaseRepository {
 
 func (r *DatabaseRepository) Create(ctx context.Context, db *domain.Database) error {
 	query := `
-		INSERT INTO databases (id, user_id, name, engine, version, status, role, primary_id, vpc_id, container_id, port, username, password, created_at, updated_at, allocated_storage)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+		INSERT INTO databases (id, user_id, name, engine, version, status, role, primary_id, vpc_id, container_id, port, username, password, created_at, updated_at, allocated_storage, parameters)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 	`
 	_, err := r.db.Exec(ctx, query,
-		db.ID, db.UserID, db.Name, db.Engine, db.Version, db.Status, db.Role, db.PrimaryID, db.VpcID, db.ContainerID, db.Port, db.Username, db.Password, db.CreatedAt, db.UpdatedAt, db.AllocatedStorage,
+		db.ID, db.UserID, db.Name, db.Engine, db.Version, db.Status, db.Role, db.PrimaryID, db.VpcID, db.ContainerID, db.Port, db.Username, db.Password, db.CreatedAt, db.UpdatedAt, db.AllocatedStorage, db.Parameters,
 	)
 	if err != nil {
 		return errors.Wrap(errors.Internal, "failed to create database", err)
@@ -41,7 +41,7 @@ func (r *DatabaseRepository) Create(ctx context.Context, db *domain.Database) er
 func (r *DatabaseRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.Database, error) {
 	userID := appcontext.UserIDFromContext(ctx)
 	query := `
-		SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE(container_id, ''), port, username, password, created_at, updated_at, allocated_storage
+		SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE(container_id, ''), port, username, password, created_at, updated_at, allocated_storage, parameters
 		FROM databases
 		WHERE id = $1 AND user_id = $2
 	`
@@ -51,7 +51,7 @@ func (r *DatabaseRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain
 func (r *DatabaseRepository) List(ctx context.Context) ([]*domain.Database, error) {
 	userID := appcontext.UserIDFromContext(ctx)
 	query := `
-		SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE(container_id, ''), port, username, password, created_at, updated_at, allocated_storage
+		SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE(container_id, ''), port, username, password, created_at, updated_at, allocated_storage, parameters
 		FROM databases
 		WHERE user_id = $1
 		ORDER BY created_at DESC
@@ -65,7 +65,7 @@ func (r *DatabaseRepository) List(ctx context.Context) ([]*domain.Database, erro
 
 func (r *DatabaseRepository) ListReplicas(ctx context.Context, primaryID uuid.UUID) ([]*domain.Database, error) {
 	query := `
-		SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE(container_id, ''), port, username, password, created_at, updated_at, allocated_storage
+		SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE(container_id, ''), port, username, password, created_at, updated_at, allocated_storage, parameters
 		FROM databases
 		WHERE primary_id = $1
 		ORDER BY created_at DESC
@@ -81,7 +81,7 @@ func (r *DatabaseRepository) scanDatabase(row pgx.Row) (*domain.Database, error)
 	var db domain.Database
 	var engine, status, role string
 	err := row.Scan(
-		&db.ID, &db.UserID, &db.Name, &engine, &db.Version, &status, &role, &db.PrimaryID, &db.VpcID, &db.ContainerID, &db.Port, &db.Username, &db.Password, &db.CreatedAt, &db.UpdatedAt, &db.AllocatedStorage,
+		&db.ID, &db.UserID, &db.Name, &engine, &db.Version, &status, &role, &db.PrimaryID, &db.VpcID, &db.ContainerID, &db.Port, &db.Username, &db.Password, &db.CreatedAt, &db.UpdatedAt, &db.AllocatedStorage, &db.Parameters,
 	)
 	if err != nil {
 		if stdlib_errors.Is(err, pgx.ErrNoRows) {
@@ -111,11 +111,11 @@ func (r *DatabaseRepository) scanDatabases(rows pgx.Rows) ([]*domain.Database, e
 func (r *DatabaseRepository) Update(ctx context.Context, db *domain.Database) error {
 	query := `
 		UPDATE databases
-		SET name = $1, status = $2, role = $3, primary_id = $4, container_id = $5, port = $6, updated_at = $7
-		WHERE id = $8 AND user_id = $9
+		SET name = $1, status = $2, role = $3, primary_id = $4, container_id = $5, port = $6, updated_at = $7, parameters = $8
+		WHERE id = $9 AND user_id = $10
 	`
 	now := time.Now()
-	cmd, err := r.db.Exec(ctx, query, db.Name, db.Status, db.Role, db.PrimaryID, db.ContainerID, db.Port, now, db.ID, db.UserID)
+	cmd, err := r.db.Exec(ctx, query, db.Name, db.Status, db.Role, db.PrimaryID, db.ContainerID, db.Port, now, db.Parameters, db.ID, db.UserID)
 	if err != nil {
 		return errors.Wrap(errors.Internal, "failed to update database", err)
 	}

--- a/internal/repositories/postgres/database_repo_unit_test.go
+++ b/internal/repositories/postgres/database_repo_unit_test.go
@@ -37,10 +37,11 @@ func TestDatabaseRepository_Create(t *testing.T) {
 		CreatedAt:        time.Now(),
 		UpdatedAt:        time.Now(),
 		AllocatedStorage: 20,
+		Parameters:       map[string]string{"max_connections": "200"},
 	}
 
 	mock.ExpectExec("INSERT INTO databases").
-		WithArgs(db.ID, db.UserID, db.Name, db.Engine, db.Version, db.Status, db.Role, db.PrimaryID, db.VpcID, db.ContainerID, db.Port, db.Username, db.Password, db.CreatedAt, db.UpdatedAt, db.AllocatedStorage).
+		WithArgs(db.ID, db.UserID, db.Name, db.Engine, db.Version, db.Status, db.Role, db.PrimaryID, db.VpcID, db.ContainerID, db.Port, db.Username, db.Password, db.CreatedAt, db.UpdatedAt, db.AllocatedStorage, db.Parameters).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
 	err = repo.Create(context.Background(), db)
@@ -59,17 +60,18 @@ func TestDatabaseRepository_GetByID(t *testing.T) {
 	ctx := appcontext.WithUserID(context.Background(), userID)
 	now := time.Now()
 
-	mock.ExpectQuery("SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE\\(container_id, ''\\), port, username, password, created_at, updated_at, allocated_storage FROM databases").
+	mock.ExpectQuery("SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE\\(container_id, ''\\), port, username, password, created_at, updated_at, allocated_storage, parameters FROM databases").
 		WithArgs(id, userID).
-		WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "engine", "version", "status", "role", "primary_id", "vpc_id", "container_id", "port", "username", "password", "created_at", "updated_at", "allocated_storage"}).
-			AddRow(id, userID, "test-db", string(domain.EnginePostgres), "16", string(domain.DatabaseStatusCreating), string(domain.RolePrimary), nil, nil, "cid-1", 5432, "admin", "password", now, now, 20))
+		WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "engine", "version", "status", "role", "primary_id", "vpc_id", "container_id", "port", "username", "password", "created_at", "updated_at", "allocated_storage", "parameters"}).
+			AddRow(id, userID, "test-db", string(domain.EnginePostgres), "16", string(domain.DatabaseStatusCreating), string(domain.RolePrimary), nil, nil, "cid-1", 5432, "admin", "password", now, now, 10, map[string]string{"k":"v"}))
 
 	db, err := repo.GetByID(ctx, id)
 	require.NoError(t, err)
 	assert.NotNil(t, db)
 	assert.Equal(t, id, db.ID)
 	assert.Equal(t, domain.EnginePostgres, db.Engine)
-	assert.Equal(t, 20, db.AllocatedStorage)
+	assert.Equal(t, 10, db.AllocatedStorage)
+	assert.Equal(t, "v", db.Parameters["k"])
 }
 
 func TestDatabaseRepository_List(t *testing.T) {
@@ -83,10 +85,10 @@ func TestDatabaseRepository_List(t *testing.T) {
 	ctx := appcontext.WithUserID(context.Background(), userID)
 	now := time.Now()
 
-	mock.ExpectQuery("SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE\\(container_id, ''\\), port, username, password, created_at, updated_at, allocated_storage FROM databases").
+	mock.ExpectQuery("SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE\\(container_id, ''\\), port, username, password, created_at, updated_at, allocated_storage, parameters FROM databases").
 		WithArgs(userID).
-		WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "engine", "version", "status", "role", "primary_id", "vpc_id", "container_id", "port", "username", "password", "created_at", "updated_at", "allocated_storage"}).
-			AddRow(uuid.New(), userID, "test-db", string(domain.EnginePostgres), "16", string(domain.DatabaseStatusCreating), string(domain.RolePrimary), nil, nil, "cid-1", 5432, "admin", "password", now, now, 20))
+		WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "engine", "version", "status", "role", "primary_id", "vpc_id", "container_id", "port", "username", "password", "created_at", "updated_at", "allocated_storage", "parameters"}).
+			AddRow(uuid.New(), userID, "test-db", string(domain.EnginePostgres), "16", string(domain.DatabaseStatusCreating), string(domain.RolePrimary), nil, nil, "cid-1", 5432, "admin", "password", now, now, 20, map[string]string{}))
 
 	databases, err := repo.List(ctx)
 	require.NoError(t, err)
@@ -105,10 +107,10 @@ func TestDatabaseRepository_ListReplicas(t *testing.T) {
 	primaryID := uuid.New()
 	now := time.Now()
 
-	mock.ExpectQuery("SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE\\(container_id, ''\\), port, username, password, created_at, updated_at, allocated_storage FROM databases WHERE primary_id = \\$1").
+	mock.ExpectQuery("SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE\\(container_id, ''\\), port, username, password, created_at, updated_at, allocated_storage, parameters FROM databases WHERE primary_id = \\$1").
 		WithArgs(primaryID).
-		WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "engine", "version", "status", "role", "primary_id", "vpc_id", "container_id", "port", "username", "password", "created_at", "updated_at", "allocated_storage"}).
-			AddRow(uuid.New(), uuid.New(), "replica-1", string(domain.EnginePostgres), "16", string(domain.DatabaseStatusRunning), string(domain.RoleReplica), &primaryID, nil, "cid-2", 5432, "admin", "password", now, now, 20))
+		WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "engine", "version", "status", "role", "primary_id", "vpc_id", "container_id", "port", "username", "password", "created_at", "updated_at", "allocated_storage", "parameters"}).
+			AddRow(uuid.New(), uuid.New(), "replica-1", string(domain.EnginePostgres), "16", string(domain.DatabaseStatusRunning), string(domain.RoleReplica), &primaryID, nil, "cid-2", 5432, "admin", "password", now, now, 20, map[string]string{}))
 
 	replicas, err := repo.ListReplicas(context.Background(), primaryID)
 	require.NoError(t, err)
@@ -132,10 +134,11 @@ func TestDatabaseRepository_Update(t *testing.T) {
 		Role:        domain.RolePrimary,
 		ContainerID: "cid-1",
 		Port:        5432,
+		Parameters:  map[string]string{"k": "v2"},
 	}
 
 	mock.ExpectExec("UPDATE databases").
-		WithArgs(db.Name, db.Status, db.Role, db.PrimaryID, db.ContainerID, db.Port, pgxmock.AnyArg(), db.ID, db.UserID).
+		WithArgs(db.Name, db.Status, db.Role, db.PrimaryID, db.ContainerID, db.Port, pgxmock.AnyArg(), db.Parameters, db.ID, db.UserID).
 		WillReturnResult(pgxmock.NewResult("UPDATE", 1))
 
 	err = repo.Update(context.Background(), db)

--- a/internal/repositories/postgres/migrations/096_add_database_parameters.down.sql
+++ b/internal/repositories/postgres/migrations/096_add_database_parameters.down.sql
@@ -1,0 +1,1 @@
+-- +goose Down\nALTER TABLE databases DROP COLUMN parameters;

--- a/internal/repositories/postgres/migrations/096_add_database_parameters.down.sql
+++ b/internal/repositories/postgres/migrations/096_add_database_parameters.down.sql
@@ -1,1 +1,2 @@
--- +goose Down\nALTER TABLE databases DROP COLUMN parameters;
+-- +goose Down
+ALTER TABLE databases DROP COLUMN parameters;

--- a/internal/repositories/postgres/migrations/096_add_database_parameters.up.sql
+++ b/internal/repositories/postgres/migrations/096_add_database_parameters.up.sql
@@ -1,0 +1,1 @@
+-- +goose Up\nALTER TABLE databases ADD COLUMN parameters JSONB DEFAULT '{}'::jsonb;

--- a/internal/repositories/postgres/migrations/096_add_database_parameters.up.sql
+++ b/internal/repositories/postgres/migrations/096_add_database_parameters.up.sql
@@ -1,1 +1,2 @@
--- +goose Up\nALTER TABLE databases ADD COLUMN parameters JSONB DEFAULT '{}'::jsonb;
+-- +goose Up
+ALTER TABLE databases ADD COLUMN parameters JSONB DEFAULT '{}'::jsonb;

--- a/internal/workers/database_failover_worker_test.go
+++ b/internal/workers/database_failover_worker_test.go
@@ -49,8 +49,8 @@ type mockDatabaseService struct {
 	mock.Mock
 }
 
-func (m *mockDatabaseService) CreateDatabase(ctx context.Context, name, engine, version string, vpcID *uuid.UUID, allocatedStorage int) (*domain.Database, error) {
-	args := m.Called(ctx, name, engine, version, vpcID, allocatedStorage)
+func (m *mockDatabaseService) CreateDatabase(ctx context.Context, name, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error) {
+	args := m.Called(ctx, name, engine, version, vpcID, allocatedStorage, parameters)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/tests/database_advanced_e2e_test.go
+++ b/tests/database_advanced_e2e_test.go
@@ -27,7 +27,40 @@ func TestDatabaseAdvancedE2E(t *testing.T) {
 	client := &http.Client{Timeout: 30 * time.Second}
 	token := registerAndLogin(t, client, "db-advanced@thecloud.local", "Advanced Tester")
 
+	t.Run("CreateDatabaseWithParameters", func(t *testing.T) {
+		payload := map[string]interface{}{
+			"name":              "e2e-db-with-params",
+			"engine":            "postgres",
+			"version":           "16",
+			"allocated_storage": 10,
+			"parameters": map[string]string{
+				"max_connections": "200",
+			},
+		}
+		resp := postRequest(t, client, testutil.TestBaseURL+"/databases", token, payload)
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
+
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		var res struct {
+			Data domain.Database `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		dbID := res.Data.ID.String()
+		assert.NotEmpty(t, dbID)
+		assert.Equal(t, "200", res.Data.Parameters["max_connections"])
+
+		// Cleanup
+		respDel := deleteRequest(t, client, fmt.Sprintf("%s/databases/%s", testutil.TestBaseURL, dbID), token)
+		if respDel != nil && respDel.Body != nil {
+			defer respDel.Body.Close()
+		}
+	})
+
 	t.Run("InvalidConfigurations", func(t *testing.T) {
+
 		runInvalidConfigsTest(t, client, token)
 	})
 


### PR DESCRIPTION
This PR introduces the ability to specify custom engine parameters when provisioning managed databases (PostgreSQL and MySQL).

### Key Features:
- **Dynamic Configuration**: Users can now provide a `parameters` map (key-value pairs) in the `CreateDatabaseRequest`.
- **Engine Injection**: Parameters are securely injected directly into the container entrypoint via CLI arguments (`-c key=value` for Postgres, `--key=value` for MySQL).
- **Metadata Persistence**: The parameters map is persisted as a `JSONB` column in the `databases` repository, allowing for tracking and future configuration updates.
- **Replica Inheritance**: Read replicas are provisioned using the same exact parameters as their primary counterpart, ensuring consistency across the cluster.

### Implementation Details:
- `domain.Database` extended with `Parameters map[string]string`.
- Added migration `096_add_database_parameters`.
- Updated `DatabaseService.CreateDatabase` to parse and format the `Cmd` execution slice.
- Extended unit, integration, and E2E tests (including a new `CreateDatabaseWithParameters` test case) to cover the configuration logic.