### PR TITLE
test(storage): reconstruct useful coverage updates

### DIFF
--- a/internal/core/services/storage.go
+++ b/internal/core/services/storage.go
@@ -228,7 +228,13 @@ func (s *StorageService) Download(ctx context.Context, bucket, key string) (io.R
 
 	// Decryption
 	b, err := s.repo.GetBucket(ctx, bucket)
-	if err == nil && b.EncryptionEnabled && s.encryptSvc != nil {
+	if err != nil {
+		if closeErr := reader.Close(); closeErr != nil {
+			return nil, nil, fmt.Errorf("failed to get bucket: %w; close error: %w", err, closeErr)
+		}
+		return nil, nil, fmt.Errorf("failed to get bucket: %w", err)
+	}
+	if b.EncryptionEnabled && s.encryptSvc != nil {
 		decryptedReader, err := s.encryptSvc.Decrypt(ctx, bucket, reader)
 		if err != nil {
 			if closeErr := reader.Close(); closeErr != nil {
@@ -379,6 +385,9 @@ func (s *StorageService) CreateBucket(ctx context.Context, name string, isPublic
 
 	if strings.HasPrefix(name, "-") || strings.HasSuffix(name, "-") || strings.HasPrefix(name, ".") || strings.HasSuffix(name, ".") {
 		return nil, errors.New(errors.InvalidInput, "bucket name cannot start or end with a hyphen or dot")
+	}
+	if strings.Contains(name, "..") {
+		return nil, errors.New(errors.InvalidInput, "bucket name cannot contain consecutive dots")
 	}
 
 	bucket := &domain.Bucket{

--- a/internal/core/services/storage.go
+++ b/internal/core/services/storage.go
@@ -230,9 +230,9 @@ func (s *StorageService) Download(ctx context.Context, bucket, key string) (io.R
 	b, err := s.repo.GetBucket(ctx, bucket)
 	if err != nil {
 		if closeErr := reader.Close(); closeErr != nil {
-			return nil, nil, fmt.Errorf("failed to get bucket: %w; close error: %w", err, closeErr)
+			return nil, nil, errors.Wrap(errors.Internal, "failed to get bucket; close error", fmt.Errorf("bucket error: %w; close error: %w", err, closeErr))
 		}
-		return nil, nil, fmt.Errorf("failed to get bucket: %w", err)
+		return nil, nil, errors.Wrap(errors.Internal, "failed to get bucket", err)
 	}
 	if b.EncryptionEnabled && s.encryptSvc != nil {
 		decryptedReader, err := s.encryptSvc.Decrypt(ctx, bucket, reader)

--- a/internal/core/services/storage_unit_test.go
+++ b/internal/core/services/storage_unit_test.go
@@ -19,6 +19,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (t *trackingReadCloser) Close() error {
+	t.closed = true
+	return nil
+}
+
 func TestStorageServiceUnit(t *testing.T) {
 	mockRepo := new(MockStorageRepo)
 	mockStore := new(MockFileStore)
@@ -178,7 +188,8 @@ func TestStorageServiceUnit(t *testing.T) {
 		assert.NotNil(t, reader)
 		assert.Equal(t, obj, meta)
 
-		data, _ := io.ReadAll(reader)
+		data, err := io.ReadAll(reader)
+		require.NoError(t, err)
 		assert.Equal(t, "hello world!", string(data))
 		mockRepo.AssertExpectations(t)
 		mockStore.AssertExpectations(t)
@@ -186,7 +197,7 @@ func TestStorageServiceUnit(t *testing.T) {
 
 	t.Run("Download Bucket Lookup Failure Closes Reader", func(t *testing.T) {
 		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: "null"}
-		reader := io.NopCloser(strings.NewReader("hello world!"))
+		reader := &trackingReadCloser{Reader: strings.NewReader("hello world!")}
 		mockRepo.On("GetMeta", mock.Anything, "my-bucket", "test.txt").Return(obj, nil).Once()
 		mockStore.On("Read", mock.Anything, "my-bucket", "test.txt").Return(reader, nil).Once()
 		mockRepo.On("GetBucket", mock.Anything, "my-bucket").Return(nil, fmt.Errorf("bucket error")).Once()
@@ -196,6 +207,7 @@ func TestStorageServiceUnit(t *testing.T) {
 		assert.Nil(t, gotReader)
 		assert.Nil(t, meta)
 		assert.Contains(t, err.Error(), "failed to get bucket")
+		assert.True(t, reader.closed)
 		mockRepo.AssertExpectations(t)
 		mockStore.AssertExpectations(t)
 	})
@@ -229,7 +241,8 @@ func TestStorageServiceUnit(t *testing.T) {
 		assert.NotNil(t, reader)
 		assert.Equal(t, obj, meta)
 
-		data, _ := io.ReadAll(reader)
+		data, err := io.ReadAll(reader)
+		require.NoError(t, err)
 		assert.Equal(t, "hello v1", string(data))
 		mockRepo.AssertExpectations(t)
 		mockStore.AssertExpectations(t)

--- a/internal/core/services/storage_unit_test.go
+++ b/internal/core/services/storage_unit_test.go
@@ -377,7 +377,7 @@ func TestStorageServiceUnit(t *testing.T) {
 		mockStore.On("Read", mock.Anything, "b", "k").Return(io.NopCloser(strings.NewReader("data")), nil).Once()
 		mockRepo.On("GetBucket", mock.Anything, "b").Return(nil, fmt.Errorf("bucket error")).Once()
 		_, _, err := svc.Download(ctx, "b", "k")
-		assert.Error(t, err)
+		require.Error(t, err)
 
 		mockRepo.On("GetBucket", mock.Anything, "non-existent").Return(nil, fmt.Errorf("not found")).Once()
 		_, err = svc.CreateMultipartUpload(ctx, "non-existent", "k")

--- a/internal/core/services/storage_unit_test.go
+++ b/internal/core/services/storage_unit_test.go
@@ -2,10 +2,12 @@ package services_test
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
@@ -24,14 +26,14 @@ func TestStorageServiceUnit(t *testing.T) {
 	rbacSvc := new(MockRBACService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	cfg := &platform.Config{SecretsEncryptionKey: "test-secret-key-32-chars-long-!!!"}
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil)) 
-	svc := services.NewStorageService(services.StorageServiceParams{ 
-		Repo:       mockRepo, 
-		RBACSvc:    rbacSvc, 
-		Store:      mockStore, 
-		AuditSvc:   mockAuditSvc, 
-		EncryptSvc: nil, 
-		Config:     cfg, 
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := services.NewStorageService(services.StorageServiceParams{
+		Repo:       mockRepo,
+		RBACSvc:    rbacSvc,
+		Store:      mockStore,
+		AuditSvc:   mockAuditSvc,
+		EncryptSvc: nil,
+		Config:     cfg,
 		Logger:     logger,
 	})
 
@@ -50,11 +52,76 @@ func TestStorageServiceUnit(t *testing.T) {
 		mockRepo.AssertExpectations(t)
 	})
 
+	t.Run("CreateBucket Invalid Names", func(t *testing.T) {
+		invalidNames := []string{"a", "ab", "Invalid_Name", "-start-hyphen", "end-dot.", "two..dots"}
+		for _, name := range invalidNames {
+			_, err := svc.CreateBucket(ctx, name, false)
+			assert.Error(t, err, "expected error for bucket name: %s", name)
+		}
+	})
+
+	t.Run("GetBucket", func(t *testing.T) {
+		bucket := &domain.Bucket{Name: "my-bucket"}
+		mockRepo.On("GetBucket", mock.Anything, "my-bucket").Return(bucket, nil).Once()
+
+		res, err := svc.GetBucket(ctx, "my-bucket")
+		require.NoError(t, err)
+		assert.Equal(t, bucket, res)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("DeleteBucket", func(t *testing.T) {
+		mockRepo.On("List", mock.Anything, "my-bucket").Return([]*domain.Object{}, nil).Once()
+		mockRepo.On("DeleteBucket", mock.Anything, "my-bucket").Return(nil).Once()
+
+		err := svc.DeleteBucket(ctx, "my-bucket", false)
+		require.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("DeleteBucket Not Empty", func(t *testing.T) {
+		mockRepo.On("List", mock.Anything, "my-bucket").Return([]*domain.Object{{Key: "k1"}}, nil).Once()
+
+		err := svc.DeleteBucket(ctx, "my-bucket", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bucket is not empty")
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("DeleteBucket Force", func(t *testing.T) {
+		mockRepo.On("List", mock.Anything, "my-bucket").Return([]*domain.Object{{Key: "k1"}}, nil).Once()
+		mockRepo.On("SoftDelete", mock.Anything, "my-bucket", "k1").Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "storage.object_delete", "storage", mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo.On("DeleteBucket", mock.Anything, "my-bucket").Return(nil).Once()
+
+		err := svc.DeleteBucket(ctx, "my-bucket", true)
+		require.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("ListBuckets", func(t *testing.T) {
+		buckets := []*domain.Bucket{{Name: "b1"}, {Name: "b2"}}
+		mockRepo.On("ListBuckets", mock.Anything, userID.String()).Return(buckets, nil).Once()
+
+		res, err := svc.ListBuckets(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, buckets, res)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("SetBucketVersioning", func(t *testing.T) {
+		mockRepo.On("SetBucketVersioning", mock.Anything, "my-bucket", true).Return(nil).Once()
+
+		err := svc.SetBucketVersioning(ctx, "my-bucket", true)
+		require.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+	})
+
 	t.Run("Upload", func(t *testing.T) {
 		bucket := &domain.Bucket{Name: "my-bucket", VersioningEnabled: false}
 		mockRepo.On("GetBucket", mock.Anything, "my-bucket").Return(bucket, nil).Once()
 		mockStore.On("Write", mock.Anything, "my-bucket", "test.txt", mock.Anything).Return(int64(12), nil).Once()
-		
+
 		// First SaveMeta call for PENDING status
 		mockRepo.On("SaveMeta", mock.Anything, mock.MatchedBy(func(obj *domain.Object) bool {
 			return obj.UploadStatus == domain.UploadStatusPending && obj.SizeBytes == 0
@@ -64,7 +131,7 @@ func TestStorageServiceUnit(t *testing.T) {
 		mockRepo.On("SaveMeta", mock.Anything, mock.MatchedBy(func(obj *domain.Object) bool {
 			return obj.UploadStatus == domain.UploadStatusAvailable && obj.SizeBytes == 12
 		})).Return(nil).Once()
-		
+
 		mockAuditSvc.On("Log", mock.Anything, userID, "storage.object_upload", "storage", mock.Anything, mock.Anything).Return(nil).Once()
 
 		obj, err := svc.Upload(ctx, "my-bucket", "test.txt", strings.NewReader("hello world!"), "")
@@ -92,11 +159,228 @@ func TestStorageServiceUnit(t *testing.T) {
 
 		providedChecksum := "invalid-checksum"
 		_, err := svc.Upload(ctx, "my-bucket", "test.txt", strings.NewReader("hello world!"), providedChecksum)
-		
+
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "data integrity check failed")
-		
+
 		mockRepo.AssertExpectations(t)
 		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("Download", func(t *testing.T) {
+		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: "null", SizeBytes: 12}
+		mockRepo.On("GetMeta", mock.Anything, "my-bucket", "test.txt").Return(obj, nil).Once()
+		mockStore.On("Read", mock.Anything, "my-bucket", "test.txt").Return(io.NopCloser(strings.NewReader("hello world!")), nil).Once()
+		mockRepo.On("GetBucket", mock.Anything, "my-bucket").Return(&domain.Bucket{Name: "my-bucket"}, nil).Once()
+
+		reader, meta, err := svc.Download(ctx, "my-bucket", "test.txt")
+		require.NoError(t, err)
+		assert.NotNil(t, reader)
+		assert.Equal(t, obj, meta)
+
+		data, _ := io.ReadAll(reader)
+		assert.Equal(t, "hello world!", string(data))
+		mockRepo.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("Download Bucket Lookup Failure Closes Reader", func(t *testing.T) {
+		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: "null"}
+		reader := io.NopCloser(strings.NewReader("hello world!"))
+		mockRepo.On("GetMeta", mock.Anything, "my-bucket", "test.txt").Return(obj, nil).Once()
+		mockStore.On("Read", mock.Anything, "my-bucket", "test.txt").Return(reader, nil).Once()
+		mockRepo.On("GetBucket", mock.Anything, "my-bucket").Return(nil, fmt.Errorf("bucket error")).Once()
+
+		gotReader, meta, err := svc.Download(ctx, "my-bucket", "test.txt")
+		require.Error(t, err)
+		assert.Nil(t, gotReader)
+		assert.Nil(t, meta)
+		assert.Contains(t, err.Error(), "failed to get bucket")
+		mockRepo.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("ListObjects", func(t *testing.T) {
+		objects := []*domain.Object{{Key: "test.txt"}}
+		mockRepo.On("List", mock.Anything, "my-bucket").Return(objects, nil).Once()
+
+		res, err := svc.ListObjects(ctx, "my-bucket")
+		require.NoError(t, err)
+		assert.Equal(t, objects, res)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("DeleteObject", func(t *testing.T) {
+		mockRepo.On("SoftDelete", mock.Anything, "my-bucket", "test.txt").Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "storage.object_delete", "storage", mock.Anything, mock.Anything).Return(nil).Once()
+
+		err := svc.DeleteObject(ctx, "my-bucket", "test.txt")
+		require.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("DownloadVersion", func(t *testing.T) {
+		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: "v1", SizeBytes: 12}
+		mockRepo.On("GetMetaByVersion", mock.Anything, "my-bucket", "test.txt", "v1").Return(obj, nil).Once()
+		mockStore.On("Read", mock.Anything, "my-bucket", "test.txt?versionId=v1").Return(io.NopCloser(strings.NewReader("hello v1")), nil).Once()
+
+		reader, meta, err := svc.DownloadVersion(ctx, "my-bucket", "test.txt", "v1")
+		require.NoError(t, err)
+		assert.NotNil(t, reader)
+		assert.Equal(t, obj, meta)
+
+		data, _ := io.ReadAll(reader)
+		assert.Equal(t, "hello v1", string(data))
+		mockRepo.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("ListVersions", func(t *testing.T) {
+		versions := []*domain.Object{{Key: "test.txt", VersionID: "v1"}, {Key: "test.txt", VersionID: "v2"}}
+		mockRepo.On("ListVersions", mock.Anything, "my-bucket", "test.txt").Return(versions, nil).Once()
+
+		res, err := svc.ListVersions(ctx, "my-bucket", "test.txt")
+		require.NoError(t, err)
+		assert.Equal(t, versions, res)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("DeleteVersion", func(t *testing.T) {
+		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: "v1"}
+		mockRepo.On("GetMetaByVersion", mock.Anything, "my-bucket", "test.txt", "v1").Return(obj, nil).Once()
+		mockStore.On("Delete", mock.Anything, "my-bucket", "test.txt?versionId=v1").Return(nil).Once()
+		mockRepo.On("DeleteVersion", mock.Anything, "my-bucket", "test.txt", "v1").Return(nil).Once()
+
+		err := svc.DeleteVersion(ctx, "my-bucket", "test.txt", "v1")
+		require.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("GetClusterStatus", func(t *testing.T) {
+		status := &domain.StorageCluster{Nodes: []domain.StorageNode{{ID: "n1"}}}
+		mockStore.On("GetClusterStatus", mock.Anything).Return(status, nil).Once()
+
+		res, err := svc.GetClusterStatus(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, status, res)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("CleanupDeleted", func(t *testing.T) {
+		deleted := []*domain.Object{{Bucket: "b1", Key: "k1", VersionID: "null"}}
+		mockRepo.On("ListDeleted", mock.Anything, 10).Return(deleted, nil).Once()
+		mockStore.On("Delete", mock.Anything, "b1", "k1").Return(nil).Once()
+		mockRepo.On("HardDelete", mock.Anything, "b1", "k1", "null").Return(nil).Once()
+
+		count, err := svc.CleanupDeleted(ctx, 10)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+		mockRepo.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("CleanupPendingUploads", func(t *testing.T) {
+		pending := []*domain.Object{{Bucket: "b1", Key: "k1", VersionID: "null"}}
+		mockRepo.On("ListPending", mock.Anything, mock.Anything, 10).Return(pending, nil).Once()
+		mockStore.On("Delete", mock.Anything, "b1", "k1").Return(nil).Once()
+		mockRepo.On("HardDelete", mock.Anything, "b1", "k1", "null").Return(nil).Once()
+
+		count, err := svc.CleanupPendingUploads(ctx, time.Hour, 10)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+		mockRepo.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("Multipart Lifecycle", func(t *testing.T) {
+		uploadID := uuid.New()
+		bucket := "my-bucket"
+		key := "large.file"
+
+		mockRepo.On("GetBucket", mock.Anything, bucket).Return(&domain.Bucket{Name: bucket}, nil).Once()
+		mockRepo.On("SaveMultipartUpload", mock.Anything, mock.MatchedBy(func(u *domain.MultipartUpload) bool {
+			return u.Bucket == bucket && u.Key == key
+		})).Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "storage.multipart_init", "storage", mock.Anything, mock.Anything).Return(nil).Once()
+
+		mu, err := svc.CreateMultipartUpload(ctx, bucket, key)
+		require.NoError(t, err)
+		assert.NotNil(t, mu)
+
+		mockRepo.On("GetMultipartUpload", mock.Anything, uploadID).Return(&domain.MultipartUpload{ID: uploadID, Bucket: bucket, Key: key}, nil).Once()
+		mockStore.On("Write", mock.Anything, bucket, mock.Anything, mock.Anything).Return(int64(100), nil).Once()
+		mockRepo.On("SavePart", mock.Anything, mock.MatchedBy(func(p *domain.Part) bool {
+			return p.UploadID == uploadID && p.PartNumber == 1
+		})).Return(nil).Once()
+
+		part, err := svc.UploadPart(ctx, uploadID, 1, strings.NewReader("part data"), "")
+		require.NoError(t, err)
+		assert.NotNil(t, part)
+
+		mockRepo.On("GetMultipartUpload", mock.Anything, uploadID).Return(&domain.MultipartUpload{ID: uploadID, Bucket: bucket, Key: key, UserID: userID}, nil).Once()
+		parts := []*domain.Part{{PartNumber: 1, SizeBytes: 100}}
+		mockRepo.On("ListParts", mock.Anything, uploadID).Return(parts, nil).Once()
+		mockRepo.On("GetBucket", mock.Anything, bucket).Return(&domain.Bucket{Name: bucket}, nil).Once()
+		mockStore.On("Assemble", mock.Anything, bucket, key, mock.Anything).Return(int64(100), nil).Once()
+		mockStore.On("Read", mock.Anything, bucket, key).Return(io.NopCloser(strings.NewReader("part data")), nil).Once()
+		mockRepo.On("SaveMeta", mock.Anything, mock.MatchedBy(func(obj *domain.Object) bool {
+			return obj.UploadStatus == domain.UploadStatusAvailable && obj.SizeBytes == 100
+		})).Return(nil).Once()
+		mockRepo.On("DeleteMultipartUpload", mock.Anything, uploadID).Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "storage.multipart_complete", "storage", mock.Anything, mock.Anything).Return(nil).Once()
+
+		obj, err := svc.CompleteMultipartUpload(ctx, uploadID)
+		require.NoError(t, err)
+		assert.NotNil(t, obj)
+		assert.Equal(t, int64(100), obj.SizeBytes)
+
+		mockRepo.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
+		mockAuditSvc.AssertExpectations(t)
+	})
+
+	t.Run("AbortMultipartUpload", func(t *testing.T) {
+		uploadID := uuid.New()
+		bucket := "my-bucket"
+		mockRepo.On("GetMultipartUpload", mock.Anything, uploadID).Return(&domain.MultipartUpload{ID: uploadID, Bucket: bucket}, nil).Once()
+		parts := []*domain.Part{{PartNumber: 1}}
+		mockRepo.On("ListParts", mock.Anything, uploadID).Return(parts, nil).Once()
+		mockStore.On("Delete", mock.Anything, bucket, mock.Anything).Return(nil).Once()
+		mockRepo.On("DeleteMultipartUpload", mock.Anything, uploadID).Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "storage.multipart_abort", "storage", uploadID.String(), mock.Anything).Return(nil).Once()
+
+		err := svc.AbortMultipartUpload(ctx, uploadID)
+		require.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+		mockStore.AssertExpectations(t)
+		mockAuditSvc.AssertExpectations(t)
+	})
+
+	t.Run("GeneratePresignedURL", func(t *testing.T) {
+		bucket := "my-bucket"
+		key := "file.txt"
+		mockRepo.On("GetBucket", mock.Anything, bucket).Return(&domain.Bucket{Name: bucket}, nil).Once()
+
+		res, err := svc.GeneratePresignedURL(ctx, bucket, key, "GET", time.Hour)
+		require.NoError(t, err)
+		assert.NotNil(t, res)
+		assert.Contains(t, res.URL, "/storage/presigned/my-bucket/file.txt")
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("Additional Error Paths", func(t *testing.T) {
+		mockRepo.ExpectedCalls = nil
+		mockStore.ExpectedCalls = nil
+
+		mockRepo.On("GetMeta", mock.Anything, "b", "k").Return(&domain.Object{Bucket: "b", Key: "k", VersionID: "null"}, nil).Once()
+		mockStore.On("Read", mock.Anything, "b", "k").Return(io.NopCloser(strings.NewReader("data")), nil).Once()
+		mockRepo.On("GetBucket", mock.Anything, "b").Return(nil, fmt.Errorf("bucket error")).Once()
+		_, _, err := svc.Download(ctx, "b", "k")
+		assert.Error(t, err)
+
+		mockRepo.On("GetBucket", mock.Anything, "non-existent").Return(nil, fmt.Errorf("not found")).Once()
+		_, err = svc.CreateMultipartUpload(ctx, "non-existent", "k")
+		assert.Error(t, err)
 	})
 }

--- a/internal/repositories/postgres/storage_repo_test.go
+++ b/internal/repositories/postgres/storage_repo_test.go
@@ -342,3 +342,157 @@ func TestStorageRepositorySetBucketVersioning(t *testing.T) {
 		}
 	})
 }
+
+func TestStorageRepositoryBucketOps(t *testing.T) {
+	t.Run("CreateBucket", func(t *testing.T) {
+		mock, _ := pgxmock.NewPool()
+		defer mock.Close()
+		repo := NewStorageRepository(mock)
+		bucket := &domain.Bucket{ID: uuid.New(), Name: "b1", UserID: uuid.New(), CreatedAt: time.Now()}
+
+		mock.ExpectExec("INSERT INTO buckets").WithArgs(bucket.ID, bucket.Name, bucket.UserID, bucket.IsPublic, bucket.VersioningEnabled, bucket.EncryptionEnabled, bucket.EncryptionKeyID, bucket.CreatedAt).
+			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+		err := repo.CreateBucket(context.Background(), bucket)
+		require.NoError(t, err)
+	})
+
+	t.Run("GetBucket", func(t *testing.T) {
+		mock, _ := pgxmock.NewPool()
+		defer mock.Close()
+		repo := NewStorageRepository(mock)
+		name := "b1"
+
+		mock.ExpectQuery("SELECT id, name, user_id, is_public, versioning_enabled, encryption_enabled, encryption_key_id, created_at FROM buckets").
+			WithArgs(name).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "name", "user_id", "is_public", "versioning_enabled", "encryption_enabled", "encryption_key_id", "created_at"}).
+				AddRow(uuid.New(), name, uuid.New(), false, false, false, "", time.Now()))
+
+		bucket, err := repo.GetBucket(context.Background(), name)
+		require.NoError(t, err)
+		assert.Equal(t, name, bucket.Name)
+	})
+
+	t.Run("ListBuckets", func(t *testing.T) {
+		mock, _ := pgxmock.NewPool()
+		defer mock.Close()
+		repo := NewStorageRepository(mock)
+		userID := uuid.New().String()
+
+		mock.ExpectQuery("SELECT id, name, user_id, is_public, versioning_enabled, encryption_enabled, encryption_key_id, created_at FROM buckets").
+			WithArgs(userID).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "name", "user_id", "is_public", "versioning_enabled", "encryption_enabled", "encryption_key_id", "created_at"}).
+				AddRow(uuid.New(), "b1", userID, false, false, false, "", time.Now()))
+
+		buckets, err := repo.ListBuckets(context.Background(), userID)
+		require.NoError(t, err)
+		assert.Len(t, buckets, 1)
+	})
+
+	t.Run("DeleteBucket", func(t *testing.T) {
+		mock, _ := pgxmock.NewPool()
+		defer mock.Close()
+		repo := NewStorageRepository(mock)
+		name := "b1"
+
+		mock.ExpectExec("DELETE FROM buckets WHERE name = \\$1").
+			WithArgs(name).
+			WillReturnResult(pgxmock.NewResult("DELETE", 1))
+
+		err := repo.DeleteBucket(context.Background(), name)
+		require.NoError(t, err)
+	})
+}
+
+func TestStorageRepositoryMultipart(t *testing.T) {
+	t.Run("MultipartOps", func(t *testing.T) {
+		mock, _ := pgxmock.NewPool()
+		defer mock.Close()
+		repo := NewStorageRepository(mock)
+		uploadID := uuid.New()
+		userID := uuid.New()
+		now := time.Now()
+
+		mock.ExpectExec("INSERT INTO multipart_uploads").WithArgs(uploadID, userID, "b", "k", now).
+			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		err := repo.SaveMultipartUpload(context.Background(), &domain.MultipartUpload{ID: uploadID, UserID: userID, Bucket: "b", Key: "k", CreatedAt: now})
+		require.NoError(t, err)
+
+		mock.ExpectQuery("SELECT id, user_id, bucket, key, created_at FROM multipart_uploads").
+			WithArgs(uploadID).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "bucket", "key", "created_at"}).
+				AddRow(uploadID, userID, "b", "k", now))
+		mu, err := repo.GetMultipartUpload(context.Background(), uploadID)
+		require.NoError(t, err)
+		assert.Equal(t, uploadID, mu.ID)
+
+		mock.ExpectExec("INSERT INTO multipart_parts").WithArgs(uploadID, 1, int64(100), "etag").
+			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		err = repo.SavePart(context.Background(), &domain.Part{UploadID: uploadID, PartNumber: 1, SizeBytes: 100, ETag: "etag"})
+		require.NoError(t, err)
+
+		mock.ExpectQuery("SELECT upload_id, part_number, size_bytes, etag FROM multipart_parts").
+			WithArgs(uploadID).
+			WillReturnRows(pgxmock.NewRows([]string{"upload_id", "part_number", "size_bytes", "etag"}).
+				AddRow(uploadID, 1, int64(100), "etag"))
+		parts, err := repo.ListParts(context.Background(), uploadID)
+		require.NoError(t, err)
+		assert.Len(t, parts, 1)
+
+		mock.ExpectExec("DELETE FROM multipart_uploads").WithArgs(uploadID).WillReturnResult(pgxmock.NewResult("DELETE", 1))
+		err = repo.DeleteMultipartUpload(context.Background(), uploadID)
+		require.NoError(t, err)
+	})
+}
+
+func TestStorageRepositoryMisc(t *testing.T) {
+	t.Run("Versioning and Delete Ops", func(t *testing.T) {
+		mock, _ := pgxmock.NewPool()
+		defer mock.Close()
+		repo := NewStorageRepository(mock)
+		bucket, key, versionID := "b", "k", "v1"
+		userID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+
+		mock.ExpectQuery("SELECT id, user_id, arn, bucket, key, version_id, is_latest, size_bytes, content_type, COALESCE\\(checksum, ''\\), upload_status, created_at, deleted_at FROM objects WHERE bucket = \\$1 AND key = \\$2 AND version_id = \\$3 AND deleted_at IS NULL AND user_id = \\$4 AND upload_status = 'AVAILABLE'").
+			WithArgs(bucket, key, versionID, userID).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "arn", "bucket", "key", "version_id", "is_latest", "size_bytes", "content_type", "checksum", "upload_status", "created_at", "deleted_at"}).
+				AddRow(uuid.New(), userID, "arn", bucket, key, versionID, true, int64(100), "text", "sum", domain.UploadStatusAvailable, time.Now(), nil))
+		_, err := repo.GetMetaByVersion(ctx, bucket, key, versionID)
+		require.NoError(t, err)
+
+		mock.ExpectQuery("SELECT id, user_id, arn, bucket, key, version_id, is_latest, size_bytes, content_type, COALESCE\\(checksum, ''\\), upload_status, created_at, deleted_at FROM objects WHERE bucket = \\$1 AND key = \\$2 AND deleted_at IS NULL AND user_id = \\$3 AND upload_status = 'AVAILABLE' ORDER BY created_at DESC").
+			WithArgs(bucket, key, userID).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "arn", "bucket", "key", "version_id", "is_latest", "size_bytes", "content_type", "checksum", "upload_status", "created_at", "deleted_at"}).
+				AddRow(uuid.New(), userID, "arn", bucket, key, versionID, true, int64(100), "text", "sum", domain.UploadStatusAvailable, time.Now(), nil))
+		_, err = repo.ListVersions(ctx, bucket, key)
+		require.NoError(t, err)
+
+		mock.ExpectQuery("SELECT id, user_id, arn, bucket, key, version_id, is_latest, size_bytes, content_type, COALESCE\\(checksum, ''\\), upload_status, created_at, deleted_at FROM objects WHERE deleted_at IS NOT NULL ORDER BY deleted_at ASC LIMIT \\$1").
+			WithArgs(10).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "arn", "bucket", "key", "version_id", "is_latest", "size_bytes", "content_type", "checksum", "upload_status", "created_at", "deleted_at"}).
+				AddRow(uuid.New(), userID, "arn", bucket, key, versionID, true, int64(100), "text", "sum", domain.UploadStatusAvailable, time.Now(), nil))
+		_, err = repo.ListDeleted(context.Background(), 10)
+		require.NoError(t, err)
+
+		mock.ExpectExec("DELETE FROM objects WHERE bucket = \\$1 AND key = \\$2 AND version_id = \\$3").
+			WithArgs(bucket, key, versionID).
+			WillReturnResult(pgxmock.NewResult("DELETE", 1))
+		err = repo.HardDelete(context.Background(), bucket, key, versionID)
+		require.NoError(t, err)
+
+		olderThan := time.Now()
+		mock.ExpectQuery("SELECT id, user_id, arn, bucket, key, version_id, is_latest, size_bytes, content_type, COALESCE\\(checksum, ''\\), upload_status, created_at, deleted_at FROM objects WHERE upload_status = 'PENDING' AND created_at < \\$1 ORDER BY created_at ASC, id ASC LIMIT \\$2").
+			WithArgs(olderThan, 10).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "arn", "bucket", "key", "version_id", "is_latest", "size_bytes", "content_type", "checksum", "upload_status", "created_at", "deleted_at"}).
+				AddRow(uuid.New(), userID, "arn", bucket, key, "null", true, int64(0), "text", "", domain.UploadStatusPending, olderThan.Add(-time.Hour), nil))
+		_, err = repo.ListPending(context.Background(), olderThan, 10)
+		require.NoError(t, err)
+
+		mock.ExpectExec("DELETE FROM objects WHERE bucket = \\$1 AND key = \\$2 AND version_id = \\$3 AND user_id = \\$4").
+			WithArgs(bucket, key, versionID, userID).
+			WillReturnResult(pgxmock.NewResult("DELETE", 1))
+		err = repo.DeleteVersion(ctx, bucket, key, versionID)
+		require.NoError(t, err)
+	})
+}

--- a/internal/repositories/postgres/storage_repo_test.go
+++ b/internal/repositories/postgres/storage_repo_test.go
@@ -345,7 +345,8 @@ func TestStorageRepositorySetBucketVersioning(t *testing.T) {
 
 func TestStorageRepositoryBucketOps(t *testing.T) {
 	t.Run("CreateBucket", func(t *testing.T) {
-		mock, _ := pgxmock.NewPool()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
 		defer mock.Close()
 		repo := NewStorageRepository(mock)
 		bucket := &domain.Bucket{ID: uuid.New(), Name: "b1", UserID: uuid.New(), CreatedAt: time.Now()}
@@ -353,12 +354,13 @@ func TestStorageRepositoryBucketOps(t *testing.T) {
 		mock.ExpectExec("INSERT INTO buckets").WithArgs(bucket.ID, bucket.Name, bucket.UserID, bucket.IsPublic, bucket.VersioningEnabled, bucket.EncryptionEnabled, bucket.EncryptionKeyID, bucket.CreatedAt).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
-		err := repo.CreateBucket(context.Background(), bucket)
+		err = repo.CreateBucket(context.Background(), bucket)
 		require.NoError(t, err)
 	})
 
 	t.Run("GetBucket", func(t *testing.T) {
-		mock, _ := pgxmock.NewPool()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
 		defer mock.Close()
 		repo := NewStorageRepository(mock)
 		name := "b1"
@@ -374,7 +376,8 @@ func TestStorageRepositoryBucketOps(t *testing.T) {
 	})
 
 	t.Run("ListBuckets", func(t *testing.T) {
-		mock, _ := pgxmock.NewPool()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
 		defer mock.Close()
 		repo := NewStorageRepository(mock)
 		userID := uuid.New().String()
@@ -390,7 +393,8 @@ func TestStorageRepositoryBucketOps(t *testing.T) {
 	})
 
 	t.Run("DeleteBucket", func(t *testing.T) {
-		mock, _ := pgxmock.NewPool()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
 		defer mock.Close()
 		repo := NewStorageRepository(mock)
 		name := "b1"
@@ -399,14 +403,15 @@ func TestStorageRepositoryBucketOps(t *testing.T) {
 			WithArgs(name).
 			WillReturnResult(pgxmock.NewResult("DELETE", 1))
 
-		err := repo.DeleteBucket(context.Background(), name)
+		err = repo.DeleteBucket(context.Background(), name)
 		require.NoError(t, err)
 	})
 }
 
 func TestStorageRepositoryMultipart(t *testing.T) {
 	t.Run("MultipartOps", func(t *testing.T) {
-		mock, _ := pgxmock.NewPool()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
 		defer mock.Close()
 		repo := NewStorageRepository(mock)
 		uploadID := uuid.New()
@@ -415,7 +420,7 @@ func TestStorageRepositoryMultipart(t *testing.T) {
 
 		mock.ExpectExec("INSERT INTO multipart_uploads").WithArgs(uploadID, userID, "b", "k", now).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
-		err := repo.SaveMultipartUpload(context.Background(), &domain.MultipartUpload{ID: uploadID, UserID: userID, Bucket: "b", Key: "k", CreatedAt: now})
+		err = repo.SaveMultipartUpload(context.Background(), &domain.MultipartUpload{ID: uploadID, UserID: userID, Bucket: "b", Key: "k", CreatedAt: now})
 		require.NoError(t, err)
 
 		mock.ExpectQuery("SELECT id, user_id, bucket, key, created_at FROM multipart_uploads").
@@ -447,7 +452,8 @@ func TestStorageRepositoryMultipart(t *testing.T) {
 
 func TestStorageRepositoryMisc(t *testing.T) {
 	t.Run("Versioning and Delete Ops", func(t *testing.T) {
-		mock, _ := pgxmock.NewPool()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
 		defer mock.Close()
 		repo := NewStorageRepository(mock)
 		bucket, key, versionID := "b", "k", "v1"
@@ -458,7 +464,7 @@ func TestStorageRepositoryMisc(t *testing.T) {
 			WithArgs(bucket, key, versionID, userID).
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "arn", "bucket", "key", "version_id", "is_latest", "size_bytes", "content_type", "checksum", "upload_status", "created_at", "deleted_at"}).
 				AddRow(uuid.New(), userID, "arn", bucket, key, versionID, true, int64(100), "text", "sum", domain.UploadStatusAvailable, time.Now(), nil))
-		_, err := repo.GetMetaByVersion(ctx, bucket, key, versionID)
+		_, err = repo.GetMetaByVersion(ctx, bucket, key, versionID)
 		require.NoError(t, err)
 
 		mock.ExpectQuery("SELECT id, user_id, arn, bucket, key, version_id, is_latest, size_bytes, content_type, COALESCE\\(checksum, ''\\), upload_status, created_at, deleted_at FROM objects WHERE bucket = \\$1 AND key = \\$2 AND deleted_at IS NULL AND user_id = \\$3 AND upload_status = 'AVAILABLE' ORDER BY created_at DESC").


### PR DESCRIPTION
## Summary
- port the still-useful storage changes from the old coverage PR onto current `main`
- keep the real behavior fixes in `StorageService`:
  - return an error and close the reader when `Download` cannot load bucket metadata
  - reject bucket names containing consecutive dots
- add the non-duplicated storage service and storage repository unit tests that still improve coverage on current code

## Notes
- this reconstructs the useful parts of PR #100 on top of the current codebase instead of merging the stale branch directly

## Testing
- `go test ./internal/core/services -run 'TestStorageServiceUnit'`
- `go test ./internal/repositories/postgres -run 'TestStorageRepository'`
- `go test -run '^$' ./cmd/... ./internal/... ./pkg/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when downloading objects from buckets to properly manage resource cleanup.
  * Added validation to prevent creating buckets with consecutive dots in their names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->