### PR TITLE
docs: update kubernetes documentation to reflect new capabilities

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -134,5 +134,5 @@ spec:
 ```
 
 ## Limitations (MVP)
-*   **Persistent Volumes**: Dynamic storage provisioning (CSI) is now available in Phase 7.
-*   **Multi-Master**: While we have self-healing for single master, multi-control plane HA is a future roadmap item.
+*   **Persistent Volumes**: Dynamic storage provisioning (CSI) is fully supported.
+*   **Multi-Master**: Multi-control plane HA (3 masters + LB) is fully supported via the `--ha` flag.


### PR DESCRIPTION
Updates the `docs/kubernetes.md` limitations section to reflect that the CSI driver and Multi-Master HA are now fully implemented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Kubernetes documentation clarified: Dynamic storage provisioning via CSI is now fully supported, and multi-control plane high availability with 3 masters and automatic load balancing is now available via the `--ha` flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->