### PR TITLE
fix: scope accounting authorization to requested user

### DIFF
--- a/internal/core/services/accounting.go
+++ b/internal/core/services/accounting.go
@@ -42,7 +42,7 @@ func (s *accountingService) GetSummary(ctx context.Context, userID uuid.UUID, st
 	uID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)
 
-	if err := s.rbacSvc.Authorize(ctx, uID, tenantID, domain.PermissionAccountingRead, "*"); err != nil {
+	if err := s.rbacSvc.Authorize(ctx, uID, tenantID, domain.PermissionAccountingRead, userID.String()); err != nil {
 		return nil, err
 	}
 
@@ -76,7 +76,7 @@ func (s *accountingService) ListUsage(ctx context.Context, userID uuid.UUID, sta
 	uID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)
 
-	if err := s.rbacSvc.Authorize(ctx, uID, tenantID, domain.PermissionAccountingRead, "*"); err != nil {
+	if err := s.rbacSvc.Authorize(ctx, uID, tenantID, domain.PermissionAccountingRead, userID.String()); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- authorize accounting reads against the requested user resource instead of a wildcard
- tighten `GetSummary` and `ListUsage` so the RBAC check matches the data being fetched