### PR TITLE
fix: resolve websocket hub mismatch and add tenant isolation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 
-version: 2
-
 run:
   timeout: 5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 
+version: 2
+
 run:
   timeout: 5m
 

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -207,7 +207,7 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 	// 2. WebSocket & Core Infrastructure
 	wsHub := ws.NewHub(c.Logger)
 	go wsHub.Run()
-	eventSvc := services.NewEventService(services.EventServiceParams{Repo: c.Repos.Event, RBACSvc: rbacSvc, Hub: wsHub, Logger: c.Logger})
+	eventSvc := services.NewEventService(services.EventServiceParams{Repo: c.Repos.Event, RBACSvc: rbacSvc, Publisher: wsHub, Logger: c.Logger})
 
 	// 3. Cloud Infrastructure Services (VPC, Subnet, Instance, Volume, SG, LB)
 	vpcSvc := services.NewVpcService(services.VpcServiceParams{Repo: c.Repos.Vpc, LBRepo: c.Repos.LB, PeeringRepo: c.Repos.VPCPeering, RBACSvc: rbacSvc, Network: c.Network, AuditSvc: auditSvc, Logger: c.Logger, DefaultCIDR: c.Config.DefaultVPCCIDR})

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -76,9 +76,6 @@ type Handlers struct {
 
 // InitHandlers constructs HTTP handlers and websocket hub.
 func InitHandlers(svcs *Services, cfg *platform.Config, logger *slog.Logger) *Handlers {
-	hub := ws.NewHub(logger)
-	go hub.Run()
-
 	return &Handlers{
 		Audit:         httphandlers.NewAuditHandler(svcs.Audit),
 		Identity:      httphandlers.NewIdentityHandler(svcs.Identity),
@@ -120,7 +117,7 @@ func InitHandlers(svcs *Services, cfg *platform.Config, logger *slog.Logger) *Ha
 		Log:           httphandlers.NewLogHandler(svcs.Log),
 		IAM:           httphandlers.NewIAMHandler(svcs.IAM),
 		VPCPeering:    httphandlers.NewVPCPeeringHandler(svcs.VPCPeering),
-		Ws:            ws.NewHandler(hub, svcs.Identity, logger),
+		Ws:            ws.NewHandler(svcs.WsHub, svcs.Identity, logger),
 	}
 }
 

--- a/internal/core/domain/ws_event.go
+++ b/internal/core/domain/ws_event.go
@@ -4,6 +4,8 @@ package domain
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // WSEventType defines the types of real-time events sent via WebSocket.
@@ -36,18 +38,20 @@ const (
 // WSEvent represents a single WebSocket message broadcasted to authenticated clients for UI updates.
 type WSEvent struct {
 	Type      WSEventType     `json:"type"`      // The classification of the event
+	TenantID  uuid.UUID       `json:"tenant_id"` // Tenant that owns this event
 	Payload   json.RawMessage `json:"payload"`   // Context-specific JSON data (e.g., an Instance or AuditLog object)
 	Timestamp time.Time       `json:"timestamp"` // Actual time when the event was generated
 }
 
 // NewWSEvent wraps a payload into a WSEvent structure with the current system timestamp.
-func NewWSEvent(eventType WSEventType, payload interface{}) (*WSEvent, error) {
+func NewWSEvent(eventType WSEventType, payload interface{}, tenantID uuid.UUID) (*WSEvent, error) {
 	data, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
 	}
 	return &WSEvent{
 		Type:      eventType,
+		TenantID:  tenantID,
 		Payload:   data,
 		Timestamp: time.Now(),
 	}, nil

--- a/internal/core/domain/ws_event_test.go
+++ b/internal/core/domain/ws_event_test.go
@@ -8,12 +8,16 @@ import (
 
 func TestNewWSEvent_Success(t *testing.T) {
 	t.Parallel()
-	event, err := NewWSEvent(WSEventInstanceCreated, map[string]string{"id": "i-1"}, uuid.New())
+	tenantID := uuid.New()
+	event, err := NewWSEvent(WSEventInstanceCreated, map[string]string{"id": "i-1"}, tenantID)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	if event.Type != WSEventInstanceCreated {
 		t.Fatalf("unexpected event type: %s", event.Type)
+	}
+	if event.TenantID != tenantID {
+		t.Fatalf("unexpected tenant id: got %s want %s", event.TenantID, tenantID)
 	}
 	if len(event.Payload) == 0 {
 		t.Fatalf("expected payload to be populated")

--- a/internal/core/domain/ws_event_test.go
+++ b/internal/core/domain/ws_event_test.go
@@ -1,10 +1,14 @@
 package domain
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
 
 func TestNewWSEvent_Success(t *testing.T) {
 	t.Parallel()
-	event, err := NewWSEvent(WSEventInstanceCreated, map[string]string{"id": "i-1"})
+	event, err := NewWSEvent(WSEventInstanceCreated, map[string]string{"id": "i-1"}, uuid.New())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -18,7 +22,7 @@ func TestNewWSEvent_Success(t *testing.T) {
 
 func TestNewWSEvent_InvalidPayload(t *testing.T) {
 	t.Parallel()
-	_, err := NewWSEvent(WSEventMetricUpdate, make(chan int))
+	_, err := NewWSEvent(WSEventMetricUpdate, make(chan int), uuid.New())
 	if err == nil {
 		t.Fatalf("expected error for invalid payload")
 	}

--- a/internal/core/ports/event.go
+++ b/internal/core/ports/event.go
@@ -4,6 +4,7 @@ package ports
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 )
 
@@ -21,4 +22,11 @@ type EventService interface {
 	RecordEvent(ctx context.Context, action, resourceID, resourceType string, metadata map[string]interface{}) error
 	// ListEvents returns a slice of recent events for observability purposes.
 	ListEvents(ctx context.Context, limit int) ([]*domain.Event, error)
+}
+
+// RealtimePublisher emits real-time events to subscribed clients.
+type RealtimePublisher interface {
+	// PublishEvent sends an event to clients matching the given tenant/user scope.
+	// If userID is nil, sends to all clients in the tenant.
+	PublishEvent(event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error
 }

--- a/internal/core/ports/event.go
+++ b/internal/core/ports/event.go
@@ -28,5 +28,5 @@ type EventService interface {
 type RealtimePublisher interface {
 	// PublishEvent sends an event to clients matching the given tenant/user scope.
 	// If userID is nil, sends to all clients in the tenant.
-	PublishEvent(event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error
+	PublishEvent(ctx context.Context, event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error
 }

--- a/internal/core/services/autoscaling_test.go
+++ b/internal/core/services/autoscaling_test.go
@@ -211,7 +211,7 @@ func TestAutoScaling_TriggerScaleUp(t *testing.T) {
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    postgres.NewEventRepository(db),
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.Default(),
 	})
 

--- a/internal/core/services/cache_test.go
+++ b/internal/core/services/cache_test.go
@@ -37,7 +37,7 @@ func setupCacheServiceTest(t *testing.T) (*services.CacheService, ports.CacheRep
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    eventRepo,
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.Default(),
 	})
 

--- a/internal/core/services/container_test.go
+++ b/internal/core/services/container_test.go
@@ -32,7 +32,7 @@ func setupContainerServiceIntegrationTest(t *testing.T) (ports.ContainerService,
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    eventRepo,
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 	auditRepo := postgres.NewAuditRepository(db)
@@ -128,7 +128,7 @@ func TestContainer_ChaosRestart(t *testing.T) {
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    postgres.NewEventRepository(db),
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.Default(),
 	})
 	auditSvc := services.NewAuditService(services.AuditServiceParams{

--- a/internal/core/services/dns_test.go
+++ b/internal/core/services/dns_test.go
@@ -44,7 +44,7 @@ func setupDNSServiceTest(t *testing.T) (*services.DNSService, ports.DNSRepositor
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    eventRepo,
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.Default(),
 	})
 
@@ -339,7 +339,7 @@ func TestDNSService_BackendError(t *testing.T) {
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    postgres.NewEventRepository(db),
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.Default(),
 	})
 

--- a/internal/core/services/event.go
+++ b/internal/core/services/event.go
@@ -11,23 +11,22 @@ import (
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
-	"github.com/poyrazk/thecloud/internal/handlers/ws"
 )
 
 // EventServiceParams defines the dependencies for EventService.
 type EventServiceParams struct {
-	Repo    ports.EventRepository
-	RBACSvc ports.RBACService
-	Hub     *ws.Hub
-	Logger  *slog.Logger
+	Repo      ports.EventRepository
+	RBACSvc   ports.RBACService
+	Publisher ports.RealtimePublisher
+	Logger    *slog.Logger
 }
 
 // EventService records events and emits websocket notifications.
 type EventService struct {
-	repo    ports.EventRepository
-	rbacSvc ports.RBACService
-	hub     *ws.Hub
-	logger  *slog.Logger
+	repo      ports.EventRepository
+	rbacSvc   ports.RBACService
+	publisher ports.RealtimePublisher
+	logger    *slog.Logger
 }
 
 // NewEventService constructs an EventService with its dependencies.
@@ -37,10 +36,10 @@ func NewEventService(params EventServiceParams) *EventService {
 		logger = slog.Default()
 	}
 	return &EventService{
-		repo:    params.Repo,
-		rbacSvc: params.RBACSvc,
-		hub:     params.Hub,
-		logger:  logger,
+		repo:      params.Repo,
+		rbacSvc:   params.RBACSvc,
+		publisher: params.Publisher,
+		logger:    logger,
 	}
 }
 
@@ -72,10 +71,10 @@ func (s *EventService) RecordEvent(ctx context.Context, action, resourceID, reso
 	}
 
 	// Real-time broadcast
-	if s.hub != nil {
-		wsEvent, err := domain.NewWSEvent(domain.WSEventAuditLog, event)
+	if s.publisher != nil {
+		wsEvent, err := domain.NewWSEvent(domain.WSEventAuditLog, event, tenantID)
 		if err == nil {
-			s.hub.BroadcastEvent(wsEvent)
+			_ = s.publisher.PublishEvent(wsEvent, tenantID, nil)
 		}
 	}
 

--- a/internal/core/services/event.go
+++ b/internal/core/services/event.go
@@ -74,7 +74,12 @@ func (s *EventService) RecordEvent(ctx context.Context, action, resourceID, reso
 	if s.publisher != nil {
 		wsEvent, err := domain.NewWSEvent(domain.WSEventAuditLog, event, tenantID)
 		if err == nil {
-			_ = s.publisher.PublishEvent(wsEvent, tenantID, nil)
+			if err := s.publisher.PublishEvent(ctx, wsEvent, tenantID, nil); err != nil {
+				s.logger.Warn("failed to publish wsEvent",
+					"tenant_id", tenantID,
+					"event_id", event.ID,
+					"error", err)
+			}
 		}
 	}
 

--- a/internal/core/services/instance_test.go
+++ b/internal/core/services/instance_test.go
@@ -130,7 +130,7 @@ func setupInstanceServiceTest(t *testing.T) (*pgxpool.Pool, *services.InstanceSe
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    eventRepo,
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.Default(),
 	})
 
@@ -282,7 +282,7 @@ func TestInstanceServiceLaunchDBFailure(t *testing.T) {
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    postgres.NewEventRepository(db),
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.Default(),
 	})
 	auditSvc := services.NewAuditService(services.AuditServiceParams{

--- a/internal/core/services/notify_test.go
+++ b/internal/core/services/notify_test.go
@@ -39,7 +39,7 @@ func setupNotifyServiceIntegrationTest(t *testing.T) (ports.NotifyService, ports
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    eventRepo,
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 

--- a/internal/core/services/queue_test.go
+++ b/internal/core/services/queue_test.go
@@ -27,7 +27,7 @@ func setupQueueServiceTest(t *testing.T) (ports.QueueService, *postgres.Postgres
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    eventRepo,
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  nil,
 	})
 	auditRepo := postgres.NewAuditRepository(db)

--- a/internal/core/services/snapshot_test.go
+++ b/internal/core/services/snapshot_test.go
@@ -42,7 +42,7 @@ func setupSnapshotServiceIntegrationTest(t *testing.T) (ports.SnapshotService, p
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    eventRepo,
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 

--- a/internal/core/services/volume_test.go
+++ b/internal/core/services/volume_test.go
@@ -33,7 +33,7 @@ func setupVolumeServiceTest(t *testing.T) (*services.VolumeService, *postgres.Vo
 	eventSvc := services.NewEventService(services.EventServiceParams{
 		Repo:    eventRepo,
 		RBACSvc: rbacSvc,
-		Hub:     nil,
+		Publisher:     nil,
 		Logger:  slog.Default(),
 	})
 
@@ -175,7 +175,7 @@ func TestVolume_LaunchAttach_Conflict(t *testing.T) {
 		Repo:     volRepo, 
 		RBACSvc:  rbacSvc, 
 		Storage:  noop.NewNoopStorageBackend(), 
-		EventSvc: services.NewEventService(services.EventServiceParams{Repo: postgres.NewEventRepository(db), RBACSvc: rbacSvc, Hub: nil, Logger: slog.Default()}), 
+		EventSvc: services.NewEventService(services.EventServiceParams{Repo: postgres.NewEventRepository(db), RBACSvc: rbacSvc, Publisher: nil, Logger: slog.Default()}), 
 		AuditSvc: services.NewAuditService(services.AuditServiceParams{Repo: postgres.NewAuditRepository(db), RBACSvc: rbacSvc}), 
 		Logger:   slog.Default(), 
 	})

--- a/internal/handlers/ws/client.go
+++ b/internal/handlers/ws/client.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 )
 
@@ -17,21 +18,23 @@ const (
 
 // Client represents a WebSocket connection.
 type Client struct {
-	hub    *Hub
-	conn   *websocket.Conn
-	send   chan []byte
-	userID string
-	logger *slog.Logger
+	hub      *Hub
+	conn     *websocket.Conn
+	send     chan []byte
+	userID   string
+	tenantID uuid.UUID
+	logger   *slog.Logger
 }
 
 // NewClient creates a new WebSocket client.
-func NewClient(hub *Hub, conn *websocket.Conn, userID string, logger *slog.Logger) *Client {
+func NewClient(hub *Hub, conn *websocket.Conn, userID string, tenantID uuid.UUID, logger *slog.Logger) *Client {
 	return &Client{
-		hub:    hub,
-		conn:   conn,
-		send:   make(chan []byte, 256),
-		userID: userID,
-		logger: logger,
+		hub:      hub,
+		conn:     conn,
+		send:     make(chan []byte, 256),
+		userID:   userID,
+		tenantID: tenantID,
+		logger:   logger,
 	}
 }
 

--- a/internal/handlers/ws/handler.go
+++ b/internal/handlers/ws/handler.go
@@ -42,13 +42,14 @@ func (h *Handler) ServeWS(c *gin.Context) {
 	authHeader := c.GetHeader("Authorization")
 	if authHeader != "" {
 		lowerHeader := strings.ToLower(authHeader)
-		if strings.HasPrefix(lowerHeader, "bearer ") {
+		switch {
+		case strings.HasPrefix(lowerHeader, "bearer "):
 			apiKey = strings.TrimSpace(authHeader[len("Bearer "):])
-		} else if strings.Contains(authHeader, " ") {
+		case strings.Contains(authHeader, " "):
 			// Contains a space but not Bearer prefix - malformed
 			h.logger.Warn("malformed authorization header", "header", authHeader)
 			apiKey = ""
-		} else {
+		default:
 			// No space - treat as raw API key
 			apiKey = authHeader
 		}

--- a/internal/handlers/ws/handler.go
+++ b/internal/handlers/ws/handler.go
@@ -4,62 +4,99 @@ package ws
 import (
 	"log/slog"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 )
 
-var upgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin: func(r *http.Request) bool {
-		// Allow all origins in development; restrict in production
-		return true
-	},
-}
-
 // Handler handles WebSocket connections.
 type Handler struct {
-	hub         *Hub
-	identitySvc ports.IdentityService
-	logger      *slog.Logger
+	hub            *Hub
+	identitySvc    ports.IdentityService
+	logger         *slog.Logger
+	allowedOrigins string
 }
 
 // NewHandler creates a new WebSocket handler.
-func NewHandler(hub *Hub, identitySvc ports.IdentityService, logger *slog.Logger) *Handler {
+func NewHandler(hub *Hub, identitySvc ports.IdentityService, logger *slog.Logger, allowedOrigins ...string) *Handler {
+	origins := ""
+	if len(allowedOrigins) > 0 {
+		origins = allowedOrigins[0]
+	}
 	return &Handler{
-		hub:         hub,
-		identitySvc: identitySvc,
-		logger:      logger,
+		hub:            hub,
+		identitySvc:    identitySvc,
+		logger:         logger,
+		allowedOrigins: origins,
 	}
 }
 
 // ServeWS upgrades HTTP to WebSocket and registers the client.
 func (h *Handler) ServeWS(c *gin.Context) {
-	// Validate API key from query param
-	apiKey := c.Query("api_key")
+	// Validate API key - prefer Authorization header, fall back to query param
+	var apiKey string
+	authHeader := c.GetHeader("Authorization")
+	if authHeader != "" {
+		if strings.HasPrefix(authHeader, "Bearer ") {
+			apiKey = strings.TrimPrefix(authHeader, "Bearer ")
+		} else {
+			apiKey = authHeader
+		}
+	} else {
+		// Fallback to query param (deprecated)
+		apiKey = c.Query("api_key")
+		if apiKey != "" {
+			h.logger.Warn("websocket auth via query string is deprecated")
+		}
+	}
+
 	if apiKey == "" {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "api_key required"})
 		return
 	}
 
-	_, err := h.identitySvc.ValidateAPIKey(c.Request.Context(), apiKey)
+	apiKeyObj, err := h.identitySvc.ValidateAPIKey(c.Request.Context(), apiKey)
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid api_key"})
 		return
 	}
 
 	// Upgrade to WebSocket
-	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+	conn, err := h.upgrader().Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		h.logger.Error("websocket upgrade failed", slog.String("error", err.Error()))
 		return
 	}
 
-	client := NewClient(h.hub, conn, apiKey, h.logger)
+	client := NewClient(h.hub, conn, apiKeyObj.UserID.String(), apiKeyObj.TenantID, h.logger)
 	h.hub.Register(client)
 
 	go client.WritePump()
 	go client.ReadPump()
 }
+
+func (h *Handler) upgrader() *websocket.Upgrader {
+	return &websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin: func(r *http.Request) bool {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				return true // Same-origin requests have no Origin header
+			}
+			if h.allowedOrigins == "" {
+				return false // No origins allowed if not configured
+			}
+			allowed := strings.Split(h.allowedOrigins, ",")
+			for _, o := range allowed {
+				if strings.TrimSpace(o) == origin {
+					return true
+				}
+			}
+			return false
+		},
+	}
+}
+

--- a/internal/handlers/ws/handler.go
+++ b/internal/handlers/ws/handler.go
@@ -20,7 +20,7 @@ const (
 type Handler struct {
 	hub            *Hub
 	identitySvc    ports.IdentityService
-	logger        *slog.Logger
+	logger         *slog.Logger
 	allowedOrigins string
 }
 
@@ -47,8 +47,9 @@ func (h *Handler) ServeWS(c *gin.Context) {
 			apiKey = strings.TrimSpace(authHeader[len("Bearer "):])
 		case strings.Contains(authHeader, " "):
 			// Contains a space but not Bearer prefix - malformed
-			h.logger.Warn("malformed authorization header", "header", authHeader)
-			apiKey = ""
+			h.logger.Warn("malformed authorization header received")
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization header"})
+			return
 		default:
 			// No space - treat as raw API key
 			apiKey = authHeader
@@ -64,13 +65,13 @@ func (h *Handler) ServeWS(c *gin.Context) {
 	}
 
 	if apiKey == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "api_key required"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "api key or authorization header required"})
 		return
 	}
 
 	apiKeyObj, err := h.identitySvc.ValidateAPIKey(c.Request.Context(), apiKey)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid api_key"})
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid api key"})
 		return
 	}
 
@@ -94,11 +95,15 @@ func (h *Handler) upgrader() *websocket.Upgrader {
 		WriteBufferSize: websocketWriteBufferSize,
 		CheckOrigin: func(r *http.Request) bool {
 			origin := r.Header.Get("Origin")
-			if origin == "" {
-				return true // Same-origin requests have no Origin header
-			}
+			// Browser clients always send Origin header for WebSocket handshakes.
+			// If no origins are configured, allow all (backward compatible).
+			// If origins are configured, only allow matching origins.
 			if h.allowedOrigins == "" {
-				return true // No restriction if not configured
+				return true
+			}
+			if origin == "" {
+				// Reject requests with no origin when allowlist is enforced
+				return false
 			}
 			allowed := strings.Split(h.allowedOrigins, ",")
 			for _, o := range allowed {

--- a/internal/handlers/ws/handler.go
+++ b/internal/handlers/ws/handler.go
@@ -11,20 +11,22 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/ports"
 )
 
+const (
+	websocketReadBufferSize  = 1024
+	websocketWriteBufferSize = 1024
+)
+
 // Handler handles WebSocket connections.
 type Handler struct {
 	hub            *Hub
 	identitySvc    ports.IdentityService
-	logger         *slog.Logger
+	logger        *slog.Logger
 	allowedOrigins string
 }
 
 // NewHandler creates a new WebSocket handler.
 func NewHandler(hub *Hub, identitySvc ports.IdentityService, logger *slog.Logger, allowedOrigins ...string) *Handler {
-	origins := ""
-	if len(allowedOrigins) > 0 {
-		origins = allowedOrigins[0]
-	}
+	origins := strings.Join(allowedOrigins, ",")
 	return &Handler{
 		hub:            hub,
 		identitySvc:    identitySvc,
@@ -39,12 +41,20 @@ func (h *Handler) ServeWS(c *gin.Context) {
 	var apiKey string
 	authHeader := c.GetHeader("Authorization")
 	if authHeader != "" {
-		if strings.HasPrefix(authHeader, "Bearer ") {
-			apiKey = strings.TrimPrefix(authHeader, "Bearer ")
+		lowerHeader := strings.ToLower(authHeader)
+		if strings.HasPrefix(lowerHeader, "bearer ") {
+			apiKey = strings.TrimSpace(authHeader[len("Bearer "):])
+		} else if strings.Contains(authHeader, " ") {
+			// Contains a space but not Bearer prefix - malformed
+			h.logger.Warn("malformed authorization header", "header", authHeader)
+			apiKey = ""
 		} else {
+			// No space - treat as raw API key
 			apiKey = authHeader
 		}
-	} else {
+	}
+
+	if apiKey == "" {
 		// Fallback to query param (deprecated)
 		apiKey = c.Query("api_key")
 		if apiKey != "" {
@@ -79,15 +89,15 @@ func (h *Handler) ServeWS(c *gin.Context) {
 
 func (h *Handler) upgrader() *websocket.Upgrader {
 	return &websocket.Upgrader{
-		ReadBufferSize:  1024,
-		WriteBufferSize: 1024,
+		ReadBufferSize:  websocketReadBufferSize,
+		WriteBufferSize: websocketWriteBufferSize,
 		CheckOrigin: func(r *http.Request) bool {
 			origin := r.Header.Get("Origin")
 			if origin == "" {
 				return true // Same-origin requests have no Origin header
 			}
 			if h.allowedOrigins == "" {
-				return false // No origins allowed if not configured
+				return true // No restriction if not configured
 			}
 			allowed := strings.Split(h.allowedOrigins, ",")
 			for _, o := range allowed {
@@ -99,4 +109,3 @@ func (h *Handler) upgrader() *websocket.Upgrader {
 		},
 	}
 }
-

--- a/internal/handlers/ws/hub.go
+++ b/internal/handlers/ws/hub.go
@@ -107,14 +107,16 @@ func (h *Hub) BroadcastEventToTenant(ctx context.Context, event *domain.WSEvent,
 	}
 	h.mu.RUnlock()
 
-	// Remove dead clients via unregister channel (safe removal)
+	// Remove dead clients directly - don't go through Unregister to avoid double-decrement.
+	// ReadPump's deferred Unregister will find client already removed and skip Decrement.
 	for _, client := range toRemove {
-		select {
-		case h.unregister <- client:
-		case <-ctx.Done():
-			// Context cancelled - client will be cleaned up when hub shuts down
-			return ctx.Err()
+		h.mu.Lock()
+		if _, ok := h.clients[client]; ok {
+			delete(h.clients, client)
+			close(client.send)
+			platform.WSConnectionsActive.Dec()
 		}
+		h.mu.Unlock()
 	}
 
 	return nil

--- a/internal/handlers/ws/hub.go
+++ b/internal/handlers/ws/hub.go
@@ -109,7 +109,12 @@ func (h *Hub) BroadcastEventToTenant(ctx context.Context, event *domain.WSEvent,
 
 	// Remove dead clients via unregister channel (safe removal)
 	for _, client := range toRemove {
-		h.Unregister(client)
+		select {
+		case h.unregister <- client:
+		case <-ctx.Done():
+			// Context cancelled - client will be cleaned up when hub shuts down
+			return ctx.Err()
+		}
 	}
 
 	return nil

--- a/internal/handlers/ws/hub.go
+++ b/internal/handlers/ws/hub.go
@@ -2,6 +2,7 @@
 package ws
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"sync"
@@ -80,15 +81,16 @@ func (h *Hub) BroadcastEvent(event *domain.WSEvent) {
 
 // BroadcastEventToTenant sends a WSEvent only to clients matching the given tenant.
 // If userID is not nil, further filter to that specific user.
-func (h *Hub) BroadcastEventToTenant(event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error {
+// Collects clients to remove under RLock, then removes them via unregister channel.
+func (h *Hub) BroadcastEventToTenant(ctx context.Context, event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error {
 	data, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
 
+	// Collect clients to notify under read lock
 	h.mu.RLock()
-	defer h.mu.RUnlock()
-
+	var toRemove []*Client
 	for client := range h.clients {
 		if client.tenantID != tenantID {
 			continue
@@ -99,16 +101,23 @@ func (h *Hub) BroadcastEventToTenant(event *domain.WSEvent, tenantID uuid.UUID, 
 		select {
 		case client.send <- data:
 		default:
-			close(client.send)
-			delete(h.clients, client)
+			// Client buffer full - mark for removal
+			toRemove = append(toRemove, client)
 		}
 	}
+	h.mu.RUnlock()
+
+	// Remove dead clients via unregister channel (safe removal)
+	for _, client := range toRemove {
+		h.Unregister(client)
+	}
+
 	return nil
 }
 
 // PublishEvent implements ports.RealtimePublisher.
-func (h *Hub) PublishEvent(event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error {
-	return h.BroadcastEventToTenant(event, tenantID, userID)
+func (h *Hub) PublishEvent(ctx context.Context, event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error {
+	return h.BroadcastEventToTenant(ctx, event, tenantID, userID)
 }
 
 // ClientCount returns the number of connected clients.

--- a/internal/handlers/ws/hub.go
+++ b/internal/handlers/ws/hub.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/platform"
 )
@@ -75,6 +76,39 @@ func (h *Hub) BroadcastEvent(event *domain.WSEvent) {
 		return
 	}
 	h.broadcast <- data
+}
+
+// BroadcastEventToTenant sends a WSEvent only to clients matching the given tenant.
+// If userID is not nil, further filter to that specific user.
+func (h *Hub) BroadcastEventToTenant(event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error {
+	data, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+
+	for client := range h.clients {
+		if client.tenantID != tenantID {
+			continue
+		}
+		if userID != nil && client.userID != userID.String() {
+			continue
+		}
+		select {
+		case client.send <- data:
+		default:
+			close(client.send)
+			delete(h.clients, client)
+		}
+	}
+	return nil
+}
+
+// PublishEvent implements ports.RealtimePublisher.
+func (h *Hub) PublishEvent(event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error {
+	return h.BroadcastEventToTenant(event, tenantID, userID)
 }
 
 // ClientCount returns the number of connected clients.


### PR DESCRIPTION
## Summary
- Fix websocket hub mismatch: single hub instance now shared between EventService and ws.Handler
- Add RealtimePublisher port to decouple core services from transport layer
- Add TenantID to WSEvent for tenant-scoped broadcasts
- Improve WS auth: Authorization header preferred over query-string API keys
- Add configurable origin validation

## Changes (7 commits)
1. Add TenantID to WSEvent and RealtimePublisher port interface
2. Add tenant-aware broadcast to Hub and update Client struct
3. Improve WS auth and add origin validation
4. Refactor EventService to use RealtimePublisher port
5. Wire single hub instance in dependencies and router
6-7. Update test files to use Publisher field

## Test plan
- [x] go build ./... passes
- [x] go test ./internal/handlers/ws/... passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tenant-scoped real-time events with optional per-user targeting
  * WebSocket origin allowlisting for stricter connection control
  * Client connections now carry tenant context for targeted delivery

* **Improvements**
  * API keys preferred via the Authorization header (supports Bearer and raw tokens)
  * Using the api_key query parameter is deprecated and will emit a warning
  * Publish failures are logged as warnings and won’t interrupt main flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->