### PR TITLE
fix: use valid hash in parallel auth benchmark

### DIFF
--- a/internal/core/services/benchmarks_test.go
+++ b/internal/core/services/benchmarks_test.go
@@ -303,7 +303,9 @@ func makeBenchmarkObjects(size int, tenantID uuid.UUID, bucket string) []*domain
 }
 
 func BenchmarkAuthServiceLoginParallel(b *testing.B) {
-	userRepo := &BenchUserRepository{}
+	hash, _ := bcrypt.GenerateFromPassword([]byte(testutil.TestPasswordStrong), bcrypt.DefaultCost)
+
+	userRepo := &BenchUserRepository{hash: string(hash)}
 	idSvc := &noop.NoopIdentityService{}
 	auditSvc := &noop.NoopAuditService{}
 	tenantSvc := &NoopTenantService{}


### PR DESCRIPTION
## Summary
- generate a real bcrypt hash for the parallel auth login benchmark setup
- ensure `BenchmarkAuthServiceLoginParallel` measures successful logins instead of failing password checks