### PR TITLE
feat(rds): automated backups and snapshots for RDS

### DIFF
--- a/cmd/cloud/dns.go
+++ b/cmd/cloud/dns.go
@@ -92,7 +92,7 @@ var dnsDeleteZoneCmd = &cobra.Command{
 	Use:     "rm-zone [id]",
 	Aliases: []string{"delete-zone"},
 	Short:   "Delete a DNS zone",
-	Args:  cobra.ExactArgs(1),
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		id := args[0]
 		client := createClient(opts)

--- a/cmd/cloud/kubernetes_test.go
+++ b/cmd/cloud/kubernetes_test.go
@@ -14,7 +14,7 @@ import (
 const (
 	kubernetesTestContentType = "Content-Type"
 	kubernetesTestAppJSON     = "application/json"
-	kubernetesTestAPIKey = "kube-test-key"
+	kubernetesTestAPIKey      = "kube-test-key"
 )
 
 func TestListClustersJSONOutput(t *testing.T) {

--- a/cmd/cloud/logs_test.go
+++ b/cmd/cloud/logs_test.go
@@ -38,8 +38,8 @@ func TestLogsSearch(t *testing.T) {
 	oldURL := opts.APIURL
 	opts.APIURL = server.URL
 	opts.APIKey = "test-key"
-	defer func() { 
-		opts.APIURL = oldURL 
+	defer func() {
+		opts.APIURL = oldURL
 		opts.APIKey = ""
 	}()
 
@@ -80,8 +80,8 @@ func TestLogsShow(t *testing.T) {
 	oldURL := opts.APIURL
 	opts.APIURL = server.URL
 	opts.APIKey = "test-key"
-	defer func() { 
-		opts.APIURL = oldURL 
+	defer func() {
+		opts.APIURL = oldURL
 		opts.APIKey = ""
 	}()
 

--- a/docs/adr/ADR-018-database-automated-backups.md
+++ b/docs/adr/ADR-018-database-automated-backups.md
@@ -1,0 +1,41 @@
+# ADR 018: Managed Database Backups & Snapshots
+
+## Status
+Accepted
+
+## Context
+The Managed Database Service (RDS) provides persistent storage via block volumes, but lacked a native backup and recovery mechanism. Users needed a way to protect against data loss caused by accidental deletions or volume corruption.
+
+We needed a solution that was:
+1.  **Fast and efficient** (incremental or point-in-time).
+2.  **Engine-agnostic** (works for both Postgres and MySQL).
+3.  **Integrated** with the platform's existing storage management.
+
+## Decision
+We implemented automated backups by integrating the `DatabaseService` with the core `SnapshotService`.
+
+### 1. Volume-Level Snapshots
+Instead of logical dumps (e.g., `pg_dump`), we utilize block-level snapshots. This ensures crash-consistent backups that are extremely fast to create and restore, regardless of the database size.
+
+### 2. Implementation in DatabaseService
+The `DatabaseService` was extended with:
+-   `CreateDatabaseSnapshot`: Resolves the database's underlying volume and triggers a snapshot.
+-   `ListDatabaseSnapshots`: Retrieves all snapshots associated with a database's volume.
+-   `RestoreDatabase`: Provisions a completely new database instance using a volume restored from a snapshot.
+
+### 3. Dynamic Volume Binding
+The container launch logic was refactored to support binding existing volumes (restored from snapshots) instead of always creating fresh ones.
+
+### 4. Restore Workflow
+Restore is a "provision-from-backup" workflow rather than an "in-place overwrite". This follows immutable infrastructure principles, allowing users to verify the restored data on a new instance before decommissioning the old one.
+
+## Consequences
+
+### Positive
+-   **High Performance**: Snapshots are near-instant and handled at the storage layer.
+-   **Lower Resource Usage**: No heavy query load on the database engine during backup creation.
+-   **Stateless Restore**: Restoring to a new instance simplifies recovery and prevents data corruption on the original instance.
+
+### Negative
+-   **Crash Consistency Only**: While storage-level snapshots are highly reliable, they do not guarantee application-level consistency (e.g., in-flight transactions) unless the engine is explicitly flushed/quiesced (future enhancement).
+-   **Storage Costs**: Each snapshot consumes additional block storage space.

--- a/docs/database.md
+++ b/docs/database.md
@@ -331,6 +331,20 @@ This integration ensures that all database state (tables, indexes, logs) is stor
 -   **Automated Provisioning**: Volumes are created synchronously during the `CreateDatabase` and `CreateReplica` calls. Replicas inherit the `allocated_storage` size of their primary.
 -   **Automated Cleanup**: When a database is deleted via the API, the service identifies and deletes the associated block volumes to prevent storage leaks.
 
+### Managed Database Backups & Snapshots
+
+The platform provides a native backup and recovery mechanism leveraging volume snapshots.
+
+#### Backup Creation (Snapshots)
+Users can create manual point-in-time backups of their databases. The system takes a crash-consistent snapshot of the underlying block volume, ensuring all persisted data is captured.
+- **Endpoint**: `POST /databases/:id/snapshots`
+- **Mechanism**: Integrated with core `SnapshotService`.
+
+#### Data Recovery (Restore)
+Databases can be restored from any valid snapshot. The restore process provisions a **completely new database instance** using a volume initialized from the snapshot data. This allows for safe verification of restored data without affecting the source database.
+- **Endpoint**: `POST /databases/restore`
+- **Flexibility**: Users can specify new names, VPCs, and configurations during the restore process.
+
 ### Managed Database Configuration (Parameter Groups)
 
 The platform supports dynamic engine configuration via a `parameters` map provided at creation time.

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -1340,6 +1340,125 @@ const docTemplate = `{
                 }
             }
         },
+        "/databases/restore": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Creates a new database instance from an existing volume snapshot",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "databases"
+                ],
+                "summary": "Restore database from snapshot",
+                "parameters": [
+                    {
+                        "description": "Restore parameters",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.RestoreDatabaseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Database"
+                        }
+                    }
+                }
+            }
+        },
+        "/databases/{id}/snapshots": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Returns all snapshots belonging to a specific database",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "databases"
+                ],
+                "summary": "List database snapshots",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Database ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Snapshot"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Creates a point-in-time backup of the database underlying volume",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "databases"
+                ],
+                "summary": "Create database snapshot",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Database ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Snapshot description",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CreateDatabaseSnapshotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Snapshot"
+                        }
+                    }
+                }
+            }
+        },
         "/dns/records/{id}": {
             "get": {
                 "security": [
@@ -6768,6 +6887,104 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.Database": {
+            "type": "object",
+            "properties": {
+                "allocated_storage": {
+                    "type": "integer"
+                },
+                "container_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "engine": {
+                    "$ref": "#/definitions/domain.DatabaseEngine"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "primary_id": {
+                    "description": "ID of the primary if this is a replica",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/domain.DatabaseRole"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.DatabaseStatus"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "version": {
+                    "description": "Engine version (e.g. \"15\", \"8.0\")",
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "description": "Optional private networking",
+                    "type": "string"
+                }
+            }
+        },
+        "domain.DatabaseEngine": {
+            "type": "string",
+            "enum": [
+                "postgres",
+                "mysql"
+            ],
+            "x-enum-varnames": [
+                "EnginePostgres",
+                "EngineMySQL"
+            ]
+        },
+        "domain.DatabaseRole": {
+            "type": "string",
+            "enum": [
+                "PRIMARY",
+                "REPLICA"
+            ],
+            "x-enum-varnames": [
+                "RolePrimary",
+                "RoleReplica"
+            ]
+        },
+        "domain.DatabaseStatus": {
+            "type": "string",
+            "enum": [
+                "CREATING",
+                "RUNNING",
+                "STOPPED",
+                "DELETING",
+                "FAILED"
+            ],
+            "x-enum-varnames": [
+                "DatabaseStatusCreating",
+                "DatabaseStatusRunning",
+                "DatabaseStatusStopped",
+                "DatabaseStatusDeleting",
+                "DatabaseStatusFailed"
+            ]
+        },
         "domain.ElasticIP": {
             "type": "object",
             "properties": {
@@ -8617,6 +8834,14 @@ const docTemplate = `{
                 }
             }
         },
+        "httphandlers.CreateDatabaseSnapshotRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.CreateGlobalLBRequest": {
             "type": "object",
             "required": [
@@ -9079,6 +9304,42 @@ const docTemplate = `{
             ],
             "properties": {
                 "backup_path": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.RestoreDatabaseRequest": {
+            "type": "object",
+            "required": [
+                "allocated_storage",
+                "engine",
+                "name",
+                "snapshot_id",
+                "version"
+            ],
+            "properties": {
+                "allocated_storage": {
+                    "type": "integer"
+                },
+                "engine": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "snapshot_id": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "vpc_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1332,6 +1332,125 @@
                 }
             }
         },
+        "/databases/restore": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Creates a new database instance from an existing volume snapshot",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "databases"
+                ],
+                "summary": "Restore database from snapshot",
+                "parameters": [
+                    {
+                        "description": "Restore parameters",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.RestoreDatabaseRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Database"
+                        }
+                    }
+                }
+            }
+        },
+        "/databases/{id}/snapshots": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Returns all snapshots belonging to a specific database",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "databases"
+                ],
+                "summary": "List database snapshots",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Database ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.Snapshot"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Creates a point-in-time backup of the database underlying volume",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "databases"
+                ],
+                "summary": "Create database snapshot",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Database ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Snapshot description",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CreateDatabaseSnapshotRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Snapshot"
+                        }
+                    }
+                }
+            }
+        },
         "/dns/records/{id}": {
             "get": {
                 "security": [
@@ -6760,6 +6879,104 @@
                 }
             }
         },
+        "domain.Database": {
+            "type": "object",
+            "properties": {
+                "allocated_storage": {
+                    "type": "integer"
+                },
+                "container_id": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "engine": {
+                    "$ref": "#/definitions/domain.DatabaseEngine"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "primary_id": {
+                    "description": "ID of the primary if this is a replica",
+                    "type": "string"
+                },
+                "role": {
+                    "$ref": "#/definitions/domain.DatabaseRole"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.DatabaseStatus"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                },
+                "version": {
+                    "description": "Engine version (e.g. \"15\", \"8.0\")",
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "description": "Optional private networking",
+                    "type": "string"
+                }
+            }
+        },
+        "domain.DatabaseEngine": {
+            "type": "string",
+            "enum": [
+                "postgres",
+                "mysql"
+            ],
+            "x-enum-varnames": [
+                "EnginePostgres",
+                "EngineMySQL"
+            ]
+        },
+        "domain.DatabaseRole": {
+            "type": "string",
+            "enum": [
+                "PRIMARY",
+                "REPLICA"
+            ],
+            "x-enum-varnames": [
+                "RolePrimary",
+                "RoleReplica"
+            ]
+        },
+        "domain.DatabaseStatus": {
+            "type": "string",
+            "enum": [
+                "CREATING",
+                "RUNNING",
+                "STOPPED",
+                "DELETING",
+                "FAILED"
+            ],
+            "x-enum-varnames": [
+                "DatabaseStatusCreating",
+                "DatabaseStatusRunning",
+                "DatabaseStatusStopped",
+                "DatabaseStatusDeleting",
+                "DatabaseStatusFailed"
+            ]
+        },
         "domain.ElasticIP": {
             "type": "object",
             "properties": {
@@ -8609,6 +8826,14 @@
                 }
             }
         },
+        "httphandlers.CreateDatabaseSnapshotRequest": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.CreateGlobalLBRequest": {
             "type": "object",
             "required": [
@@ -9071,6 +9296,42 @@
             ],
             "properties": {
                 "backup_path": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.RestoreDatabaseRequest": {
+            "type": "object",
+            "required": [
+                "allocated_storage",
+                "engine",
+                "name",
+                "snapshot_id",
+                "version"
+            ],
+            "properties": {
+                "allocated_storage": {
+                    "type": "integer"
+                },
+                "engine": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "parameters": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "snapshot_id": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                },
+                "vpc_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -233,6 +233,76 @@ definitions:
       summary:
         $ref: '#/definitions/domain.ResourceSummary'
     type: object
+  domain.Database:
+    properties:
+      allocated_storage:
+        type: integer
+      container_id:
+        type: string
+      created_at:
+        type: string
+      engine:
+        $ref: '#/definitions/domain.DatabaseEngine'
+      id:
+        type: string
+      name:
+        type: string
+      parameters:
+        additionalProperties:
+          type: string
+        type: object
+      port:
+        type: integer
+      primary_id:
+        description: ID of the primary if this is a replica
+        type: string
+      role:
+        $ref: '#/definitions/domain.DatabaseRole'
+      status:
+        $ref: '#/definitions/domain.DatabaseStatus'
+      updated_at:
+        type: string
+      user_id:
+        type: string
+      username:
+        type: string
+      version:
+        description: Engine version (e.g. "15", "8.0")
+        type: string
+      vpc_id:
+        description: Optional private networking
+        type: string
+    type: object
+  domain.DatabaseEngine:
+    enum:
+    - postgres
+    - mysql
+    type: string
+    x-enum-varnames:
+    - EnginePostgres
+    - EngineMySQL
+  domain.DatabaseRole:
+    enum:
+    - PRIMARY
+    - REPLICA
+    type: string
+    x-enum-varnames:
+    - RolePrimary
+    - RoleReplica
+  domain.DatabaseStatus:
+    enum:
+    - CREATING
+    - RUNNING
+    - STOPPED
+    - DELETING
+    - FAILED
+    type: string
+    x-enum-varnames:
+    - DatabaseStatusCreating
+    - DatabaseStatusRunning
+    - DatabaseStatusStopped
+    - DatabaseStatusDeleting
+    - DatabaseStatusFailed
   domain.ElasticIP:
     properties:
       arn:
@@ -1571,6 +1641,11 @@ definitions:
     - name
     - vpc_id
     type: object
+  httphandlers.CreateDatabaseSnapshotRequest:
+    properties:
+      description:
+        type: string
+    type: object
   httphandlers.CreateGlobalLBRequest:
     properties:
       health_check:
@@ -1886,6 +1961,31 @@ definitions:
         type: string
     required:
     - backup_path
+    type: object
+  httphandlers.RestoreDatabaseRequest:
+    properties:
+      allocated_storage:
+        type: integer
+      engine:
+        type: string
+      name:
+        type: string
+      parameters:
+        additionalProperties:
+          type: string
+        type: object
+      snapshot_id:
+        type: string
+      version:
+        type: string
+      vpc_id:
+        type: string
+    required:
+    - allocated_storage
+    - engine
+    - name
+    - snapshot_id
+    - version
     type: object
   httphandlers.RestoreSnapshotRequest:
     properties:
@@ -2820,6 +2920,80 @@ paths:
       summary: Upgrade cluster version
       tags:
       - K8s
+  /databases/{id}/snapshots:
+    get:
+      description: Returns all snapshots belonging to a specific database
+      parameters:
+      - description: Database ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.Snapshot'
+            type: array
+      security:
+      - APIKeyAuth: []
+      summary: List database snapshots
+      tags:
+      - databases
+    post:
+      consumes:
+      - application/json
+      description: Creates a point-in-time backup of the database underlying volume
+      parameters:
+      - description: Database ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Snapshot description
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/httphandlers.CreateDatabaseSnapshotRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.Snapshot'
+      security:
+      - APIKeyAuth: []
+      summary: Create database snapshot
+      tags:
+      - databases
+  /databases/restore:
+    post:
+      consumes:
+      - application/json
+      description: Creates a new database instance from an existing volume snapshot
+      parameters:
+      - description: Restore parameters
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.RestoreDatabaseRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.Database'
+      security:
+      - APIKeyAuth: []
+      summary: Restore database from snapshot
+      tags:
+      - databases
   /dns/records/{id}:
     delete:
       parameters:

--- a/internal/adapters/dns/powerdns_geo_test.go
+++ b/internal/adapters/dns/powerdns_geo_test.go
@@ -47,7 +47,7 @@ func TestPowerDNSGeo(t *testing.T) {
 	t.Run("Invalid Hostname", func(t *testing.T) {
 		err := backend.CreateGeoRecord(ctx, "invalid", nil)
 		require.Error(t, err)
-		
+
 		err = backend.DeleteGeoRecord(ctx, "invalid")
 		require.Error(t, err)
 	})

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -259,17 +259,17 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 		return nil, nil, err
 	}
 
-        snapshotSvc := services.NewSnapshotService(c.Repos.Snapshot, c.Repos.Volume, c.Storage, eventSvc, auditSvc, c.Logger)
+	snapshotSvc := services.NewSnapshotService(c.Repos.Snapshot, c.Repos.Volume, c.Storage, eventSvc, auditSvc, c.Logger)
 	databaseSvc := services.NewDatabaseService(services.DatabaseServiceParams{
-		Repo:      c.Repos.Database,
-		Compute:   c.Compute,
-		VpcRepo:   c.Repos.Vpc,
-		VolumeSvc: volumeSvc,
-                SnapshotSvc:  snapshotSvc,
-                SnapshotRepo: c.Repos.Snapshot,
-		EventSvc:  eventSvc,
-		AuditSvc:  auditSvc,
-		Logger:    c.Logger,
+		Repo:         c.Repos.Database,
+		Compute:      c.Compute,
+		VpcRepo:      c.Repos.Vpc,
+		VolumeSvc:    volumeSvc,
+		SnapshotSvc:  snapshotSvc,
+		SnapshotRepo: c.Repos.Snapshot,
+		EventSvc:     eventSvc,
+		AuditSvc:     auditSvc,
+		Logger:       c.Logger,
 	})
 	secretSvc := services.NewSecretService(c.Repos.Secret, eventSvc, auditSvc, c.Logger, c.Config.SecretsEncryptionKey, c.Config.Environment)
 	fnSvc := services.NewFunctionService(c.Repos.Function, c.Compute, fileStore, auditSvc, c.Logger)
@@ -308,7 +308,7 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 		Storage: storageSvc, Database: databaseSvc, Secret: secretSvc, Function: fnSvc, Cache: cacheSvc,
 		Queue: queueSvc, Notify: notifySvc, Cron: cronSvc, Gateway: gwSvc, Container: containerSvc,
 		Pipeline: pipelineSvc,
-		Health: services.NewHealthServiceImpl(c.DB, c.Compute, clusterSvc), AutoScaling: asgSvc, Accounting: accountingSvc, Image: imageSvc,
+		Health:   services.NewHealthServiceImpl(c.DB, c.Compute, clusterSvc), AutoScaling: asgSvc, Accounting: accountingSvc, Image: imageSvc,
 		Cluster:      clusterSvc,
 		Dashboard:    services.NewDashboardService(c.Repos.Instance, c.Repos.Volume, c.Repos.Vpc, c.Repos.Event, c.Logger),
 		Lifecycle:    services.NewLifecycleService(c.Repos.Lifecycle, c.Repos.Storage),
@@ -335,7 +335,7 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 
 	workersCollection := &Workers{
 		LB: lbWorker, AutoScaling: asgWorker, Cron: cronWorker, Container: containerWorker,
-		Pipeline:          workers.NewPipelineWorker(c.Repos.Pipeline, c.Repos.TaskQueue, c.Compute, c.Logger),
+		Pipeline:  workers.NewPipelineWorker(c.Repos.Pipeline, c.Repos.TaskQueue, c.Compute, c.Logger),
 		Provision: provisionWorker, Accounting: accountingWorker,
 		Cluster:           workers.NewClusterWorker(c.Repos.Cluster, clusterProvisioner, c.Repos.TaskQueue, c.Logger),
 		Lifecycle:         workers.NewLifecycleWorker(c.Repos.Lifecycle, storageSvc, c.Repos.Storage, c.Logger),

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -259,11 +259,14 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 		return nil, nil, err
 	}
 
+        snapshotSvc := services.NewSnapshotService(c.Repos.Snapshot, c.Repos.Volume, c.Storage, eventSvc, auditSvc, c.Logger)
 	databaseSvc := services.NewDatabaseService(services.DatabaseServiceParams{
 		Repo:      c.Repos.Database,
 		Compute:   c.Compute,
 		VpcRepo:   c.Repos.Vpc,
 		VolumeSvc: volumeSvc,
+                SnapshotSvc:  snapshotSvc,
+                SnapshotRepo: c.Repos.Snapshot,
 		EventSvc:  eventSvc,
 		AuditSvc:  auditSvc,
 		Logger:    c.Logger,
@@ -281,7 +284,6 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 	gwSvc := services.NewGatewayService(c.Repos.Gateway, auditSvc)
 	containerSvc := services.NewContainerService(c.Repos.Container, eventSvc, auditSvc)
 	containerWorker := services.NewContainerWorker(c.Repos.Container, instSvcConcrete, eventSvc)
-	snapshotSvc := services.NewSnapshotService(c.Repos.Snapshot, c.Repos.Volume, c.Storage, eventSvc, auditSvc, c.Logger)
 	stackSvc := services.NewStackService(c.Repos.Stack, instSvcConcrete, vpcSvc, volumeSvc, snapshotSvc, c.Logger)
 
 	// 6. Business & Scaling Services

--- a/internal/api/setup/infrastructure_test.go
+++ b/internal/api/setup/infrastructure_test.go
@@ -1,10 +1,10 @@
 package setup
 
 import (
+	"github.com/stretchr/testify/require"
 	"log/slog"
 	"os"
 	"testing"
-	"github.com/stretchr/testify/require"
 
 	"github.com/poyrazk/thecloud/internal/platform"
 	"github.com/stretchr/testify/assert"
@@ -91,7 +91,7 @@ func TestInitNetworkBackend(t *testing.T) {
 
 func TestInitLBProxy(t *testing.T) {
 	cfg := &platform.Config{}
-	
+
 	t.Run("default", func(t *testing.T) {
 		proxy, err := InitLBProxy(cfg, nil, nil, nil)
 		require.NoError(t, err)

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -460,12 +460,15 @@ func registerDataRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 	dbGroup.Use(httputil.Auth(svcs.Identity, svcs.Tenant))
 	{
 		dbGroup.POST("", httputil.Permission(svcs.RBAC, domain.PermissionDBCreate), handlers.Database.Create)
+		dbGroup.POST("/restore", httputil.Permission(svcs.RBAC, domain.PermissionDBCreate), handlers.Database.Restore)
 		dbGroup.GET("", httputil.Permission(svcs.RBAC, domain.PermissionDBRead), handlers.Database.List)
 		dbGroup.GET("/:id", httputil.Permission(svcs.RBAC, domain.PermissionDBRead), handlers.Database.Get)
 		dbGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionDBDelete), handlers.Database.Delete)
 		dbGroup.GET("/:id/connection", httputil.Permission(svcs.RBAC, domain.PermissionDBRead), handlers.Database.GetConnectionString)
 		dbGroup.POST("/:id/replicas", httputil.Permission(svcs.RBAC, domain.PermissionDBCreate), handlers.Database.CreateReplica)
 		dbGroup.POST("/:id/promote", httputil.Permission(svcs.RBAC, domain.PermissionDBUpdate), handlers.Database.Promote)
+		dbGroup.POST("/:id/snapshots", httputil.Permission(svcs.RBAC, domain.PermissionDBCreate), handlers.Database.CreateSnapshot)
+		dbGroup.GET("/:id/snapshots", httputil.Permission(svcs.RBAC, domain.PermissionDBRead), handlers.Database.ListSnapshots)
 	}
 
 	cacheGroup := r.Group("/caches")

--- a/internal/core/domain/elastic_ip_test.go
+++ b/internal/core/domain/elastic_ip_test.go
@@ -1,8 +1,8 @@
 package domain
 
 import (
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/internal/core/domain/iam.go
+++ b/internal/core/domain/iam.go
@@ -18,11 +18,11 @@ type Condition map[string]map[string]interface{}
 
 // Statement is a single rule within a policy.
 type Statement struct {
-	Sid       string    `json:"sid,omitempty"`
+	Sid       string       `json:"sid,omitempty"`
 	Effect    PolicyEffect `json:"effect"`
-	Action    []string  `json:"action"`
-	Resource  []string  `json:"resource"`
-	Condition Condition `json:"condition,omitempty"`
+	Action    []string     `json:"action"`
+	Resource  []string     `json:"resource"`
+	Condition Condition    `json:"condition,omitempty"`
 }
 
 // Policy represents a JSON-based identity policy.

--- a/internal/core/domain/security_group_test.go
+++ b/internal/core/domain/security_group_test.go
@@ -1,8 +1,8 @@
 package domain
 
 import (
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"

--- a/internal/core/domain/tenant.go
+++ b/internal/core/domain/tenant.go
@@ -14,7 +14,7 @@ type Tenant struct {
 	Slug      string    `json:"slug"` // URL-friendly identifier
 	OwnerID   uuid.UUID `json:"owner_id"`
 	Plan      string    `json:"plan" enums:"free,pro,enterprise"` // "free", "pro", "enterprise"
-	Status    string    `json:"status" enums:"active,suspended"` // "active", "suspended"
+	Status    string    `json:"status" enums:"active,suspended"`  // "active", "suspended"
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/internal/core/ports/database.go
+++ b/internal/core/ports/database.go
@@ -40,4 +40,10 @@ type DatabaseService interface {
 	DeleteDatabase(ctx context.Context, id uuid.UUID) error
 	// GetConnectionString constructs and returns the authorized URI for connecting to the database.
 	GetConnectionString(ctx context.Context, id uuid.UUID) (string, error)
+	// CreateDatabaseSnapshot initiates a point-in-time copy of a database's underlying volume.
+	CreateDatabaseSnapshot(ctx context.Context, databaseID uuid.UUID, description string) (*domain.Snapshot, error)
+	// ListDatabaseSnapshots returns all snapshots belonging to a specific database.
+	ListDatabaseSnapshots(ctx context.Context, databaseID uuid.UUID) ([]*domain.Snapshot, error)
+	// RestoreDatabase creates a new database instance from an existing snapshot.
+	RestoreDatabase(ctx context.Context, snapshotID uuid.UUID, newName, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error)
 }

--- a/internal/core/ports/log.go
+++ b/internal/core/ports/log.go
@@ -10,10 +10,10 @@ import (
 type LogRepository interface {
 	// Create persists a batch of log entries.
 	Create(ctx context.Context, entries []*domain.LogEntry) error
-	
+
 	// List retrieves log entries based on the provided query.
 	List(ctx context.Context, query domain.LogQuery) ([]*domain.LogEntry, int, error)
-	
+
 	// DeleteByAge removes logs older than the specified duration (for retention).
 	DeleteByAge(ctx context.Context, days int) error
 }
@@ -22,10 +22,10 @@ type LogRepository interface {
 type LogService interface {
 	// IngestLogs processes and persists logs for a resource.
 	IngestLogs(ctx context.Context, entries []*domain.LogEntry) error
-	
+
 	// SearchLogs searches logs with filtering and pagination.
 	SearchLogs(ctx context.Context, query domain.LogQuery) ([]*domain.LogEntry, int, error)
-	
+
 	// RunRetentionPolicy performs periodic log cleanup.
 	RunRetentionPolicy(ctx context.Context, days int) error
 }

--- a/internal/core/services/accounting_internal_test.go
+++ b/internal/core/services/accounting_internal_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type MockAccountingRepository struct {

--- a/internal/core/services/audit_test.go
+++ b/internal/core/services/audit_test.go
@@ -71,7 +71,7 @@ func TestAuditService_Integration(t *testing.T) {
 
 		logs, err := svc.ListLogs(ctx, userID, 10)
 		require.NoError(t, err)
-		
+
 		for _, log := range logs {
 			assert.Equal(t, userID, log.UserID)
 			assert.NotEqual(t, otherUserID, log.UserID)

--- a/internal/core/services/autoscaling_test.go
+++ b/internal/core/services/autoscaling_test.go
@@ -183,7 +183,7 @@ func (s *NoopLBService) ListTargets(ctx context.Context, lbID uuid.UUID) ([]*dom
 	return nil, nil
 }
 func (s *NoopLBService) List(ctx context.Context) ([]*domain.LoadBalancer, error) { return nil, nil }
-func (s *NoopLBService) Delete(ctx context.Context, id string) error           { return nil }
+func (s *NoopLBService) Delete(ctx context.Context, id string) error              { return nil }
 func (s *NoopLBService) CreateListener(ctx context.Context, lbID uuid.UUID, port int, protocol string) error {
 	return nil
 }

--- a/internal/core/services/cache_unit_test.go
+++ b/internal/core/services/cache_unit_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type MockCacheRepository struct {
@@ -114,7 +114,7 @@ func TestCacheService_Unit_Extended(t *testing.T) {
 			Port:     6379,
 		}
 		repo.On("GetByID", mock.Anything, cacheID).Return(cache, nil).Once()
-		
+
 		conn, err := svc.GetConnectionString(ctx, cacheID.String())
 		require.NoError(t, err)
 		assert.Contains(t, conn, "redis://:pass@localhost:6379")
@@ -135,7 +135,7 @@ func TestCacheService_Unit_Extended(t *testing.T) {
 		cacheID := uuid.New()
 		cache := &domain.Cache{ID: cacheID, ContainerID: "cid", Status: domain.CacheStatusRunning}
 		repo.On("GetByID", mock.Anything, cacheID).Return(cache, nil).Once()
-		
+
 		statsJSON := `{"memory_stats": {"usage": 1024, "limit": 2048}}`
 		compute.On("GetInstanceStats", mock.Anything, "cid").Return(io.NopCloser(strings.NewReader(statsJSON)), nil).Once()
 		compute.On("Exec", mock.Anything, "cid", mock.Anything).Return("connected_clients:1\r\ndb0:keys=5,expires=0,avg_ttl=0", nil).Once()

--- a/internal/core/services/cached_identity_test.go
+++ b/internal/core/services/cached_identity_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockIdentityService struct {

--- a/internal/core/services/cloudlogs_unit_test.go
+++ b/internal/core/services/cloudlogs_unit_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
@@ -50,17 +50,17 @@ func TestCloudLogsServiceIngestLogsUnit(t *testing.T) {
 		res, _ := resource.New(ctx, resource.WithAttributes(semconv.ServiceNameKey.String("test")))
 		tp := sdktrace.NewTracerProvider(sdktrace.WithResource(res))
 		tr := tp.Tracer("test")
-		
+
 		ctxWithTrace, span := tr.Start(ctx, "test-span")
 		defer span.End()
-		
+
 		traceID := span.SpanContext().TraceID().String()
 
 		entries := []*domain.LogEntry{
 			{ID: uuid.New(), Message: "test context trace"},
 		}
 		mockRepo.On("Create", mock.Anything, entries).Return(nil).Once()
-		
+
 		err := svc.IngestLogs(ctxWithTrace, entries)
 		require.NoError(t, err)
 		assert.Equal(t, traceID, entries[0].TraceID)
@@ -69,12 +69,12 @@ func TestCloudLogsServiceIngestLogsUnit(t *testing.T) {
 	t.Run("no trace id in context", func(t *testing.T) {
 		// Use a context with a no-op span (no trace ID)
 		ctxNoTrace := trace.ContextWithSpan(ctx, trace.SpanFromContext(context.Background()))
-		
+
 		entries := []*domain.LogEntry{
 			{ID: uuid.New(), Message: "no trace"},
 		}
 		mockRepo.On("Create", mock.Anything, entries).Return(nil).Once()
-		
+
 		err := svc.IngestLogs(ctxNoTrace, entries)
 		require.NoError(t, err)
 		assert.Empty(t, entries[0].TraceID)
@@ -90,7 +90,7 @@ func TestCloudLogsServiceSearchLogsUnit(t *testing.T) {
 
 	query := domain.LogQuery{ResourceID: "res-1"}
 	expectedLogs := []*domain.LogEntry{{Message: "found"}}
-	
+
 	mockRepo.On("List", mock.Anything, query).Return(expectedLogs, 1, nil)
 
 	logs, total, err := svc.SearchLogs(ctx, query)

--- a/internal/core/services/cluster_lifecycle_test.go
+++ b/internal/core/services/cluster_lifecycle_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/core/services/cluster_test.go
+++ b/internal/core/services/cluster_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/core/services/container_unit_test.go
+++ b/internal/core/services/container_unit_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestContainerService_Unit(t *testing.T) {
@@ -18,7 +18,7 @@ func TestContainerService_Unit(t *testing.T) {
 	eventSvc := new(MockEventService)
 	auditSvc := new(MockAuditService)
 	svc := services.NewContainerService(repo, eventSvc, auditSvc)
-	
+
 	ctx := context.Background()
 	userID := uuid.New()
 	ctx = appcontext.WithUserID(ctx, userID)

--- a/internal/core/services/dashboard_test.go
+++ b/internal/core/services/dashboard_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Mock repositories (local to dashboard_test as it is in package services)

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -106,7 +106,7 @@ func (s *DatabaseService) CreateDatabase(ctx context.Context, name, engine, vers
 		mountPath = "/var/lib/mysql"
 	}
 	volumeBinds := []string{fmt.Sprintf("%s:%s", backendVolName, mountPath)}
-	
+
 	cmd := s.buildEngineCmd(dbEngine, parameters)
 
 	dockerName := fmt.Sprintf("cloud-db-%s-%s", name, db.ID.String()[:8])
@@ -574,7 +574,7 @@ func (s *DatabaseService) RestoreDatabase(ctx context.Context, snapshotID uuid.U
 		mountPath = "/var/lib/mysql"
 	}
 	volumeBinds := []string{fmt.Sprintf("%s:%s", backendVolName, mountPath)}
-	
+
 	cmd := s.buildEngineCmd(dbEngine, parameters)
 
 	dockerName := fmt.Sprintf("cloud-db-%s-%s", newName, db.ID.String()[:8])

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -20,36 +20,42 @@ import (
 
 // DatabaseService manages database instances and lifecycle.
 type DatabaseService struct {
-	repo      ports.DatabaseRepository
-	compute   ports.ComputeBackend
-	vpcRepo   ports.VpcRepository
-	volumeSvc ports.VolumeService
-	eventSvc  ports.EventService
-	auditSvc  ports.AuditService
-	logger    *slog.Logger
+	repo         ports.DatabaseRepository
+	compute      ports.ComputeBackend
+	vpcRepo      ports.VpcRepository
+	volumeSvc    ports.VolumeService
+	snapshotSvc  ports.SnapshotService
+	snapshotRepo ports.SnapshotRepository
+	eventSvc     ports.EventService
+	auditSvc     ports.AuditService
+	logger       *slog.Logger
 }
 
 // DatabaseServiceParams holds dependencies for DatabaseService creation.
 type DatabaseServiceParams struct {
-	Repo      ports.DatabaseRepository
-	Compute   ports.ComputeBackend
-	VpcRepo   ports.VpcRepository
-	VolumeSvc ports.VolumeService
-	EventSvc  ports.EventService
-	AuditSvc  ports.AuditService
-	Logger    *slog.Logger
+	Repo         ports.DatabaseRepository
+	Compute      ports.ComputeBackend
+	VpcRepo      ports.VpcRepository
+	VolumeSvc    ports.VolumeService
+	SnapshotSvc  ports.SnapshotService
+	SnapshotRepo ports.SnapshotRepository
+	EventSvc     ports.EventService
+	AuditSvc     ports.AuditService
+	Logger       *slog.Logger
 }
 
 // NewDatabaseService constructs a DatabaseService with its dependencies.
 func NewDatabaseService(params DatabaseServiceParams) *DatabaseService {
 	return &DatabaseService{
-		repo:      params.Repo,
-		compute:   params.Compute,
-		vpcRepo:   params.VpcRepo,
-		volumeSvc: params.VolumeSvc,
-		eventSvc:  params.EventSvc,
-		auditSvc:  params.AuditSvc,
-		logger:    params.Logger,
+		repo:         params.Repo,
+		compute:      params.Compute,
+		vpcRepo:      params.VpcRepo,
+		volumeSvc:    params.VolumeSvc,
+		snapshotSvc:  params.SnapshotSvc,
+		snapshotRepo: params.SnapshotRepo,
+		eventSvc:     params.EventSvc,
+		auditSvc:     params.AuditSvc,
+		logger:       params.Logger,
 	}
 }
 
@@ -443,6 +449,177 @@ func (s *DatabaseService) DeleteDatabase(ctx context.Context, id uuid.UUID) erro
 	platform.RDSInstancesTotal.WithLabelValues(string(db.Engine), "running").Dec()
 
 	return nil
+}
+
+func (s *DatabaseService) getVolumeForDatabase(ctx context.Context, db *domain.Database) (*domain.Volume, error) {
+	vols, err := s.volumeSvc.ListVolumes(ctx)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list volumes", err)
+	}
+
+	expectedPrefix := fmt.Sprintf("db-vol-%s", db.ID.String()[:8])
+	if db.Role == domain.RoleReplica {
+		expectedPrefix = fmt.Sprintf("db-replica-vol-%s", db.ID.String()[:8])
+	}
+
+	for _, v := range vols {
+		if strings.HasPrefix(v.Name, expectedPrefix) {
+			return v, nil
+		}
+	}
+
+	return nil, errors.New(errors.NotFound, "underlying database volume not found")
+}
+
+func (s *DatabaseService) CreateDatabaseSnapshot(ctx context.Context, databaseID uuid.UUID, description string) (*domain.Snapshot, error) {
+	db, err := s.repo.GetByID(ctx, databaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	if db.Status != domain.DatabaseStatusRunning && db.Status != domain.DatabaseStatusStopped {
+		return nil, errors.New(errors.InvalidInput, "database must be running or stopped to create a snapshot")
+	}
+
+	vol, err := s.getVolumeForDatabase(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotName := fmt.Sprintf("db-snap-%s-%s", db.Name, time.Now().Format("20060102150405"))
+	if description != "" {
+		snapshotName = fmt.Sprintf("%s-%s", snapshotName, description)
+	}
+
+	snap, err := s.snapshotSvc.CreateSnapshot(ctx, vol.ID, snapshotName)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = s.auditSvc.Log(ctx, db.UserID, "database.snapshot.create", "database", db.ID.String(), map[string]interface{}{
+		"snapshot_id": snap.ID,
+	})
+
+	return snap, nil
+}
+
+func (s *DatabaseService) ListDatabaseSnapshots(ctx context.Context, databaseID uuid.UUID) ([]*domain.Snapshot, error) {
+	db, err := s.repo.GetByID(ctx, databaseID)
+	if err != nil {
+		return nil, err
+	}
+
+	vol, err := s.getVolumeForDatabase(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.snapshotRepo.ListByVolumeID(ctx, vol.ID)
+}
+
+func (s *DatabaseService) RestoreDatabase(ctx context.Context, snapshotID uuid.UUID, newName, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+
+	snap, err := s.snapshotSvc.GetSnapshot(ctx, snapshotID)
+	if err != nil {
+		return nil, err
+	}
+
+	if allocatedStorage < snap.SizeGB {
+		return nil, errors.New(errors.InvalidInput, fmt.Sprintf("allocated storage (%dGB) must be at least the snapshot size (%dGB)", allocatedStorage, snap.SizeGB))
+	}
+
+	dbEngine := domain.DatabaseEngine(engine)
+	if !s.isValidEngine(dbEngine) {
+		return nil, errors.New(errors.InvalidInput, "unsupported database engine")
+	}
+
+	password, err := util.GenerateRandomPassword(16)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to generate password", err)
+	}
+
+	username := s.getDefaultUsername(dbEngine)
+	db := s.initialDatabaseRecord(userID, newName, dbEngine, version, username, password, vpcID)
+	db.Role = domain.RolePrimary
+	db.AllocatedStorage = allocatedStorage
+	db.Parameters = parameters
+
+	imageName, env, defaultPort := s.getEngineConfig(dbEngine, version, username, password, newName, db.Role, "")
+
+	networkID, err := s.resolveVpcNetwork(ctx, vpcID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create persistent volume FOR THE NEW DATABASE from the snapshot
+	volName := fmt.Sprintf("db-vol-%s", db.ID.String()[:8])
+	vol, err := s.snapshotSvc.RestoreSnapshot(ctx, snapshotID, volName)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to restore volume from snapshot", err)
+	}
+
+	// If the user requested MORE storage than the snapshot, we might need to resize the volume here.
+	// For V1, we assume the restored volume inherits the snapshot size initially, and resizing is handled by volumeSvc.
+	// We'll update our internal tracking to what the volume actually is if we couldn't resize.
+	db.AllocatedStorage = vol.SizeGB // Ensure DB record matches actual volume
+
+	backendVolName := "thecloud-vol-" + vol.ID.String()[:8]
+	if vol.BackendPath != "" {
+		backendVolName = vol.BackendPath
+	}
+
+	mountPath := "/var/lib/postgresql/data"
+	if dbEngine == domain.EngineMySQL {
+		mountPath = "/var/lib/mysql"
+	}
+	volumeBinds := []string{fmt.Sprintf("%s:%s", backendVolName, mountPath)}
+	
+	cmd := s.buildEngineCmd(dbEngine, parameters)
+
+	dockerName := fmt.Sprintf("cloud-db-%s-%s", newName, db.ID.String()[:8])
+	containerID, allocatedPorts, err := s.compute.LaunchInstanceWithOptions(ctx, ports.CreateInstanceOptions{
+		Name:        dockerName,
+		ImageName:   imageName,
+		Ports:       []string{"0:" + defaultPort},
+		NetworkID:   networkID,
+		VolumeBinds: volumeBinds,
+		Env:         env,
+		Cmd:         cmd,
+	})
+
+	if err != nil {
+		_ = s.volumeSvc.DeleteVolume(ctx, vol.ID.String())
+		s.logger.Error("failed to launch restored database container", "error", err)
+		return nil, errors.Wrap(errors.Internal, "failed to launch restored database container", err)
+	}
+
+	hostPort, err := s.parseAllocatedPort(allocatedPorts, defaultPort)
+	if err != nil || hostPort == 0 {
+		hostPort, _ = s.compute.GetInstancePort(ctx, containerID, defaultPort)
+	}
+
+	db.ContainerID = containerID
+	db.Port = hostPort
+	db.Status = domain.DatabaseStatusRunning
+
+	if err := s.repo.Create(ctx, db); err != nil {
+		_ = s.compute.DeleteInstance(ctx, containerID)
+		_ = s.volumeSvc.DeleteVolume(ctx, vol.ID.String())
+		return nil, err
+	}
+
+	_ = s.eventSvc.RecordEvent(ctx, "DATABASE_RESTORE", db.ID.String(), "DATABASE", map[string]interface{}{
+		"snapshot_id": snapshotID,
+	})
+
+	_ = s.auditSvc.Log(ctx, userID, "database.restore", "database", db.ID.String(), map[string]interface{}{
+		"snapshot_id": snapshotID,
+	})
+
+	platform.RDSInstancesTotal.WithLabelValues(engine, "running").Inc()
+
+	return db, nil
 }
 
 func (s *DatabaseService) GetConnectionString(ctx context.Context, id uuid.UUID) (string, error) {

--- a/internal/core/services/database_test.go
+++ b/internal/core/services/database_test.go
@@ -51,6 +51,8 @@ func setupDatabaseServiceTest(t *testing.T) (ports.DatabaseService, ports.Databa
 		Compute:   compute,
 		VpcRepo:   vpcRepo,
 		VolumeSvc: volumeSvc,
+		SnapshotSvc:  nil,
+		SnapshotRepo: nil,
 		EventSvc:  eventSvc,
 		AuditSvc:  auditSvc,
 		Logger:    logger,

--- a/internal/core/services/database_test.go
+++ b/internal/core/services/database_test.go
@@ -47,15 +47,15 @@ func setupDatabaseServiceTest(t *testing.T) (ports.DatabaseService, ports.Databa
 	logger := slog.Default()
 
 	svc := services.NewDatabaseService(services.DatabaseServiceParams{
-		Repo:      repo,
-		Compute:   compute,
-		VpcRepo:   vpcRepo,
-		VolumeSvc: volumeSvc,
+		Repo:         repo,
+		Compute:      compute,
+		VpcRepo:      vpcRepo,
+		VolumeSvc:    volumeSvc,
 		SnapshotSvc:  nil,
 		SnapshotRepo: nil,
-		EventSvc:  eventSvc,
-		AuditSvc:  auditSvc,
-		Logger:    logger,
+		EventSvc:     eventSvc,
+		AuditSvc:     auditSvc,
+		Logger:       logger,
 	})
 
 	return svc, repo, compute, vpcRepo, ctx

--- a/internal/core/services/database_unit_test.go
+++ b/internal/core/services/database_unit_test.go
@@ -65,7 +65,9 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 		Compute:   mockCompute,
 		VpcRepo:   mockVpcRepo,
 		VolumeSvc: mockVolumeSvc,
-		EventSvc:  mockEventSvc,
+		SnapshotSvc:  new(mockSnapshotService),
+		SnapshotRepo: new(mockSnapshotRepository),
+		EventSvc:     mockEventSvc,
 		AuditSvc:  mockAuditSvc,
 		Logger:    slog.Default(),
 	})
@@ -233,3 +235,49 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 		assert.Nil(t, replica)
 	})
 }
+
+type mockSnapshotService struct {
+	mock.Mock
+}
+func (m *mockSnapshotService) CreateSnapshot(ctx context.Context, volumeID uuid.UUID, description string) (*domain.Snapshot, error) {
+	args := m.Called(ctx, volumeID, description)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*domain.Snapshot), args.Error(1)
+}
+func (m *mockSnapshotService) ListSnapshots(ctx context.Context) ([]*domain.Snapshot, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]*domain.Snapshot), args.Error(1)
+}
+func (m *mockSnapshotService) GetSnapshot(ctx context.Context, id uuid.UUID) (*domain.Snapshot, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*domain.Snapshot), args.Error(1)
+}
+func (m *mockSnapshotService) DeleteSnapshot(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+func (m *mockSnapshotService) RestoreSnapshot(ctx context.Context, snapshotID uuid.UUID, newVolumeName string) (*domain.Volume, error) {
+	args := m.Called(ctx, snapshotID, newVolumeName)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*domain.Volume), args.Error(1)
+}
+
+type mockSnapshotRepository struct {
+	mock.Mock
+}
+func (m *mockSnapshotRepository) Create(ctx context.Context, s *domain.Snapshot) error { return m.Called(ctx, s).Error(0) }
+func (m *mockSnapshotRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.Snapshot, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*domain.Snapshot), args.Error(1)
+}
+func (m *mockSnapshotRepository) ListByVolumeID(ctx context.Context, volumeID uuid.UUID) ([]*domain.Snapshot, error) {
+	args := m.Called(ctx, volumeID)
+	return args.Get(0).([]*domain.Snapshot), args.Error(1)
+}
+func (m *mockSnapshotRepository) ListByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.Snapshot, error) {
+	args := m.Called(ctx, userID)
+	return args.Get(0).([]*domain.Snapshot), args.Error(1)
+}
+func (m *mockSnapshotRepository) Update(ctx context.Context, s *domain.Snapshot) error { return m.Called(ctx, s).Error(0) }
+func (m *mockSnapshotRepository) Delete(ctx context.Context, id uuid.UUID) error { return m.Called(ctx, id).Error(0) }

--- a/internal/core/services/database_unit_test.go
+++ b/internal/core/services/database_unit_test.go
@@ -61,15 +61,15 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 	mockVolumeSvc := new(MockVolumeService)
 
 	svc := services.NewDatabaseService(services.DatabaseServiceParams{
-		Repo:      mockRepo,
-		Compute:   mockCompute,
-		VpcRepo:   mockVpcRepo,
-		VolumeSvc: mockVolumeSvc,
+		Repo:         mockRepo,
+		Compute:      mockCompute,
+		VpcRepo:      mockVpcRepo,
+		VolumeSvc:    mockVolumeSvc,
 		SnapshotSvc:  new(mockSnapshotService),
 		SnapshotRepo: new(mockSnapshotRepository),
 		EventSvc:     mockEventSvc,
-		AuditSvc:  mockAuditSvc,
-		Logger:    slog.Default(),
+		AuditSvc:     mockAuditSvc,
+		Logger:       slog.Default(),
 	})
 
 	ctx := context.Background()
@@ -193,10 +193,10 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 		volID := uuid.New()
 		mockVolumeSvc.On("CreateVolume", mock.Anything, mock.Anything, 10).
 			Return(&domain.Volume{ID: volID, Name: "db-vol"}, nil).Once()
-		
+
 		mockCompute.On("LaunchInstanceWithOptions", mock.Anything, mock.Anything).
 			Return("", nil, fmt.Errorf("launch failed")).Once()
-		
+
 		mockVolumeSvc.On("DeleteVolume", mock.Anything, volID.String()).Return(nil).Once()
 
 		db, err := svc.CreateDatabase(ctx, "fail-db", "postgres", "16", nil, 10, nil)
@@ -209,13 +209,13 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 		volID := uuid.New()
 		mockVolumeSvc.On("CreateVolume", mock.Anything, mock.Anything, 10).
 			Return(&domain.Volume{ID: volID, Name: "db-vol"}, nil).Once()
-		
+
 		mockCompute.On("LaunchInstanceWithOptions", mock.Anything, mock.Anything).
 			Return("cid-123", []string{"30001:5432"}, nil).Once()
-		
+
 		mockRepo.On("Create", mock.Anything, mock.Anything).
 			Return(fmt.Errorf("repo failed")).Once()
-		
+
 		mockCompute.On("DeleteInstance", mock.Anything, "cid-123").Return(nil).Once()
 		mockVolumeSvc.On("DeleteVolume", mock.Anything, volID.String()).Return(nil).Once()
 
@@ -239,9 +239,12 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 type mockSnapshotService struct {
 	mock.Mock
 }
+
 func (m *mockSnapshotService) CreateSnapshot(ctx context.Context, volumeID uuid.UUID, description string) (*domain.Snapshot, error) {
 	args := m.Called(ctx, volumeID, description)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*domain.Snapshot), args.Error(1)
 }
 func (m *mockSnapshotService) ListSnapshots(ctx context.Context) ([]*domain.Snapshot, error) {
@@ -250,7 +253,9 @@ func (m *mockSnapshotService) ListSnapshots(ctx context.Context) ([]*domain.Snap
 }
 func (m *mockSnapshotService) GetSnapshot(ctx context.Context, id uuid.UUID) (*domain.Snapshot, error) {
 	args := m.Called(ctx, id)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*domain.Snapshot), args.Error(1)
 }
 func (m *mockSnapshotService) DeleteSnapshot(ctx context.Context, id uuid.UUID) error {
@@ -258,17 +263,24 @@ func (m *mockSnapshotService) DeleteSnapshot(ctx context.Context, id uuid.UUID) 
 }
 func (m *mockSnapshotService) RestoreSnapshot(ctx context.Context, snapshotID uuid.UUID, newVolumeName string) (*domain.Volume, error) {
 	args := m.Called(ctx, snapshotID, newVolumeName)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*domain.Volume), args.Error(1)
 }
 
 type mockSnapshotRepository struct {
 	mock.Mock
 }
-func (m *mockSnapshotRepository) Create(ctx context.Context, s *domain.Snapshot) error { return m.Called(ctx, s).Error(0) }
+
+func (m *mockSnapshotRepository) Create(ctx context.Context, s *domain.Snapshot) error {
+	return m.Called(ctx, s).Error(0)
+}
 func (m *mockSnapshotRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.Snapshot, error) {
 	args := m.Called(ctx, id)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*domain.Snapshot), args.Error(1)
 }
 func (m *mockSnapshotRepository) ListByVolumeID(ctx context.Context, volumeID uuid.UUID) ([]*domain.Snapshot, error) {
@@ -279,5 +291,9 @@ func (m *mockSnapshotRepository) ListByUserID(ctx context.Context, userID uuid.U
 	args := m.Called(ctx, userID)
 	return args.Get(0).([]*domain.Snapshot), args.Error(1)
 }
-func (m *mockSnapshotRepository) Update(ctx context.Context, s *domain.Snapshot) error { return m.Called(ctx, s).Error(0) }
-func (m *mockSnapshotRepository) Delete(ctx context.Context, id uuid.UUID) error { return m.Called(ctx, id).Error(0) }
+func (m *mockSnapshotRepository) Update(ctx context.Context, s *domain.Snapshot) error {
+	return m.Called(ctx, s).Error(0)
+}
+func (m *mockSnapshotRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}

--- a/internal/core/services/dns_unit_test.go
+++ b/internal/core/services/dns_unit_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type MockDNSRepository struct {
@@ -112,7 +112,7 @@ func TestDNSService_Unit_Extended(t *testing.T) {
 	vpcRepo := new(MockVpcRepo)
 	auditSvc := new(MockAuditService)
 	eventSvc := new(MockEventService)
-	
+
 	svc := services.NewDNSService(services.DNSServiceParams{
 		Repo:     repo,
 		Backend:  backend,
@@ -170,7 +170,7 @@ func TestDNSService_Unit_Extended(t *testing.T) {
 		zoneID := uuid.New()
 		record := &domain.DNSRecord{ID: recordID, ZoneID: zoneID, Name: "www", Type: domain.RecordTypeA, Content: "1.2.3.4"}
 		zone := &domain.DNSZone{ID: zoneID, Name: "example.com", PowerDNSID: "example.com."}
-		
+
 		repo.On("GetRecordByID", mock.Anything, recordID).Return(record, nil).Once()
 		repo.On("GetZoneByID", mock.Anything, zoneID).Return(zone, nil).Once()
 		backend.On("UpdateRecords", mock.Anything, "example.com.", mock.Anything).Return(nil).Once()

--- a/internal/core/services/elastic_ip_unit_test.go
+++ b/internal/core/services/elastic_ip_unit_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestElasticIPService_AllocateIP(t *testing.T) {

--- a/internal/core/services/event_test.go
+++ b/internal/core/services/event_test.go
@@ -41,7 +41,7 @@ func TestEventService_Integration(t *testing.T) {
 		// Verify in DB
 		result, err := repo.List(ctx, 10)
 		require.NoError(t, err)
-		
+
 		found := false
 		for _, e := range result {
 			if e.Action == action {
@@ -57,7 +57,7 @@ func TestEventService_Integration(t *testing.T) {
 
 	t.Run("ListEvents_Limits", func(t *testing.T) {
 		uniqueType := "LIMIT_TEST_" + uuid.New().String()[:8]
-		
+
 		for i := 0; i < 5; i++ {
 			_ = svc.RecordEvent(ctx, "ACTION", "res", uniqueType, nil)
 		}
@@ -71,7 +71,7 @@ func TestEventService_Integration(t *testing.T) {
 		t.Run("DefaultLimit", func(t *testing.T) {
 			result, err := svc.ListEvents(ctx, 0)
 			require.NoError(t, err)
-			
+
 			count := 0
 			for _, e := range result {
 				if e.ResourceType == uniqueType {

--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -346,7 +346,7 @@ func (s *FunctionService) extractZipFile(file *zip.File, tmpDir string) error {
 		return err
 	}
 
-	// Use O_EXCL to prevent overwriting existing files if applicable, 
+	// Use O_EXCL to prevent overwriting existing files if applicable,
 	// though here it's a fresh tmpDir.
 	dst, err := os.OpenFile(filepath.Clean(path), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600) // G306: tighten permissions
 	if err != nil {

--- a/internal/core/services/iam_test.go
+++ b/internal/core/services/iam_test.go
@@ -9,8 +9,8 @@ import (
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports/mocks"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIAMService(t *testing.T) {

--- a/internal/core/services/iam_unit_test.go
+++ b/internal/core/services/iam_unit_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type MockIAMRepository struct {
@@ -87,11 +87,11 @@ func TestIAMService_Unit(t *testing.T) {
 		err := svc.AttachPolicyToUser(ctx, userID, policyID)
 		require.NoError(t, err)
 	})
-	
+
 	t.Run("GetPoliciesForUser", func(t *testing.T) {
 		userID := uuid.New()
 		mockRepo.On("GetPoliciesForUser", mock.Anything, tenantID, userID).Return([]*domain.Policy{}, nil).Once()
-		
+
 		res, err := svc.GetPoliciesForUser(ctx, userID)
 		require.NoError(t, err)
 		assert.NotNil(t, res)

--- a/internal/core/services/instance_internal_test.go
+++ b/internal/core/services/instance_internal_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const testVolumeName = "test-vol"
@@ -91,13 +91,13 @@ func TestInstanceServiceInternalUpdateVolumesAfterLaunch(t *testing.T) {
 func TestInstanceService_CalculateInstanceStats(t *testing.T) {
 	svc := &InstanceService{}
 	stats := &domain.RawDockerStats{}
-	
+
 	stats.CPUStats.CPUUsage.TotalUsage = 1000
 	stats.CPUStats.SystemCPUUsage = 10000
-	
+
 	stats.PreCPUStats.CPUUsage.TotalUsage = 500
 	stats.PreCPUStats.SystemCPUUsage = 5000
-	
+
 	stats.MemoryStats.Usage = 1024
 	stats.MemoryStats.Limit = 2048
 

--- a/internal/core/services/instance_test.go
+++ b/internal/core/services/instance_test.go
@@ -79,7 +79,7 @@ func setupInstanceServiceTest(t *testing.T) (*pgxpool.Pool, *services.InstanceSe
 
 	var compute coreports.ComputeBackend
 	var err error
-	
+
 	backend := os.Getenv("COMPUTE_BACKEND")
 	if backend == "libvirt" {
 		uri := os.Getenv("LIBVIRT_URI")
@@ -182,7 +182,7 @@ func TestLaunchInstanceSuccess(t *testing.T) {
 	updatedInst, err := repo.GetByID(ctx, inst.ID)
 	require.NoError(t, err)
 	assert.Equal(t, domain.StatusRunning, updatedInst.Status)
-	
+
 	// Only verify container/IP if compute is actually functional
 	if compute.Type() != "noop" {
 		assert.NotEmpty(t, updatedInst.ContainerID)
@@ -239,7 +239,7 @@ func TestInstanceServiceLaunchDBFailure(t *testing.T) {
 	subnetRepo := postgres.NewSubnetRepository(db)
 	volumeRepo := postgres.NewVolumeRepository(db)
 	itRepo := postgres.NewInstanceTypeRepository(db)
-	
+
 	// Use noop for compute to focus on DB failure logic
 	compute := noop.NewNoopComputeBackend()
 
@@ -370,7 +370,7 @@ func TestInstanceServiceLaunchConcurrency(t *testing.T) {
 
 func TestInstanceServiceGetStatsReal(t *testing.T) {
 	_, svc, compute, _, _, _, ctx := setupInstanceServiceTest(t)
-	
+
 	// Skip if noop compute
 	if compute.Type() == "noop" {
 		t.Skip("Skipping stats test for noop compute")
@@ -413,7 +413,7 @@ func TestInstanceServiceGetStatsReal(t *testing.T) {
 
 func TestNetworkingCIDRExhaustion(t *testing.T) {
 	db, svc, compute, _, vpcRepo, _, ctx := setupInstanceServiceTest(t)
-	
+
 	// Skip if noop compute
 	if compute.Type() == "noop" {
 		t.Skip("Skipping CIDR exhaustion test for noop compute")

--- a/internal/core/services/lifecycle_svc_test.go
+++ b/internal/core/services/lifecycle_svc_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateRule(t *testing.T) {

--- a/internal/core/services/loadbalancer_unit_test.go
+++ b/internal/core/services/loadbalancer_unit_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLBService_Unit(t *testing.T) {
@@ -41,10 +41,10 @@ func TestLBService_Unit(t *testing.T) {
 		lbID := uuid.New()
 		vpcID := uuid.New()
 		instID := uuid.New()
-		
+
 		lb := &domain.LoadBalancer{ID: lbID, VpcID: vpcID, UserID: userID}
 		inst := &domain.Instance{ID: instID, VpcID: &vpcID}
-		
+
 		mockRepo.On("GetByID", mock.Anything, lbID).Return(lb, nil).Once()
 		mockInstRepo.On("GetByID", mock.Anything, instID).Return(inst, nil).Once()
 		mockRepo.On("AddTarget", mock.Anything, mock.Anything).Return(nil).Once()

--- a/internal/core/services/pipeline.go
+++ b/internal/core/services/pipeline.go
@@ -2,10 +2,10 @@
 package services
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"crypto/subtle"
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"

--- a/internal/core/services/pipeline_unit_test.go
+++ b/internal/core/services/pipeline_unit_test.go
@@ -155,12 +155,12 @@ func TestPipelineServiceTriggerBuildWebhookDuplicateDeliveryIgnored(t *testing.T
 	repo.On("ReserveWebhookDelivery", mock.Anything, pipelineID, "github", "push", "delivery-1").Return(false, nil).Once()
 
 	build, err := svc.TriggerBuildWebhook(context.Background(), ports.WebhookTriggerOptions{
-		PipelineID:  pipelineID,
-		Provider:    "github",
-		Event:       "push",
-		Signature:   githubSignature(testWebhookSecret, payload),
-		DeliveryID:  "delivery-1",
-		Payload:     payload,
+		PipelineID: pipelineID,
+		Provider:   "github",
+		Event:      "push",
+		Signature:  githubSignature(testWebhookSecret, payload),
+		DeliveryID: "delivery-1",
+		Payload:    payload,
 	})
 
 	require.NoError(t, err)
@@ -188,12 +188,12 @@ func TestPipelineServiceTriggerBuildWebhookBranchMismatchIgnored(t *testing.T) {
 	repo.On("ReserveWebhookDelivery", mock.Anything, pipelineID, "github", "push", "delivery-2").Return(true, nil).Once()
 
 	build, err := svc.TriggerBuildWebhook(context.Background(), ports.WebhookTriggerOptions{
-		PipelineID:  pipelineID,
-		Provider:    "github",
-		Event:       "push",
-		Signature:   githubSignature(testWebhookSecret, payload),
-		DeliveryID:  "delivery-2",
-		Payload:     payload,
+		PipelineID: pipelineID,
+		Provider:   "github",
+		Event:      "push",
+		Signature:  githubSignature(testWebhookSecret, payload),
+		DeliveryID: "delivery-2",
+		Payload:    payload,
 	})
 
 	require.NoError(t, err)
@@ -228,12 +228,12 @@ func TestPipelineServiceTriggerBuildWebhookSuccessQueuesBuild(t *testing.T) {
 	auditSvc.On("Log", mock.Anything, userID, "pipeline.run", "pipeline_build", mock.Anything, mock.Anything).Return(nil).Once()
 
 	build, err := svc.TriggerBuildWebhook(context.Background(), ports.WebhookTriggerOptions{
-		PipelineID:  pipelineID,
-		Provider:    "github",
-		Event:       "push",
-		Signature:   githubSignature(testWebhookSecret, payload),
-		DeliveryID:  "delivery-3",
-		Payload:     payload,
+		PipelineID: pipelineID,
+		Provider:   "github",
+		Event:      "push",
+		Signature:  githubSignature(testWebhookSecret, payload),
+		DeliveryID: "delivery-3",
+		Payload:    payload,
 	})
 
 	require.NoError(t, err)

--- a/internal/core/services/rbac_iam_test.go
+++ b/internal/core/services/rbac_iam_test.go
@@ -19,7 +19,7 @@ func TestRBACService_IAMIntegration(t *testing.T) {
 	iamRepo := new(mocks.IAMRepository)
 	evaluator := NewIAMEvaluator()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	
+
 	svc := NewRBACService(userRepo, roleRepo, iamRepo, evaluator, logger)
 	ctx := context.Background()
 	userID := uuid.New()
@@ -63,7 +63,7 @@ func TestRBACService_IAMIntegration(t *testing.T) {
 		userRepo.On("GetByID", ctx, userID).Return(&domain.User{ID: userID, TenantID: tenantID, Role: "custom-dev"}, nil).Once()
 		iamRepo.On("GetPoliciesForUser", ctx, tenantID, userID).Return([]*domain.Policy{}, nil).Once()
 		roleRepo.On("GetRoleByName", ctx, "custom-dev").Return(&domain.Role{ID: uuid.New(), Name: "custom-dev", Permissions: []domain.Permission{domain.PermissionInstanceLaunch}}, nil).Once()
-		
+
 		// Fallback logic for custom role
 		allowed, err := svc.HasPermission(ctx, userID, domain.PermissionInstanceLaunch, "*")
 		require.NoError(t, err)

--- a/internal/core/services/setup_test.go
+++ b/internal/core/services/setup_test.go
@@ -35,7 +35,7 @@ func setupDB(t *testing.T) *pgxpool.Pool {
 
 	// Use a unique schema for this test run to allow parallel execution in CI
 	schema := "test_" + strings.ReplaceAll(uuid.New().String(), "-", "_")
-	
+
 	// Create base connection to initialize schema
 	baseDB, err := pgxpool.New(ctx, dbURL)
 	require.NoError(t, err)
@@ -45,11 +45,11 @@ func setupDB(t *testing.T) *pgxpool.Pool {
 	require.NoError(t, err)
 
 	// Configure pool to use the schema for ALL connections
-	// We MUST include 'public' in search_path because extensions like uuid-ossp 
+	// We MUST include 'public' in search_path because extensions like uuid-ossp
 	// are usually installed there and functions like uuid_generate_v4() won't be found otherwise.
 	config, err := pgxpool.ParseConfig(dbURL)
 	require.NoError(t, err)
-	
+
 	if config.ConnConfig.RuntimeParams == nil {
 		config.ConnConfig.RuntimeParams = make(map[string]string)
 	}
@@ -80,7 +80,7 @@ func setupDB(t *testing.T) *pgxpool.Pool {
 	} else {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
-	
+
 	err = postgres.RunMigrations(ctx, db, logger)
 	require.NoError(t, err, "Failed to run migrations")
 
@@ -176,7 +176,7 @@ func cleanDB(t *testing.T, db *pgxpool.Pool) {
 		AND table_type = 'BASE TABLE'
 		AND table_name != 'schema_migrations'
 	`, schema)
-	
+
 	rows, err := db.Query(ctx, query)
 	if err != nil {
 		t.Logf("Warning: failed to query tables for cleanup: %v", err)

--- a/internal/core/services/stack_unit_test.go
+++ b/internal/core/services/stack_unit_test.go
@@ -10,8 +10,8 @@ import (
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStackServiceUnit(t *testing.T) {
@@ -30,12 +30,12 @@ func TestStackServiceUnit(t *testing.T) {
 		mockRepo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
 		// Allow background updates
 		mockRepo.On("Update", mock.Anything, mock.Anything).Return(nil).Maybe()
-		
+
 		stack, err := svc.CreateStack(ctx, "my-stack", "Resources: {}", nil)
 		require.NoError(t, err)
 		assert.NotNil(t, stack)
 		assert.Equal(t, "my-stack", stack.Name)
-		
+
 		// Give background processing a tiny bit of time
 		time.Sleep(10 * time.Millisecond)
 	})

--- a/internal/core/services/storage_unit_test.go
+++ b/internal/core/services/storage_unit_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/poyrazk/thecloud/internal/platform"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStorageServiceUnit(t *testing.T) {

--- a/internal/core/services/vpc_peering_test.go
+++ b/internal/core/services/vpc_peering_test.go
@@ -99,7 +99,7 @@ func TestVPCPeeringServiceIntegration(t *testing.T) {
 		vpc2 := createVPC("vpc-reject-2", "10.50.0.0/16")
 
 		peering, _ := svc.CreatePeering(ctx, vpc1.ID, vpc2.ID)
-		
+
 		err := svc.RejectPeering(ctx, peering.ID)
 		require.NoError(t, err)
 
@@ -114,7 +114,7 @@ func TestVPCPeeringServiceIntegration(t *testing.T) {
 
 		// Create another user/tenant
 		ctx2 := setupTestUser(t, db)
-		
+
 		// Should not be able to see peering from first tenant
 		list, err := svc.ListPeerings(ctx2)
 		require.NoError(t, err)

--- a/internal/handlers/cache_handler_test.go
+++ b/internal/handlers/cache_handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/container_handler_test.go
+++ b/internal/handlers/container_handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/database_handler.go
+++ b/internal/handlers/database_handler.go
@@ -164,6 +164,17 @@ type RestoreDatabaseRequest struct {
 	Parameters       map[string]string `json:"parameters"`
 }
 
+// CreateSnapshot creates a point-in-time backup of the database.
+// @Summary Create database snapshot
+// @Description Creates a point-in-time backup of the database underlying volume
+// @Tags databases
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Database ID"
+// @Param request body CreateDatabaseSnapshotRequest false "Snapshot description"
+// @Success 201 {object} domain.Snapshot
+// @Router /databases/{id}/snapshots [post]
 func (h *DatabaseHandler) CreateSnapshot(c *gin.Context) {
 	databaseID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -186,6 +197,15 @@ func (h *DatabaseHandler) CreateSnapshot(c *gin.Context) {
 	httputil.Success(c, http.StatusCreated, snap)
 }
 
+// ListSnapshots returns all snapshots for a database.
+// @Summary List database snapshots
+// @Description Returns all snapshots belonging to a specific database
+// @Tags databases
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Database ID"
+// @Success 200 {array} domain.Snapshot
+// @Router /databases/{id}/snapshots [get]
 func (h *DatabaseHandler) ListSnapshots(c *gin.Context) {
 	databaseID, err := uuid.Parse(c.Param("id"))
 	if err != nil {
@@ -202,6 +222,16 @@ func (h *DatabaseHandler) ListSnapshots(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, snaps)
 }
 
+// Restore provisions a new database from a snapshot.
+// @Summary Restore database from snapshot
+// @Description Creates a new database instance from an existing volume snapshot
+// @Tags databases
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param request body RestoreDatabaseRequest true "Restore parameters"
+// @Success 201 {object} domain.Database
+// @Router /databases/restore [post]
 func (h *DatabaseHandler) Restore(c *gin.Context) {
 	var req RestoreDatabaseRequest
 	if err := c.ShouldBindJSON(&req); err != nil {

--- a/internal/handlers/database_handler.go
+++ b/internal/handlers/database_handler.go
@@ -147,3 +147,73 @@ func (h *DatabaseHandler) GetConnectionString(c *gin.Context) {
 
 	httputil.Success(c, http.StatusOK, gin.H{"connection_string": connStr})
 }
+
+// CreateDatabaseSnapshotRequest is the payload for creating a database snapshot.
+type CreateDatabaseSnapshotRequest struct {
+	Description string `json:"description"`
+}
+
+// RestoreDatabaseRequest is the payload for restoring a database from a snapshot.
+type RestoreDatabaseRequest struct {
+	SnapshotID       uuid.UUID         `json:"snapshot_id" binding:"required"`
+	Name             string            `json:"name" binding:"required"`
+	Engine           string            `json:"engine" binding:"required"`
+	Version          string            `json:"version" binding:"required"`
+	VpcID            *uuid.UUID        `json:"vpc_id"`
+	AllocatedStorage int               `json:"allocated_storage" binding:"required"`
+	Parameters       map[string]string `json:"parameters"`
+}
+
+func (h *DatabaseHandler) CreateSnapshot(c *gin.Context) {
+	databaseID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, invalidDatabaseIDMsg))
+		return
+	}
+
+	var req CreateDatabaseSnapshotRequest
+	if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" { // Allow empty body
+		httputil.Error(c, errors.New(errors.InvalidInput, err.Error()))
+		return
+	}
+
+	snap, err := h.svc.CreateDatabaseSnapshot(c.Request.Context(), databaseID, req.Description)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusCreated, snap)
+}
+
+func (h *DatabaseHandler) ListSnapshots(c *gin.Context) {
+	databaseID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, invalidDatabaseIDMsg))
+		return
+	}
+
+	snaps, err := h.svc.ListDatabaseSnapshots(c.Request.Context(), databaseID)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, snaps)
+}
+
+func (h *DatabaseHandler) Restore(c *gin.Context) {
+	var req RestoreDatabaseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, err.Error()))
+		return
+	}
+
+	db, err := h.svc.RestoreDatabase(c.Request.Context(), req.SnapshotID, req.Name, req.Engine, req.Version, req.VpcID, req.AllocatedStorage, req.Parameters)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusCreated, db)
+}

--- a/internal/handlers/database_handler_test.go
+++ b/internal/handlers/database_handler_test.go
@@ -80,6 +80,21 @@ func (m *mockDatabaseService) DeleteDatabase(ctx context.Context, id uuid.UUID) 
 	return args.Error(0)
 }
 
+
+func (m *mockDatabaseService) CreateDatabaseSnapshot(ctx context.Context, databaseID uuid.UUID, description string) (*domain.Snapshot, error) {
+	args := m.Called(ctx, databaseID, description)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*domain.Snapshot), args.Error(1)
+}
+func (m *mockDatabaseService) ListDatabaseSnapshots(ctx context.Context, databaseID uuid.UUID) ([]*domain.Snapshot, error) {
+	args := m.Called(ctx, databaseID)
+	return args.Get(0).([]*domain.Snapshot), args.Error(1)
+}
+func (m *mockDatabaseService) RestoreDatabase(ctx context.Context, snapshotID uuid.UUID, newName, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error) {
+	args := m.Called(ctx, snapshotID, newName, engine, version, vpcID, allocatedStorage, parameters)
+	if args.Get(0) == nil { return nil, args.Error(1) }
+	return args.Get(0).(*domain.Database), args.Error(1)
+}
 func (m *mockDatabaseService) GetConnectionString(ctx context.Context, id uuid.UUID) (string, error) {
 	args := m.Called(ctx, id)
 	return args.String(0), args.Error(1)

--- a/internal/handlers/database_handler_test.go
+++ b/internal/handlers/database_handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -80,10 +80,11 @@ func (m *mockDatabaseService) DeleteDatabase(ctx context.Context, id uuid.UUID) 
 	return args.Error(0)
 }
 
-
 func (m *mockDatabaseService) CreateDatabaseSnapshot(ctx context.Context, databaseID uuid.UUID, description string) (*domain.Snapshot, error) {
 	args := m.Called(ctx, databaseID, description)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*domain.Snapshot), args.Error(1)
 }
 func (m *mockDatabaseService) ListDatabaseSnapshots(ctx context.Context, databaseID uuid.UUID) ([]*domain.Snapshot, error) {
@@ -92,7 +93,9 @@ func (m *mockDatabaseService) ListDatabaseSnapshots(ctx context.Context, databas
 }
 func (m *mockDatabaseService) RestoreDatabase(ctx context.Context, snapshotID uuid.UUID, newName, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error) {
 	args := m.Called(ctx, snapshotID, newName, engine, version, vpcID, allocatedStorage, parameters)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*domain.Database), args.Error(1)
 }
 func (m *mockDatabaseService) GetConnectionString(ctx context.Context, id uuid.UUID) (string, error) {

--- a/internal/handlers/dns_handler_test.go
+++ b/internal/handlers/dns_handler_test.go
@@ -13,8 +13,8 @@ import (
 	mocks "github.com/poyrazk/thecloud/internal/core/ports/mocks"
 	"github.com/poyrazk/thecloud/pkg/httputil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/function_handler_test.go
+++ b/internal/handlers/function_handler_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/identity_handler_test.go
+++ b/internal/handlers/identity_handler_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/lb_handler_test.go
+++ b/internal/handlers/lb_handler_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/log_handler.go
+++ b/internal/handlers/log_handler.go
@@ -41,7 +41,7 @@ func NewLogHandler(svc ports.LogService) *LogHandler {
 // @Router /logs [get]
 func (h *LogHandler) Search(c *gin.Context) {
 	tenantID := appcontext.TenantIDFromContext(c.Request.Context())
-	
+
 	query := domain.LogQuery{
 		TenantID:     tenantID,
 		ResourceID:   c.Query("resource_id"),

--- a/internal/handlers/log_handler_test.go
+++ b/internal/handlers/log_handler_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockLogService struct {
@@ -61,7 +61,7 @@ func TestLogHandlerSearch(t *testing.T) {
 		r.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		
+
 		var resp struct {
 			Data struct {
 				Entries []domain.LogEntry `json:"entries"`

--- a/internal/handlers/notify_handler_test.go
+++ b/internal/handlers/notify_handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/rbac_handler_test.go
+++ b/internal/handlers/rbac_handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/ssh_key_handler_test.go
+++ b/internal/handlers/ssh_key_handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/handlers/volume_handler_test.go
+++ b/internal/handlers/volume_handler_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/internal/platform/circuit_breaker_test.go
+++ b/internal/platform/circuit_breaker_test.go
@@ -2,8 +2,8 @@ package platform
 
 import (
 	"errors"
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"

--- a/internal/platform/config_test.go
+++ b/internal/platform/config_test.go
@@ -1,9 +1,9 @@
 package platform
 
 import (
+	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
-	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/platform/redis_test.go
+++ b/internal/platform/redis_test.go
@@ -2,10 +2,10 @@ package platform
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"io"
 	"log/slog"
 	"testing"
-	"github.com/stretchr/testify/require"
 	"time"
 
 	"github.com/alicebob/miniredis/v2"

--- a/internal/repositories/k8s/provisioner_unit_test.go
+++ b/internal/repositories/k8s/provisioner_unit_test.go
@@ -78,7 +78,7 @@ func (m *mockStorageSvc) CreateBucket(ctx context.Context, n string, p bool) (*d
 func (m *mockStorageSvc) GetBucket(ctx context.Context, n string) (*domain.Bucket, error) {
 	return nil, nil
 }
-func (m *mockStorageSvc) DeleteBucket(ctx context.Context, n string, force bool) error { return nil }
+func (m *mockStorageSvc) DeleteBucket(ctx context.Context, n string, force bool) error    { return nil }
 func (m *mockStorageSvc) ListBuckets(ctx context.Context) ([]*domain.Bucket, error)       { return nil, nil }
 func (m *mockStorageSvc) SetBucketVersioning(ctx context.Context, n string, e bool) error { return nil }
 func (m *mockStorageSvc) GetClusterStatus(ctx context.Context) (*domain.StorageCluster, error) {

--- a/internal/repositories/libvirt/adapter.go
+++ b/internal/repositories/libvirt/adapter.go
@@ -6,8 +6,8 @@ package libvirt
 import (
 	"bytes"
 	"context"
-	stdlib_errors "errors"
 	"encoding/json"
+	stdlib_errors "errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -110,7 +110,7 @@ func NewLibvirtAdapter(logger *slog.Logger, uri string) (*LibvirtAdapter, error)
 		}
 	}
 
-	//nolint:staticcheck 
+	//nolint:staticcheck
 	l := libvirt.New(c)
 	adapter := &LibvirtAdapter{
 		client:             &RealLibvirtClient{conn: l},
@@ -286,7 +286,7 @@ func (a *LibvirtAdapter) cleanupCreateFailure(ctx context.Context, vol libvirt.S
 func (a *LibvirtAdapter) waitInitialIP(ctx context.Context, id string) (string, error) {
 	ticker := time.NewTicker(a.ipWaitInterval)
 	defer ticker.Stop()
-	
+
 	// Safety limit: max 5 minutes regardless of context
 	timeout := time.After(5 * time.Minute)
 
@@ -457,7 +457,7 @@ func (a *LibvirtAdapter) AttachVolume(ctx context.Context, id string, volumePath
 		return fmt.Errorf(errDomainNotFound, err)
 	}
 
-	dev := "vdb" 
+	dev := "vdb"
 
 	diskType := "file"
 	driverType := "qcow2"

--- a/internal/repositories/libvirt/adapter_lifecycle_test.go
+++ b/internal/repositories/libvirt/adapter_lifecycle_test.go
@@ -130,7 +130,7 @@ func TestWaitTaskTimeout(t *testing.T) {
 	m := new(MockLibvirtClient)
 	a := newTestAdapter(m)
 	a.taskWaitInterval = 1 * time.Millisecond
-	
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 

--- a/internal/repositories/libvirt/adapter_unit_test.go
+++ b/internal/repositories/libvirt/adapter_unit_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/digitalocean/go-libvirt"
 	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -609,8 +609,8 @@ func TestDeleteInstance_Unit(t *testing.T) {
 	t.Parallel()
 	m := new(MockLibvirtClient)
 	a := &LibvirtAdapter{
-		client: m, 
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		client:       m,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
 		portMappings: make(map[string]map[string]int),
 	}
 	ctx := context.Background()
@@ -620,7 +620,7 @@ func TestDeleteInstance_Unit(t *testing.T) {
 	m.On("DomainGetState", mock.Anything, dom, uint32(0)).Return(int32(domainStateRunning), int32(0), nil).Once()
 	m.On("DomainDestroy", mock.Anything, dom).Return(nil).Once()
 	m.On("DomainUndefine", mock.Anything, dom).Return(nil).Once()
-	
+
 	// Root volume cleanup mocks
 	pool := libvirt.StoragePool{Name: "default"}
 	vol := libvirt.StorageVol{Name: "test-vm-root"}
@@ -691,7 +691,7 @@ func TestLibvirtAdapter_WaitInitialIP(t *testing.T) {
 		m.On("DomainLookupByName", mock.Anything, id).Return(dom, nil)
 		m.On("DomainGetXMLDesc", mock.Anything, dom, mock.Anything).Return(xml, nil)
 		m.On("NetworkLookupByName", mock.Anything, "default").Return(network, nil)
-		
+
 		// First call returns no lease, second returns lease
 		m.On("NetworkGetDhcpLeases", mock.Anything, network, mock.Anything, uint32(0), uint32(0)).
 			Return([]libvirt.NetworkDhcpLease{}, uint32(0), nil).Once()
@@ -740,7 +740,7 @@ func TestLibvirtAdapter_StatsAndConsole(t *testing.T) {
 		m.On("DomainLookupByName", mock.Anything, id).Return(dom, nil).Once()
 		m.On("DomainMemoryStats", mock.Anything, dom, uint32(10), uint32(0)).Return([]libvirt.DomainMemoryStat{}, nil).Once()
 		m.On("DomainGetState", mock.Anything, dom, uint32(0)).Return(int32(1), int32(0), nil).Once()
-		
+
 		stats, err := a.GetInstanceStats(ctx, id)
 		require.NoError(t, err)
 		assert.NotNil(t, stats)
@@ -770,7 +770,7 @@ func TestLibvirtAdapter_NetworkAndVolume(t *testing.T) {
 	t.Run("CreateNetwork", func(t *testing.T) {
 		m.On("NetworkDefineXML", mock.Anything, mock.Anything).Return(libvirt.Network{Name: "test-net"}, nil).Once()
 		m.On("NetworkCreate", mock.Anything, mock.Anything).Return(nil).Once()
-		
+
 		id, err := a.CreateNetwork(ctx, "10.0.0.0/24")
 		require.NoError(t, err)
 		assert.NotEmpty(t, id)
@@ -781,7 +781,7 @@ func TestLibvirtAdapter_NetworkAndVolume(t *testing.T) {
 		m.On("NetworkLookupByName", mock.Anything, "test-net").Return(net, nil).Once()
 		m.On("NetworkDestroy", mock.Anything, net).Return(nil).Once()
 		m.On("NetworkUndefine", mock.Anything, net).Return(nil).Once()
-		
+
 		err := a.DeleteNetwork(ctx, "test-net")
 		require.NoError(t, err)
 	})
@@ -791,7 +791,7 @@ func TestLibvirtAdapter_NetworkAndVolume(t *testing.T) {
 		m.On("StoragePoolLookupByName", mock.Anything, "default").Return(pool, nil).Once()
 		m.On("StoragePoolRefresh", mock.Anything, pool, uint32(0)).Return(nil).Once()
 		m.On("StorageVolCreateXML", mock.Anything, pool, mock.Anything, uint32(0)).Return(libvirt.StorageVol{Name: "v1"}, nil).Once()
-		
+
 		err := a.CreateVolume(ctx, "v1")
 		require.NoError(t, err)
 	})
@@ -802,7 +802,7 @@ func TestLibvirtAdapter_NetworkAndVolume(t *testing.T) {
 		m.On("StoragePoolLookupByName", mock.Anything, "default").Return(pool, nil).Once()
 		m.On("StorageVolLookupByName", mock.Anything, pool, "v1").Return(vol, nil).Once()
 		m.On("StorageVolDelete", mock.Anything, vol, uint32(0)).Return(nil).Once()
-		
+
 		err := a.DeleteVolume(ctx, "v1")
 		require.NoError(t, err)
 	})

--- a/internal/repositories/libvirt/lb_proxy_test.go
+++ b/internal/repositories/libvirt/lb_proxy_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockCompute struct {
@@ -24,8 +24,8 @@ type mockCompute struct {
 func (m *mockCompute) LaunchInstanceWithOptions(ctx context.Context, opts ports.CreateInstanceOptions) (string, []string, error) {
 	return "", nil, nil
 }
-func (m *mockCompute) StartInstance(ctx context.Context, id string) error { return nil }
-func (m *mockCompute) StopInstance(ctx context.Context, id string) error  { return nil }
+func (m *mockCompute) StartInstance(ctx context.Context, id string) error  { return nil }
+func (m *mockCompute) StopInstance(ctx context.Context, id string) error   { return nil }
 func (m *mockCompute) DeleteInstance(ctx context.Context, id string) error { return nil }
 func (m *mockCompute) GetInstanceLogs(ctx context.Context, id string) (io.ReadCloser, error) {
 	return io.NopCloser(strings.NewReader("")), nil
@@ -47,7 +47,7 @@ func (m *mockCompute) Exec(ctx context.Context, id string, cmd []string) (string
 func (m *mockCompute) RunTask(ctx context.Context, opts ports.RunTaskOptions) (string, []string, error) {
 	return "", nil, nil
 }
-func (m *mockCompute) WaitTask(ctx context.Context, id string) (int64, error) { return 0, nil }
+func (m *mockCompute) WaitTask(ctx context.Context, id string) (int64, error)         { return 0, nil }
 func (m *mockCompute) CreateNetwork(ctx context.Context, name string) (string, error) { return "", nil }
 func (m *mockCompute) DeleteNetwork(ctx context.Context, id string) error             { return nil }
 func (m *mockCompute) AttachVolume(ctx context.Context, id string, volumePath string) error {
@@ -93,7 +93,7 @@ func TestLBProxyAdapter(t *testing.T) {
 		configPath := filepath.Join("/tmp", "thecloud", "lb", lb.ID.String(), "nginx.conf")
 		_, err = os.Stat(configPath)
 		require.NoError(t, err)
-		
+
 		content, _ := os.ReadFile(filepath.Clean(configPath))
 		assert.Contains(t, string(content), "server 10.0.0.1:8080 weight=1;")
 	})
@@ -107,7 +107,7 @@ func TestLBProxyAdapter(t *testing.T) {
 
 	t.Run("RemoveProxy", func(t *testing.T) {
 		executedCommands = []string{}
-		
+
 		// Create a dummy pid file to trigger stop command
 		configDir := filepath.Join("/tmp", "thecloud", "lb", lb.ID.String())
 		_ = os.MkdirAll(configDir, 0750)

--- a/internal/repositories/libvirt/templates_test.go
+++ b/internal/repositories/libvirt/templates_test.go
@@ -54,7 +54,7 @@ func TestGenerateDomainXML(t *testing.T) {
 		assert.Contains(t, xml, "<source dev='/dev/sdc'/>")
 		assert.Contains(t, xml, "<target dev='vdc' bus='virtio'/>")
 	})
-	
+
 	t.Run("with port mapping", func(t *testing.T) {
 		t.Parallel()
 		ports := []string{"8080:80", "443:443"}

--- a/internal/repositories/lvm/adapter_test.go
+++ b/internal/repositories/lvm/adapter_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/repositories/noop/adapters.go
+++ b/internal/repositories/noop/adapters.go
@@ -300,7 +300,9 @@ func (s *NoopStorageService) CreateBucket(ctx context.Context, name string, isPu
 func (s *NoopStorageService) GetBucket(ctx context.Context, name string) (*domain.Bucket, error) {
 	return &domain.Bucket{Name: name}, nil
 }
-func (s *NoopStorageService) DeleteBucket(ctx context.Context, name string, force bool) error { return nil }
+func (s *NoopStorageService) DeleteBucket(ctx context.Context, name string, force bool) error {
+	return nil
+}
 func (s *NoopStorageService) ListBuckets(ctx context.Context) ([]*domain.Bucket, error) {
 	return []*domain.Bucket{}, nil
 }

--- a/internal/repositories/noop/repos_extra_test.go
+++ b/internal/repositories/noop/repos_extra_test.go
@@ -2,8 +2,8 @@ package noop
 
 import (
 	"context"
-	"testing"
 	"github.com/stretchr/testify/require"
+	"testing"
 
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"

--- a/internal/repositories/postgres/autoscaling_repo_extra_test.go
+++ b/internal/repositories/postgres/autoscaling_repo_extra_test.go
@@ -58,7 +58,7 @@ func TestAutoScalingRepoExtra(t *testing.T) {
 		mock.ExpectQuery("SELECT scaling_group_id, instance_id FROM scaling_group_instances").
 			WithArgs([]uuid.UUID{groupID}).
 			WillReturnRows(pgxmock.NewRows([]string{"scaling_group_id", "instance_id"}).AddRow(groupID, instanceID))
-		
+
 		result, err := repo.GetAllScalingGroupInstances(ctx, []uuid.UUID{groupID})
 		require.NoError(t, err)
 		assert.Len(t, result[groupID], 1)
@@ -76,12 +76,12 @@ func TestAutoScalingRepoExtra(t *testing.T) {
 		mock.ExpectQuery("SELECT COALESCE").
 			WithArgs([]uuid.UUID{instanceID}, since).
 			WillReturnRows(pgxmock.NewRows([]string{"avg"}).AddRow(45.5))
-		
+
 		avg, err := repo.GetAverageCPU(ctx, []uuid.UUID{instanceID}, since)
 		require.NoError(t, err)
 		assert.InDelta(t, 45.5, avg, 0.01)
 	})
-	
+
 	t.Run("GetAllPolicies", func(t *testing.T) {
 		t.Parallel()
 		mock, _ := pgxmock.NewPool()
@@ -94,7 +94,7 @@ func TestAutoScalingRepoExtra(t *testing.T) {
 			WithArgs([]uuid.UUID{groupID}).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "scaling_group_id", "name", "metric_type", "target_value", "scale_out_step", "scale_in_step", "cooldown_sec", "last_scaled_at"}).
 				AddRow(policyID, groupID, "p1", "cpu", 70.0, 1, 1, 300, nil))
-		
+
 		result, err := repo.GetAllPolicies(ctx, []uuid.UUID{groupID})
 		require.NoError(t, err)
 		assert.Len(t, result[groupID], 1)

--- a/internal/repositories/postgres/cache_repo.go
+++ b/internal/repositories/postgres/cache_repo.go
@@ -4,9 +4,9 @@ package postgres
 import (
 	"context"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 )

--- a/internal/repositories/postgres/cluster_repo.go
+++ b/internal/repositories/postgres/cluster_repo.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/database_repo.go
+++ b/internal/repositories/postgres/database_repo.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/database_repo_unit_test.go
+++ b/internal/repositories/postgres/database_repo_unit_test.go
@@ -63,7 +63,7 @@ func TestDatabaseRepository_GetByID(t *testing.T) {
 	mock.ExpectQuery("SELECT id, user_id, name, engine, version, status, role, primary_id, vpc_id, COALESCE\\(container_id, ''\\), port, username, password, created_at, updated_at, allocated_storage, parameters FROM databases").
 		WithArgs(id, userID).
 		WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "name", "engine", "version", "status", "role", "primary_id", "vpc_id", "container_id", "port", "username", "password", "created_at", "updated_at", "allocated_storage", "parameters"}).
-			AddRow(id, userID, "test-db", string(domain.EnginePostgres), "16", string(domain.DatabaseStatusCreating), string(domain.RolePrimary), nil, nil, "cid-1", 5432, "admin", "password", now, now, 10, map[string]string{"k":"v"}))
+			AddRow(id, userID, "test-db", string(domain.EnginePostgres), "16", string(domain.DatabaseStatusCreating), string(domain.RolePrimary), nil, nil, "cid-1", 5432, "admin", "password", now, now, 10, map[string]string{"k": "v"}))
 
 	db, err := repo.GetByID(ctx, id)
 	require.NoError(t, err)

--- a/internal/repositories/postgres/dns_repo.go
+++ b/internal/repositories/postgres/dns_repo.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/iam_repo.go
+++ b/internal/repositories/postgres/iam_repo.go
@@ -2,8 +2,8 @@ package postgres
 
 import (
 	"context"
-	stdlib_errors "errors"
 	"encoding/json"
+	stdlib_errors "errors"
 	"fmt"
 
 	"github.com/google/uuid"

--- a/internal/repositories/postgres/identity_repo.go
+++ b/internal/repositories/postgres/identity_repo.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 )

--- a/internal/repositories/postgres/image_repo.go
+++ b/internal/repositories/postgres/image_repo.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/instance_repo.go
+++ b/internal/repositories/postgres/instance_repo.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/instance_type_repo.go
+++ b/internal/repositories/postgres/instance_type_repo.go
@@ -4,8 +4,8 @@ package postgres
 import (
 	"context"
 
-	"github.com/jackc/pgx/v5"
 	stdlib_errors "errors"
+	"github.com/jackc/pgx/v5"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 )

--- a/internal/repositories/postgres/lb_repo.go
+++ b/internal/repositories/postgres/lb_repo.go
@@ -4,9 +4,9 @@ package postgres
 import (
 	"context"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/lifecycle_repo.go
+++ b/internal/repositories/postgres/lifecycle_repo.go
@@ -4,9 +4,9 @@ package postgres
 import (
 	"context"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/log_repo.go
+++ b/internal/repositories/postgres/log_repo.go
@@ -30,7 +30,7 @@ func (r *LogRepository) Create(ctx context.Context, entries []*domain.LogEntry) 
 
 	for i, entry := range entries {
 		offset := i * 8
-		placeholders = append(placeholders, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)", 
+		placeholders = append(placeholders, fmt.Sprintf("($%d, $%d, $%d, $%d, $%d, $%d, $%d, $%d)",
 			offset+1, offset+2, offset+3, offset+4, offset+5, offset+6, offset+7, offset+8))
 		values = append(values, entry.ID, entry.TenantID, entry.ResourceID, entry.ResourceType, entry.Level, entry.Message, entry.Timestamp, entry.TraceID)
 	}
@@ -91,7 +91,7 @@ func (r *LogRepository) List(ctx context.Context, query domain.LogQuery) ([]*dom
 	}
 
 	sqlQuery += " ORDER BY timestamp DESC"
-	
+
 	limit := query.Limit
 	if limit <= 0 {
 		limit = 100

--- a/internal/repositories/postgres/pipeline_repo.go
+++ b/internal/repositories/postgres/pipeline_repo.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"encoding/json"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
-	stdlib_errors "errors"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 )

--- a/internal/repositories/postgres/queue_repo.go
+++ b/internal/repositories/postgres/queue_repo.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/secret_repo.go
+++ b/internal/repositories/postgres/secret_repo.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/security_group_repo.go
+++ b/internal/repositories/postgres/security_group_repo.go
@@ -4,9 +4,9 @@ package postgres
 import (
 	"context"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/ssh_key_repo.go
+++ b/internal/repositories/postgres/ssh_key_repo.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 )

--- a/internal/repositories/postgres/storage_repo.go
+++ b/internal/repositories/postgres/storage_repo.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"time"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/subnet_repo.go
+++ b/internal/repositories/postgres/subnet_repo.go
@@ -4,9 +4,9 @@ package postgres
 import (
 	"context"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/postgres/tenant_repo.go
+++ b/internal/repositories/postgres/tenant_repo.go
@@ -4,9 +4,9 @@ package postgres
 import (
 	"context"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"
 )

--- a/internal/repositories/postgres/test_helpers.go
+++ b/internal/repositories/postgres/test_helpers.go
@@ -37,7 +37,7 @@ func SetupDB(t *testing.T) (*pgxpool.Pool, string) {
 
 	// Use a unique schema for this test run to allow parallel execution in CI
 	schema := "test_repo_" + strings.ReplaceAll(uuid.New().String(), "-", "_")
-	
+
 	// Create base connection to initialize schema
 	baseDB, err := pgxpool.New(ctx, dbURL)
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func SetupDB(t *testing.T) (*pgxpool.Pool, string) {
 	// We include 'public' for extensions like uuid-ossp
 	config, err := pgxpool.ParseConfig(dbURL)
 	require.NoError(t, err)
-	
+
 	if config.ConnConfig.RuntimeParams == nil {
 		config.ConnConfig.RuntimeParams = make(map[string]string)
 	}
@@ -150,7 +150,7 @@ func CleanDB(t *testing.T, db *pgxpool.Pool) {
 		AND table_type = 'BASE TABLE'
 		AND table_name != 'schema_migrations'
 	`, schema)
-	
+
 	rows, err := db.Query(ctx, query)
 	if err != nil {
 		t.Logf("Warning: failed to query tables for cleanup: %v", err)

--- a/internal/repositories/postgres/vpc_repo.go
+++ b/internal/repositories/postgres/vpc_repo.go
@@ -4,9 +4,9 @@ package postgres
 import (
 	"context"
 
+	stdlib_errors "errors"
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	stdlib_errors "errors"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/errors"

--- a/internal/repositories/redis/task_queue.go
+++ b/internal/repositories/redis/task_queue.go
@@ -3,8 +3,8 @@ package redis
 
 import (
 	"context"
-	stdlib_errors "errors"
 	"encoding/json"
+	stdlib_errors "errors"
 	"time"
 
 	"github.com/redis/go-redis/v9"

--- a/internal/storage/coordinator/service_test.go
+++ b/internal/storage/coordinator/service_test.go
@@ -11,8 +11,8 @@ import (
 
 	pb "github.com/poyrazk/thecloud/internal/storage/protocol"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 

--- a/internal/workers/database_failover_worker_test.go
+++ b/internal/workers/database_failover_worker_test.go
@@ -70,6 +70,16 @@ func (m *mockDatabaseService) ListDatabases(ctx context.Context) ([]*domain.Data
 	return nil, nil
 }
 func (m *mockDatabaseService) DeleteDatabase(ctx context.Context, id uuid.UUID) error { return nil }
+
+func (m *mockDatabaseService) CreateDatabaseSnapshot(ctx context.Context, databaseID uuid.UUID, description string) (*domain.Snapshot, error) {
+	return nil, nil
+}
+func (m *mockDatabaseService) ListDatabaseSnapshots(ctx context.Context, databaseID uuid.UUID) ([]*domain.Snapshot, error) {
+	return nil, nil
+}
+func (m *mockDatabaseService) RestoreDatabase(ctx context.Context, snapshotID uuid.UUID, newName, engine, version string, vpcID *uuid.UUID, allocatedStorage int, parameters map[string]string) (*domain.Database, error) {
+	return nil, nil
+}
 func (m *mockDatabaseService) GetConnectionString(ctx context.Context, id uuid.UUID) (string, error) {
 	return "", nil
 }

--- a/internal/workers/healing_worker_test.go
+++ b/internal/workers/healing_worker_test.go
@@ -140,12 +140,12 @@ func TestHealingWorker(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name          string
-		instances     []*domain.Instance
-		listErr       error
-		stopErr       error
-		startErr      error
-		expectedStops []string
+		name           string
+		instances      []*domain.Instance
+		listErr        error
+		stopErr        error
+		startErr       error
+		expectedStops  []string
 		expectedStarts []string
 	}{
 		{

--- a/internal/workers/log_worker.go
+++ b/internal/workers/log_worker.go
@@ -11,9 +11,9 @@ import (
 
 // LogWorker handles background tasks for the CloudLogs service.
 type LogWorker struct {
-	logSvc ports.LogService
-	logger *slog.Logger
-	interval time.Duration
+	logSvc        ports.LogService
+	logger        *slog.Logger
+	interval      time.Duration
 	retentionDays int
 }
 
@@ -23,7 +23,7 @@ func NewLogWorker(logSvc ports.LogService, logger *slog.Logger) *LogWorker {
 		logSvc:        logSvc,
 		logger:        logger,
 		interval:      24 * time.Hour, // Run retention once a day
-		retentionDays: 30,            // Default 30 days retention
+		retentionDays: 30,             // Default 30 days retention
 	}
 }
 

--- a/internal/workers/storage_cleanup_worker.go
+++ b/internal/workers/storage_cleanup_worker.go
@@ -48,7 +48,7 @@ func (w *StorageCleanupWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 func (w *StorageCleanupWorker) cleanup(ctx context.Context) {
 	w.logger.Info("running storage cleanup")
-	
+
 	totalDeleted := 0
 	for {
 		count, err := w.storageSvc.CleanupDeleted(ctx, w.batchSize)
@@ -56,12 +56,12 @@ func (w *StorageCleanupWorker) cleanup(ctx context.Context) {
 			w.logger.Error("failed to cleanup deleted objects", "error", err)
 			break
 		}
-		
+
 		totalDeleted += count
 		if count < w.batchSize {
 			break
 		}
-		
+
 		w.logger.Debug("processed cleanup batch", "count", count)
 	}
 

--- a/internal/workers/storage_cleanup_worker_internal_test.go
+++ b/internal/workers/storage_cleanup_worker_internal_test.go
@@ -21,11 +21,19 @@ func (m *mockStorageService) CleanupDeleted(ctx context.Context, limit int) (int
 	return args.Int(0), args.Error(1)
 }
 
-func (m *mockStorageService) Upload(ctx context.Context, bucket, key string, r io.Reader) (*domain.Object, error) { return nil, nil }
-func (m *mockStorageService) Download(ctx context.Context, bucket, key string) (io.ReadCloser, *domain.Object, error) { return nil, nil, nil }
-func (m *mockStorageService) ListObjects(ctx context.Context, bucket string) ([]*domain.Object, error) { return nil, nil }
+func (m *mockStorageService) Upload(ctx context.Context, bucket, key string, r io.Reader) (*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageService) Download(ctx context.Context, bucket, key string) (io.ReadCloser, *domain.Object, error) {
+	return nil, nil, nil
+}
+func (m *mockStorageService) ListObjects(ctx context.Context, bucket string) ([]*domain.Object, error) {
+	return nil, nil
+}
 func (m *mockStorageService) DeleteObject(ctx context.Context, bucket, key string) error { return nil }
-func (m *mockStorageService) DownloadVersion(ctx context.Context, bucket, key, versionID string) (io.ReadCloser, *domain.Object, error) { return nil, nil, nil }
+func (m *mockStorageService) DownloadVersion(ctx context.Context, bucket, key, versionID string) (io.ReadCloser, *domain.Object, error) {
+	return nil, nil, nil
+}
 func (m *mockStorageService) ListVersions(ctx context.Context, bucket, key string) ([]*domain.Object, error) {
 	return nil, nil
 }
@@ -38,18 +46,34 @@ func (m *mockStorageService) CreateBucket(ctx context.Context, name string, isPu
 func (m *mockStorageService) GetBucket(ctx context.Context, name string) (*domain.Bucket, error) {
 	return nil, nil
 }
-func (m *mockStorageService) DeleteBucket(ctx context.Context, name string, force bool) error { return nil }
+func (m *mockStorageService) DeleteBucket(ctx context.Context, name string, force bool) error {
+	return nil
+}
 func (m *mockStorageService) ListBuckets(ctx context.Context) ([]*domain.Bucket, error) {
 	return nil, nil
 }
 
-func (m *mockStorageService) SetBucketVersioning(ctx context.Context, name string, enabled bool) error { return nil }
-func (m *mockStorageService) GetClusterStatus(ctx context.Context) (*domain.StorageCluster, error) { return nil, nil }
-func (m *mockStorageService) CreateMultipartUpload(ctx context.Context, bucket, key string) (*domain.MultipartUpload, error) { return nil, nil }
-func (m *mockStorageService) UploadPart(ctx context.Context, uploadID uuid.UUID, partNumber int, r io.Reader) (*domain.Part, error) { return nil, nil }
-func (m *mockStorageService) CompleteMultipartUpload(ctx context.Context, uploadID uuid.UUID) (*domain.Object, error) { return nil, nil }
-func (m *mockStorageService) AbortMultipartUpload(ctx context.Context, uploadID uuid.UUID) error { return nil }
-func (m *mockStorageService) GeneratePresignedURL(ctx context.Context, bucket, key, method string, expiry time.Duration) (*domain.PresignedURL, error) { return nil, nil }
+func (m *mockStorageService) SetBucketVersioning(ctx context.Context, name string, enabled bool) error {
+	return nil
+}
+func (m *mockStorageService) GetClusterStatus(ctx context.Context) (*domain.StorageCluster, error) {
+	return nil, nil
+}
+func (m *mockStorageService) CreateMultipartUpload(ctx context.Context, bucket, key string) (*domain.MultipartUpload, error) {
+	return nil, nil
+}
+func (m *mockStorageService) UploadPart(ctx context.Context, uploadID uuid.UUID, partNumber int, r io.Reader) (*domain.Part, error) {
+	return nil, nil
+}
+func (m *mockStorageService) CompleteMultipartUpload(ctx context.Context, uploadID uuid.UUID) (*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageService) AbortMultipartUpload(ctx context.Context, uploadID uuid.UUID) error {
+	return nil
+}
+func (m *mockStorageService) GeneratePresignedURL(ctx context.Context, bucket, key, method string, expiry time.Duration) (*domain.PresignedURL, error) {
+	return nil, nil
+}
 
 func TestStorageCleanupWorker_Cleanup(t *testing.T) {
 	svc := new(mockStorageService)

--- a/internal/workers/workers_unit_test.go
+++ b/internal/workers/workers_unit_test.go
@@ -17,92 +17,185 @@ import (
 
 // Minimal local mocks
 type mockAccountingSvc struct{ mock.Mock }
-func (m *mockAccountingSvc) TrackUsage(ctx context.Context, record domain.UsageRecord) error { return nil }
-func (m *mockAccountingSvc) GetSummary(ctx context.Context, userID uuid.UUID, start, end time.Time) (*domain.BillSummary, error) { return nil, nil }
-func (m *mockAccountingSvc) ListUsage(ctx context.Context, userID uuid.UUID, start, end time.Time) ([]domain.UsageRecord, error) { return nil, nil }
-func (m *mockAccountingSvc) ProcessHourlyBilling(ctx context.Context) error { return m.Called(ctx).Error(0) }
+
+func (m *mockAccountingSvc) TrackUsage(ctx context.Context, record domain.UsageRecord) error {
+	return nil
+}
+func (m *mockAccountingSvc) GetSummary(ctx context.Context, userID uuid.UUID, start, end time.Time) (*domain.BillSummary, error) {
+	return nil, nil
+}
+func (m *mockAccountingSvc) ListUsage(ctx context.Context, userID uuid.UUID, start, end time.Time) ([]domain.UsageRecord, error) {
+	return nil, nil
+}
+func (m *mockAccountingSvc) ProcessHourlyBilling(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}
 
 type mockStorageRepo struct{ mock.Mock }
+
 func (m *mockStorageRepo) SaveMeta(ctx context.Context, obj *domain.Object) error { return nil }
-func (m *mockStorageRepo) GetMeta(ctx context.Context, bucket, key string) (*domain.Object, error) { return nil, nil }
-func (m *mockStorageRepo) List(ctx context.Context, bucket string) ([]*domain.Object, error) { return nil, nil }
+func (m *mockStorageRepo) GetMeta(ctx context.Context, bucket, key string) (*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageRepo) List(ctx context.Context, bucket string) ([]*domain.Object, error) {
+	return nil, nil
+}
 func (m *mockStorageRepo) SoftDelete(ctx context.Context, bucket, key string) error { return nil }
-func (m *mockStorageRepo) DeleteVersion(ctx context.Context, bucket, key, versionID string) error { return nil }
-func (m *mockStorageRepo) GetMetaByVersion(ctx context.Context, bucket, key, versionID string) (*domain.Object, error) { return nil, nil }
-func (m *mockStorageRepo) ListVersions(ctx context.Context, bucket, key string) ([]*domain.Object, error) { return nil, nil }
-func (m *mockStorageRepo) ListDeleted(ctx context.Context, limit int) ([]*domain.Object, error) { return nil, nil }
-func (m *mockStorageRepo) HardDelete(ctx context.Context, bucket, key, versionID string) error { return nil }
+func (m *mockStorageRepo) DeleteVersion(ctx context.Context, bucket, key, versionID string) error {
+	return nil
+}
+func (m *mockStorageRepo) GetMetaByVersion(ctx context.Context, bucket, key, versionID string) (*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageRepo) ListVersions(ctx context.Context, bucket, key string) ([]*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageRepo) ListDeleted(ctx context.Context, limit int) ([]*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageRepo) HardDelete(ctx context.Context, bucket, key, versionID string) error {
+	return nil
+}
 func (m *mockStorageRepo) CreateBucket(ctx context.Context, bucket *domain.Bucket) error { return nil }
-func (m *mockStorageRepo) GetBucket(ctx context.Context, name string) (*domain.Bucket, error) { return nil, nil }
+func (m *mockStorageRepo) GetBucket(ctx context.Context, name string) (*domain.Bucket, error) {
+	return nil, nil
+}
 func (m *mockStorageRepo) DeleteBucket(ctx context.Context, name string) error { return nil }
-func (m *mockStorageRepo) ListBuckets(ctx context.Context, userID string) ([]*domain.Bucket, error) { return nil, nil }
-func (m *mockStorageRepo) SetBucketVersioning(ctx context.Context, name string, enabled bool) error { return nil }
-func (m *mockStorageRepo) SaveMultipartUpload(ctx context.Context, upload *domain.MultipartUpload) error { return nil }
-func (m *mockStorageRepo) GetMultipartUpload(ctx context.Context, uploadID uuid.UUID) (*domain.MultipartUpload, error) { return nil, nil }
-func (m *mockStorageRepo) DeleteMultipartUpload(ctx context.Context, uploadID uuid.UUID) error { return nil }
+func (m *mockStorageRepo) ListBuckets(ctx context.Context, userID string) ([]*domain.Bucket, error) {
+	return nil, nil
+}
+func (m *mockStorageRepo) SetBucketVersioning(ctx context.Context, name string, enabled bool) error {
+	return nil
+}
+func (m *mockStorageRepo) SaveMultipartUpload(ctx context.Context, upload *domain.MultipartUpload) error {
+	return nil
+}
+func (m *mockStorageRepo) GetMultipartUpload(ctx context.Context, uploadID uuid.UUID) (*domain.MultipartUpload, error) {
+	return nil, nil
+}
+func (m *mockStorageRepo) DeleteMultipartUpload(ctx context.Context, uploadID uuid.UUID) error {
+	return nil
+}
 func (m *mockStorageRepo) SavePart(ctx context.Context, part *domain.Part) error { return nil }
-func (m *mockStorageRepo) ListParts(ctx context.Context, uploadID uuid.UUID) ([]*domain.Part, error) { return nil, nil }
+func (m *mockStorageRepo) ListParts(ctx context.Context, uploadID uuid.UUID) ([]*domain.Part, error) {
+	return nil, nil
+}
 
 type mockStorageSvc struct{ mock.Mock }
-func (m *mockStorageSvc) Upload(ctx context.Context, bucket, key string, r io.Reader) (*domain.Object, error) { return nil, nil }
-func (m *mockStorageSvc) Download(ctx context.Context, bucket, key string) (io.ReadCloser, *domain.Object, error) { return nil, nil, nil }
-func (m *mockStorageSvc) ListObjects(ctx context.Context, bucket string) ([]*domain.Object, error) { return nil, nil }
+
+func (m *mockStorageSvc) Upload(ctx context.Context, bucket, key string, r io.Reader) (*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageSvc) Download(ctx context.Context, bucket, key string) (io.ReadCloser, *domain.Object, error) {
+	return nil, nil, nil
+}
+func (m *mockStorageSvc) ListObjects(ctx context.Context, bucket string) ([]*domain.Object, error) {
+	return nil, nil
+}
 func (m *mockStorageSvc) DeleteObject(ctx context.Context, bucket, key string) error { return nil }
-func (m *mockStorageSvc) DownloadVersion(ctx context.Context, bucket, key, versionID string) (io.ReadCloser, *domain.Object, error) { return nil, nil, nil }
-func (m *mockStorageSvc) ListVersions(ctx context.Context, bucket, key string) ([]*domain.Object, error) { return nil, nil }
-func (m *mockStorageSvc) DeleteVersion(ctx context.Context, bucket, key, versionID string) error { return nil }
-func (m *mockStorageSvc) CreateBucket(ctx context.Context, name string, isPublic bool) (*domain.Bucket, error) { return nil, nil }
+func (m *mockStorageSvc) DownloadVersion(ctx context.Context, bucket, key, versionID string) (io.ReadCloser, *domain.Object, error) {
+	return nil, nil, nil
+}
+func (m *mockStorageSvc) ListVersions(ctx context.Context, bucket, key string) ([]*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageSvc) DeleteVersion(ctx context.Context, bucket, key, versionID string) error {
+	return nil
+}
+func (m *mockStorageSvc) CreateBucket(ctx context.Context, name string, isPublic bool) (*domain.Bucket, error) {
+	return nil, nil
+}
 func (m *mockStorageSvc) GetBucket(ctx context.Context, name string) (*domain.Bucket, error) {
 	return nil, nil
 }
 func (m *mockStorageSvc) DeleteBucket(ctx context.Context, name string, force bool) error { return nil }
 func (m *mockStorageSvc) ListBuckets(ctx context.Context) ([]*domain.Bucket, error)       { return nil, nil }
 
-func (m *mockStorageSvc) SetBucketVersioning(ctx context.Context, name string, enabled bool) error { return nil }
+func (m *mockStorageSvc) SetBucketVersioning(ctx context.Context, name string, enabled bool) error {
+	return nil
+}
 func (m *mockStorageSvc) GetClusterStatus(ctx context.Context) (*domain.StorageCluster, error) {
 	args := m.Called(ctx)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*domain.StorageCluster), args.Error(1)
 }
-func (m *mockStorageSvc) CreateMultipartUpload(ctx context.Context, bucket, key string) (*domain.MultipartUpload, error) { return nil, nil }
-func (m *mockStorageSvc) UploadPart(ctx context.Context, uploadID uuid.UUID, partNumber int, r io.Reader) (*domain.Part, error) { return nil, nil }
-func (m *mockStorageSvc) CompleteMultipartUpload(ctx context.Context, uploadID uuid.UUID) (*domain.Object, error) { return nil, nil }
-func (m *mockStorageSvc) AbortMultipartUpload(ctx context.Context, uploadID uuid.UUID) error { return nil }
+func (m *mockStorageSvc) CreateMultipartUpload(ctx context.Context, bucket, key string) (*domain.MultipartUpload, error) {
+	return nil, nil
+}
+func (m *mockStorageSvc) UploadPart(ctx context.Context, uploadID uuid.UUID, partNumber int, r io.Reader) (*domain.Part, error) {
+	return nil, nil
+}
+func (m *mockStorageSvc) CompleteMultipartUpload(ctx context.Context, uploadID uuid.UUID) (*domain.Object, error) {
+	return nil, nil
+}
+func (m *mockStorageSvc) AbortMultipartUpload(ctx context.Context, uploadID uuid.UUID) error {
+	return nil
+}
 func (m *mockStorageSvc) CleanupDeleted(ctx context.Context, limit int) (int, error) { return 0, nil }
-func (m *mockStorageSvc) GeneratePresignedURL(ctx context.Context, bucket, key, method string, expiry time.Duration) (*domain.PresignedURL, error) { return nil, nil }
+func (m *mockStorageSvc) GeneratePresignedURL(ctx context.Context, bucket, key, method string, expiry time.Duration) (*domain.PresignedURL, error) {
+	return nil, nil
+}
 
 type mockClusterRepo struct{ mock.Mock }
+
 func (m *mockClusterRepo) Create(ctx context.Context, cluster *domain.Cluster) error { return nil }
-func (m *mockClusterRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.Cluster, error) { return nil, nil }
+func (m *mockClusterRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.Cluster, error) {
+	return nil, nil
+}
 func (m *mockClusterRepo) Update(ctx context.Context, cluster *domain.Cluster) error { return nil }
-func (m *mockClusterRepo) Delete(ctx context.Context, id uuid.UUID) error { return nil }
-func (m *mockClusterRepo) ListByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.Cluster, error) { return nil, nil }
+func (m *mockClusterRepo) Delete(ctx context.Context, id uuid.UUID) error            { return nil }
+func (m *mockClusterRepo) ListByUserID(ctx context.Context, userID uuid.UUID) ([]*domain.Cluster, error) {
+	return nil, nil
+}
 func (m *mockClusterRepo) ListAll(ctx context.Context) ([]*domain.Cluster, error) {
 	args := m.Called(ctx)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).([]*domain.Cluster), args.Error(1)
 }
 func (m *mockClusterRepo) AddNode(ctx context.Context, node *domain.ClusterNode) error { return nil }
-func (m *mockClusterRepo) GetNodes(ctx context.Context, clusterID uuid.UUID) ([]*domain.ClusterNode, error) { return nil, nil }
+func (m *mockClusterRepo) GetNodes(ctx context.Context, clusterID uuid.UUID) ([]*domain.ClusterNode, error) {
+	return nil, nil
+}
 func (m *mockClusterRepo) UpdateNode(ctx context.Context, node *domain.ClusterNode) error { return nil }
-func (m *mockClusterRepo) DeleteNode(ctx context.Context, nodeID uuid.UUID) error { return nil }
+func (m *mockClusterRepo) DeleteNode(ctx context.Context, nodeID uuid.UUID) error         { return nil }
 
 type mockClusterProv struct{ mock.Mock }
-func (m *mockClusterProv) Provision(ctx context.Context, cluster *domain.Cluster) error { return nil }
+
+func (m *mockClusterProv) Provision(ctx context.Context, cluster *domain.Cluster) error   { return nil }
 func (m *mockClusterProv) Deprovision(ctx context.Context, cluster *domain.Cluster) error { return nil }
-func (m *mockClusterProv) Upgrade(ctx context.Context, cluster *domain.Cluster, version string) error { return nil }
-func (m *mockClusterProv) GetKubeconfig(ctx context.Context, cluster *domain.Cluster, role string) (string, error) { return "", nil }
+func (m *mockClusterProv) Upgrade(ctx context.Context, cluster *domain.Cluster, version string) error {
+	return nil
+}
+func (m *mockClusterProv) GetKubeconfig(ctx context.Context, cluster *domain.Cluster, role string) (string, error) {
+	return "", nil
+}
 func (m *mockClusterProv) GetHealth(ctx context.Context, cluster *domain.Cluster) (*ports.ClusterHealth, error) {
 	args := m.Called(ctx, cluster)
-	if args.Get(0) == nil { return nil, args.Error(1) }
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
 	return args.Get(0).(*ports.ClusterHealth), args.Error(1)
 }
-func (m *mockClusterProv) Repair(ctx context.Context, cluster *domain.Cluster) error { return m.Called(ctx, cluster).Error(0) }
-func (m *mockClusterProv) GetStatus(ctx context.Context, cluster *domain.Cluster) (domain.ClusterStatus, error) { return domain.ClusterStatusRunning, nil }
+func (m *mockClusterProv) Repair(ctx context.Context, cluster *domain.Cluster) error {
+	return m.Called(ctx, cluster).Error(0)
+}
+func (m *mockClusterProv) GetStatus(ctx context.Context, cluster *domain.Cluster) (domain.ClusterStatus, error) {
+	return domain.ClusterStatusRunning, nil
+}
 func (m *mockClusterProv) Scale(ctx context.Context, cluster *domain.Cluster) error { return nil }
-func (m *mockClusterProv) RotateSecrets(ctx context.Context, cluster *domain.Cluster) error { return nil }
-func (m *mockClusterProv) CreateBackup(ctx context.Context, cluster *domain.Cluster) error { return nil }
-func (m *mockClusterProv) Restore(ctx context.Context, cluster *domain.Cluster, backupPath string) error { return nil }
+func (m *mockClusterProv) RotateSecrets(ctx context.Context, cluster *domain.Cluster) error {
+	return nil
+}
+func (m *mockClusterProv) CreateBackup(ctx context.Context, cluster *domain.Cluster) error {
+	return nil
+}
+func (m *mockClusterProv) Restore(ctx context.Context, cluster *domain.Cluster, backupPath string) error {
+	return nil
+}
 
 func TestNewAccountingWorker(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -120,19 +213,19 @@ func TestClusterReconciler_Run(t *testing.T) {
 	mockRepo := new(mockClusterRepo)
 	mockProv := new(mockClusterProv)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	
+
 	r := NewClusterReconciler(mockRepo, mockProv, logger)
-	
+
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately to stop after first reconcile
-	
+
 	var wg sync.WaitGroup
 	wg.Add(1)
-	
+
 	mockRepo.On("ListAll", mock.Anything).Return([]*domain.Cluster{}, nil).Once()
-	
+
 	r.Run(ctx, &wg)
 	wg.Wait()
-	
+
 	mockRepo.AssertExpectations(t)
 }

--- a/pkg/audit/simple_audit_test.go
+++ b/pkg/audit/simple_audit_test.go
@@ -3,7 +3,6 @@ package simpleaudit
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/require"
 	"log/slog"
 	"testing"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/pkg/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSimpleAuditLoggerLog(t *testing.T) {

--- a/pkg/audit/simple_audit_test.go
+++ b/pkg/audit/simple_audit_test.go
@@ -3,9 +3,9 @@ package simpleaudit
 import (
 	"bytes"
 	"context"
+	"github.com/stretchr/testify/require"
 	"log/slog"
 	"testing"
-	"github.com/stretchr/testify/require"
 	"time"
 
 	"github.com/google/uuid"

--- a/pkg/crypto/presign_test.go
+++ b/pkg/crypto/presign_test.go
@@ -1,12 +1,12 @@
 package crypto
 
 import (
-	"github.com/stretchr/testify/require"
 	"net/url"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSignAndVerifyURL(t *testing.T) {

--- a/pkg/crypto/presign_test.go
+++ b/pkg/crypto/presign_test.go
@@ -1,9 +1,9 @@
 package crypto
 
 import (
+	"github.com/stretchr/testify/require"
 	"net/url"
 	"testing"
-	"github.com/stretchr/testify/require"
 	"time"
 
 	"github.com/stretchr/testify/assert"

--- a/pkg/ratelimit/limiter_unit_test.go
+++ b/pkg/ratelimit/limiter_unit_test.go
@@ -40,11 +40,11 @@ func TestMiddlewareAllowsFirstRequest(t *testing.T) {
 }
 
 func TestMiddlewareBlocksWhenRateExceeded(t *testing.T) {
-        limiter := NewIPRateLimiter(rate.Limit(1), 1, slog.New(slog.NewTextHandler(io.Discard, nil)))
-        ctx, _ := newTestContext("POST", "/submit", testutil.TestNoopIP4)
-        Middleware(limiter)(ctx)
+	limiter := NewIPRateLimiter(rate.Limit(1), 1, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	ctx, _ := newTestContext("POST", "/submit", testutil.TestNoopIP4)
+	Middleware(limiter)(ctx)
 
-        ctx2, resp2 := newTestContext("GET", "/", testutil.TestNoopIP4)
+	ctx2, resp2 := newTestContext("GET", "/", testutil.TestNoopIP4)
 
 	Middleware(limiter)(ctx2)
 

--- a/pkg/sdk/compute.go
+++ b/pkg/sdk/compute.go
@@ -137,14 +137,14 @@ type SSHKey struct {
 
 // InstanceType describes available resource sizing.
 type InstanceType struct {
-	ID           string  `json:"id"`
-	Name         string  `json:"name"`
-	VCPUs        int     `json:"vcpus"`
-	MemoryMB     int     `json:"memory_mb"`
-	DiskGB       int     `json:"disk_gb"`
-	NetworkMbps  int     `json:"network_mbps"`
-	PricePerHr   float64 `json:"price_per_hour"`
-	Category     string  `json:"category"`
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	VCPUs       int     `json:"vcpus"`
+	MemoryMB    int     `json:"memory_mb"`
+	DiskGB      int     `json:"disk_gb"`
+	NetworkMbps int     `json:"network_mbps"`
+	PricePerHr  float64 `json:"price_per_hour"`
+	Category    string  `json:"category"`
 }
 
 // ListInstanceTypes returns all available instance sizes.

--- a/pkg/sdk/iac_test.go
+++ b/pkg/sdk/iac_test.go
@@ -38,7 +38,10 @@ func TestClientCreateStack(t *testing.T) {
 
 		var req map[string]interface{}
 		err := json.NewDecoder(r.Body).Decode(&req)
-		if err != nil { t.Errorf("failed to decode: %v", err); return }
+		if err != nil {
+			t.Errorf("failed to decode: %v", err)
+			return
+		}
 		assert.Equal(t, expectedStack.Name, req["name"])
 		assert.Equal(t, expectedStack.Template, req["template"])
 
@@ -50,7 +53,10 @@ func TestClientCreateStack(t *testing.T) {
 	client := NewClient(server.URL, iacTestAPIKey)
 	stack, err := client.CreateStack(iacTestStackName, iacTestTemplate, map[string]string{})
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.NotNil(t, stack)
 	assert.Equal(t, expectedStack.ID, stack.ID)
 	assert.Equal(t, expectedStack.Name, stack.Name)
@@ -74,7 +80,10 @@ func TestClientListStacks(t *testing.T) {
 	client := NewClient(server.URL, iacTestAPIKey)
 	stacks, err := client.ListStacks()
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.Len(t, stacks, 2)
 	assert.Equal(t, expectedStacks[0].Name, stacks[0].Name)
 }
@@ -98,7 +107,10 @@ func TestClientGetStack(t *testing.T) {
 	client := NewClient(server.URL, iacTestAPIKey)
 	stack, err := client.GetStack(id)
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.NotNil(t, stack)
 	assert.Equal(t, expectedStack.ID, stack.ID)
 }
@@ -117,7 +129,10 @@ func TestClientDeleteStack(t *testing.T) {
 	client := NewClient(server.URL, iacTestAPIKey)
 	err := client.DeleteStack(id)
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 }
 
 func TestClientValidateTemplate(t *testing.T) {
@@ -133,7 +148,10 @@ func TestClientValidateTemplate(t *testing.T) {
 
 		var req map[string]interface{}
 		err := json.NewDecoder(r.Body).Decode(&req)
-		if err != nil { t.Errorf("failed to decode: %v", err); return }
+		if err != nil {
+			t.Errorf("failed to decode: %v", err)
+			return
+		}
 		assert.Equal(t, template, req["template"])
 
 		w.Header().Set(iacTestContentType, iacTestAppJSON)
@@ -144,7 +162,10 @@ func TestClientValidateTemplate(t *testing.T) {
 	client := NewClient(server.URL, iacTestAPIKey)
 	resp, err := client.ValidateTemplate(template)
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.NotNil(t, resp)
 	assert.True(t, resp.Valid)
 }

--- a/pkg/sdk/kubernetes_test.go
+++ b/pkg/sdk/kubernetes_test.go
@@ -35,7 +35,10 @@ func TestClientListClusters(t *testing.T) {
 	client := NewClient(server.URL, testAPIKey)
 	clusters, err := client.ListClusters()
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.Len(t, clusters, 1)
 	assert.Equal(t, clusterID, clusters[0].ID)
 }
@@ -49,7 +52,10 @@ func TestClientCreateCluster(t *testing.T) {
 
 		var payload CreateClusterInput
 		err := json.NewDecoder(r.Body).Decode(&payload)
-		if err != nil { t.Errorf("failed to decode: %v", err); return }
+		if err != nil {
+			t.Errorf("failed to decode: %v", err)
+			return
+		}
 		assert.Equal(t, kubeTestClusterName, payload.Name)
 		assert.Equal(t, vpcID, payload.VpcID)
 		assert.Equal(t, 3, payload.WorkerCount)
@@ -69,7 +75,10 @@ func TestClientCreateCluster(t *testing.T) {
 		HA:          true,
 	})
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.Equal(t, clusterID, cluster.ID)
 }
 
@@ -87,7 +96,10 @@ func TestClientGetCluster(t *testing.T) {
 	client := NewClient(server.URL, testAPIKey)
 	cluster, err := client.GetCluster(clusterID.String())
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.Equal(t, clusterID, cluster.ID)
 }
 
@@ -103,7 +115,10 @@ func TestClientDeleteCluster(t *testing.T) {
 	client := NewClient(server.URL, testAPIKey)
 	err := client.DeleteCluster(clusterID.String())
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 }
 
 func TestClientGetKubeconfig(t *testing.T) {
@@ -121,7 +136,10 @@ func TestClientGetKubeconfig(t *testing.T) {
 	client := NewClient(server.URL, testAPIKey)
 	config, err := client.GetKubeconfig(clusterID.String(), kubeTestRoleAdmin)
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.Equal(t, kubeTestKubeconfig, config)
 }
 
@@ -140,7 +158,10 @@ func TestClientGetKubeconfigNoRole(t *testing.T) {
 	client := NewClient(server.URL, testAPIKey)
 	config, err := client.GetKubeconfig(clusterID.String(), "")
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.Equal(t, kubeTestKubeconfig, config)
 }
 
@@ -168,13 +189,19 @@ func TestClientRepairScaleUpgradeRotateBackupRestoreCluster(t *testing.T) {
 			assert.Equal(t, http.MethodPost, r.Method)
 			var payload ScaleClusterInput
 			err := json.NewDecoder(r.Body).Decode(&payload)
-			if err != nil { t.Errorf("failed to decode: %v", err); return }
+			if err != nil {
+				t.Errorf("failed to decode: %v", err)
+				return
+			}
 			assert.Equal(t, 5, payload.Workers)
 		case kubeTestClusters + "/" + clusterID.String() + "/upgrade":
 			assert.Equal(t, http.MethodPost, r.Method)
 			var payload UpgradeClusterInput
 			err := json.NewDecoder(r.Body).Decode(&payload)
-			if err != nil { t.Errorf("failed to decode: %v", err); return }
+			if err != nil {
+				t.Errorf("failed to decode: %v", err)
+				return
+			}
 			assert.Equal(t, "1.30", payload.Version)
 		case kubeTestClusters + "/" + clusterID.String() + "/rotate-secrets":
 			assert.Equal(t, http.MethodPost, r.Method)
@@ -184,7 +211,10 @@ func TestClientRepairScaleUpgradeRotateBackupRestoreCluster(t *testing.T) {
 			assert.Equal(t, http.MethodPost, r.Method)
 			var payload RestoreBackupInput
 			err := json.NewDecoder(r.Body).Decode(&payload)
-			if err != nil { t.Errorf("failed to decode: %v", err); return }
+			if err != nil {
+				t.Errorf("failed to decode: %v", err)
+				return
+			}
 			assert.Equal(t, kubeTestBackupPath, payload.BackupPath)
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -218,7 +248,10 @@ func TestClientGetClusterHealth(t *testing.T) {
 	client := NewClient(server.URL, testAPIKey)
 	status, err := client.GetClusterHealth(clusterID.String())
 
-	if err != nil { t.Errorf("failed to decode: %v", err); return }
+	if err != nil {
+		t.Errorf("failed to decode: %v", err)
+		return
+	}
 	assert.Equal(t, "ok", status.Status)
 	assert.Equal(t, 3, status.NodesReady)
 }

--- a/pkg/sshutil/client_test.go
+++ b/pkg/sshutil/client_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 // generateTestKey generates a private key for testing
-func generateTestKey(t *testing.T) string { t.Helper()
+func generateTestKey(t *testing.T) string {
+	t.Helper()
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 

--- a/tests/database_advanced_e2e_test.go
+++ b/tests/database_advanced_e2e_test.go
@@ -391,7 +391,7 @@ func runUnauthorizedAccessTest(t *testing.T, client *http.Client) {
 func runResourceNotFoundTest(t *testing.T, client *http.Client, token string) {
 	t.Helper()
 	fakeID := uuid.New().String()
-	
+
 	// 1. Get non-existent DB
 	respG := getRequest(t, client, fmt.Sprintf("%s/databases/%s", testutil.TestBaseURL, fakeID), token)
 	if respG != nil && respG.Body != nil {

--- a/tests/firecracker_api_test.go
+++ b/tests/firecracker_api_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestFirecrackerAPI_E2E(t *testing.T) {
-	// Only run this if we are in an environment that supports firecracker 
+	// Only run this if we are in an environment that supports firecracker
 	// or explicitly enabled for CI.
 	backend := os.Getenv("COMPUTE_BACKEND")
 	if backend != "firecracker" && backend != "firecracker-mock" {
@@ -37,7 +37,7 @@ func TestFirecrackerAPI_E2E(t *testing.T) {
 			"image":         "alpine",
 			"instance_type": "basic-2", // Matches defaults in setup_test.go
 		}
-		
+
 		body, err := json.Marshal(payload)
 		require.NoError(t, err, "failed to marshal payload")
 

--- a/tests/firecracker_e2e_test.go
+++ b/tests/firecracker_e2e_test.go
@@ -36,7 +36,7 @@ func TestFirecrackerBackend_E2E(t *testing.T) {
 
 	adapter, err := firecracker.NewFirecrackerAdapter(logger, cfg)
 	require.NoError(t, err, "failed to create adapter")
-	
+
 	// If we are on non-linux, this will return the firecracker-noop type
 	if adapter.Type() != "firecracker" && adapter.Type() != "firecracker-mock" {
 		t.Skipf("Skipping real firecracker test on %s platform", adapter.Type())
@@ -52,14 +52,14 @@ func TestFirecrackerBackend_E2E(t *testing.T) {
 
 	t.Run("Launch and Delete", func(t *testing.T) {
 		id, _, err := adapter.LaunchInstanceWithOptions(ctx, opts)
-		// We expect an error if the kernel/rootfs are missing, 
+		// We expect an error if the kernel/rootfs are missing,
 		// but we want to see HOW it fails in CI.
 		if err != nil {
 			t.Skipf("Launch failed, skipping test (likely missing artifacts or KVM access): %v", err)
 		}
 
 		require.NotEmpty(t, id)
-		
+
 		err = adapter.DeleteInstance(ctx, id)
 		assert.NoError(t, err)
 	})

--- a/tests/gateway_e2e_test.go
+++ b/tests/gateway_e2e_test.go
@@ -329,7 +329,7 @@ func TestGatewayE2E(t *testing.T) {
 		urlPost := testutil.TestBaseURL + "/gw" + pattern + "/post"
 		reqPost, _ := http.NewRequest("POST", urlPost, nil)
 		reqPost.Header.Set(testutil.TestHeaderAPIKey, token)
-		
+
 		// Use a simple retry for POST since waitForRoute is GET only
 		var respPost *http.Response
 		for i := 0; i < 5; i++ {
@@ -342,7 +342,7 @@ func TestGatewayE2E(t *testing.T) {
 			}
 			time.Sleep(1 * time.Second)
 		}
-		
+
 		require.NoError(t, err)
 		defer func() { _ = respPost.Body.Close() }()
 		require.Equal(t, http.StatusOK, respPost.StatusCode, "POST request failed after retries")

--- a/tests/logs_e2e_test.go
+++ b/tests/logs_e2e_test.go
@@ -75,7 +75,7 @@ func TestLogsE2E(t *testing.T) {
 			} `json:"data"`
 		}
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
-		
+
 		// In a real environment with Docker, we'd expect entries > 0.
 		// In CI/Dev without real execution, we at least verify the service returns 200 OK.
 		t.Logf("Found %d historical logs for terminated instance", res.Data.Total)


### PR DESCRIPTION
This PR implements point-in-time recovery and snapshot management for the Managed Database Service.

### Key Features:
- **Snapshot Creation**: Users can trigger point-in-time backups of their databases via `POST /databases/:id/snapshots`.
- **Snapshot Listing**: View all snapshots for a specific database via `GET /databases/:id/snapshots`.
- **Database Restore**: Provision new database instances from existing snapshots via `POST /databases/restore`.
- **Durability**: Leverages the underlying `SnapshotService` for crash-consistent volume backups.

### Implementation Details:
- Updated `DatabaseService` to resolve volumes and interact with `SnapshotService`.
- Added REST handlers and routes for snapshot lifecycle.
- Wired new dependencies in `dependencies.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added database snapshot capabilities: create crash-consistent snapshots of managed databases, list existing snapshots, and restore new database instances from snapshots with configurable settings.

* **Documentation**
  * Added comprehensive documentation for database backup and snapshot management, including usage examples and restore workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->