### PR TITLE
fix: invalidate cache on API key revoke and rotate

### DIFF
--- a/internal/core/ports/identity.go
+++ b/internal/core/ports/identity.go
@@ -28,6 +28,8 @@ type IdentityService interface {
 	CreateKey(ctx context.Context, userID uuid.UUID, name string) (*domain.APIKey, error)
 	// ValidateAPIKey authenticates a request using a raw API key string.
 	ValidateAPIKey(ctx context.Context, key string) (*domain.APIKey, error)
+	// GetAPIKeyByID retrieves a key's metadata by its unique UUID.
+	GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error)
 	// ListKeys returns all keys associated with an authorized user.
 	ListKeys(ctx context.Context, userID uuid.UUID) ([]*domain.APIKey, error)
 	// RevokeKey immediately invalidates an API key.

--- a/internal/core/services/cached_identity.go
+++ b/internal/core/services/cached_identity.go
@@ -79,8 +79,17 @@ func (s *cachedIdentityService) RevokeKey(ctx context.Context, userID uuid.UUID,
 		return err
 	}
 	keyHash := computeKeyHash(key.Key)
-	s.redis.Del(ctx, fmt.Sprintf("apikey:hash:%s", keyHash))
-	return s.base.RevokeKey(ctx, userID, id)
+
+	// Call authoritative revocation first; only delete from cache if it succeeds
+	if err := s.base.RevokeKey(ctx, userID, id); err != nil {
+		return err
+	}
+
+	if err := s.redis.Del(ctx, fmt.Sprintf("apikey:hash:%s", keyHash)).Err(); err != nil {
+		s.logger.Warn("failed to delete API key from cache",
+			"keyHash", keyHash, "userID", userID, "id", id, "error", err)
+	}
+	return nil
 }
 
 func (s *cachedIdentityService) RotateKey(ctx context.Context, userID uuid.UUID, id uuid.UUID) (*domain.APIKey, error) {
@@ -90,12 +99,15 @@ func (s *cachedIdentityService) RotateKey(ctx context.Context, userID uuid.UUID,
 		return nil, err
 	}
 	oldHash := computeKeyHash(oldKey.Key)
-	s.redis.Del(ctx, fmt.Sprintf("apikey:hash:%s", oldHash))
 
 	newKey, err := s.base.RotateKey(ctx, userID, id)
 	if err != nil {
 		return nil, err
 	}
-	// New key's hash is cached by ValidateAPIKey on next use — no action needed here
+
+	if err := s.redis.Del(ctx, fmt.Sprintf("apikey:hash:%s", oldHash)).Err(); err != nil {
+		s.logger.Warn("failed to delete old API key hash from cache",
+			"keyHash", oldHash, "userID", userID, "id", id, "error", err)
+	}
 	return newKey, nil
 }

--- a/internal/core/services/cached_identity.go
+++ b/internal/core/services/cached_identity.go
@@ -68,13 +68,34 @@ func (s *cachedIdentityService) ListKeys(ctx context.Context, userID uuid.UUID) 
 	return s.base.ListKeys(ctx, userID)
 }
 
+func (s *cachedIdentityService) GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	return s.base.GetAPIKeyByID(ctx, id)
+}
+
 func (s *cachedIdentityService) RevokeKey(ctx context.Context, userID uuid.UUID, id uuid.UUID) error {
-	// For simplicity, we don't know the key string here to invalidate it by string.
-	// In a real system, we'd either invalidate all keys for the user or store a mapping.
-	// For 1k users, we'll just let the 5m TTL handle it or invalidate by ID if we change cache structure.
+	// Fetch key by ID (base, not cached) to get raw key for cache invalidation
+	key, err := s.base.GetAPIKeyByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	keyHash := computeKeyHash(key.Key)
+	s.redis.Del(ctx, fmt.Sprintf("apikey:hash:%s", keyHash))
 	return s.base.RevokeKey(ctx, userID, id)
 }
 
 func (s *cachedIdentityService) RotateKey(ctx context.Context, userID uuid.UUID, id uuid.UUID) (*domain.APIKey, error) {
-	return s.base.RotateKey(ctx, userID, id)
+	// Fetch old key to invalidate its cache entry
+	oldKey, err := s.base.GetAPIKeyByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	oldHash := computeKeyHash(oldKey.Key)
+	s.redis.Del(ctx, fmt.Sprintf("apikey:hash:%s", oldHash))
+
+	newKey, err := s.base.RotateKey(ctx, userID, id)
+	if err != nil {
+		return nil, err
+	}
+	// New key's hash is cached by ValidateAPIKey on next use — no action needed here
+	return newKey, nil
 }

--- a/internal/core/services/cached_identity_test.go
+++ b/internal/core/services/cached_identity_test.go
@@ -30,6 +30,12 @@ func (m *mockIdentityService) ValidateAPIKey(ctx context.Context, key string) (*
 	return r0, args.Error(1)
 }
 
+func (m *mockIdentityService) GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	args := m.Called(ctx, id)
+	r0, _ := args.Get(0).(*domain.APIKey)
+	return r0, args.Error(1)
+}
+
 func (m *mockIdentityService) ListKeys(ctx context.Context, userID uuid.UUID) ([]*domain.APIKey, error) {
 	args := m.Called(ctx, userID)
 	r0, _ := args.Get(0).([]*domain.APIKey)
@@ -121,6 +127,8 @@ func TestCachedIdentityServicePassthrough(t *testing.T) {
 	})
 
 	t.Run("RevokeKey", func(t *testing.T) {
+		apiKey := &domain.APIKey{ID: keyID, Key: "test-key"}
+		base.On("GetAPIKeyByID", mock.Anything, keyID).Return(apiKey, nil)
 		base.On("RevokeKey", mock.Anything, userID, keyID).Return(nil)
 		err := svc.RevokeKey(ctx, userID, keyID)
 		require.NoError(t, err)
@@ -128,7 +136,10 @@ func TestCachedIdentityServicePassthrough(t *testing.T) {
 	})
 
 	t.Run("RotateKey", func(t *testing.T) {
-		base.On("RotateKey", mock.Anything, userID, keyID).Return(&domain.APIKey{}, nil)
+		oldKey := &domain.APIKey{ID: keyID, Key: "old-key"}
+		newKey := &domain.APIKey{ID: uuid.New(), Key: "new-key"}
+		base.On("GetAPIKeyByID", mock.Anything, keyID).Return(oldKey, nil)
+		base.On("RotateKey", mock.Anything, userID, keyID).Return(newKey, nil)
 		_, err := svc.RotateKey(ctx, userID, keyID)
 		require.NoError(t, err)
 		base.AssertExpectations(t)

--- a/internal/core/services/cached_identity_test.go
+++ b/internal/core/services/cached_identity_test.go
@@ -2,8 +2,11 @@ package services
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
@@ -142,6 +145,82 @@ func TestCachedIdentityServicePassthrough(t *testing.T) {
 		base.On("RotateKey", mock.Anything, userID, keyID).Return(newKey, nil)
 		_, err := svc.RotateKey(ctx, userID, keyID)
 		require.NoError(t, err)
+		base.AssertExpectations(t)
+	})
+}
+
+func mustMarshal(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+func TestCachedIdentityServiceCacheInvalidation(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("RevokeKey invalidates cache", func(t *testing.T) {
+		base, client := setupCachedIdentityTest(t)
+		svc := NewCachedIdentityService(base, client, slog.Default())
+
+		keyID := uuid.New()
+		rawKey := "thecloud_testkey123"
+		apiKey := &domain.APIKey{ID: keyID, Key: rawKey, Name: "test"}
+
+		// Pre-populate cache (simulating a prior ValidateAPIKey call)
+		keyHash := computeKeyHash(rawKey)
+		cacheKey := fmt.Sprintf("apikey:hash:%s", keyHash)
+		client.Set(ctx, cacheKey, mustMarshal(apiKey), 5*time.Minute)
+
+		// Confirm it's cached
+		exists, err := client.Exists(ctx, cacheKey).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), exists)
+
+		// Revoke — should delete from cache
+		base.On("GetAPIKeyByID", mock.Anything, keyID).Return(apiKey, nil)
+		base.On("RevokeKey", mock.Anything, mock.Anything, keyID).Return(nil)
+
+		err = svc.RevokeKey(ctx, uuid.New(), keyID)
+		require.NoError(t, err)
+
+		// Verify cache was deleted
+		exists, err = client.Exists(ctx, cacheKey).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), exists)
+		base.AssertExpectations(t)
+	})
+
+	t.Run("RotateKey invalidates old cache entry", func(t *testing.T) {
+		base, client := setupCachedIdentityTest(t)
+		svc := NewCachedIdentityService(base, client, slog.Default())
+
+		keyID := uuid.New()
+		oldKey := "thecloud_oldkey456"
+		newKey := &domain.APIKey{ID: uuid.New(), Key: "thecloud_newkey789", Name: "rotated"}
+
+		oldHash := computeKeyHash(oldKey)
+		oldCacheKey := fmt.Sprintf("apikey:hash:%s", oldHash)
+
+		// Pre-populate cache with old key
+		client.Set(ctx, oldCacheKey, mustMarshal(&domain.APIKey{ID: keyID, Key: oldKey, Name: "test"}), 5*time.Minute)
+		exists, err := client.Exists(ctx, oldCacheKey).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), exists)
+
+		base.On("GetAPIKeyByID", mock.Anything, keyID).Return(&domain.APIKey{ID: keyID, Key: oldKey, Name: "test"}, nil)
+		base.On("RotateKey", mock.Anything, mock.Anything, keyID).Return(newKey, nil)
+
+		result, err := svc.RotateKey(ctx, uuid.New(), keyID)
+		require.NoError(t, err)
+		assert.Equal(t, newKey.ID, result.ID)
+
+		// Old cache key should be gone
+		exists, err = client.Exists(ctx, oldCacheKey).Result()
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), exists)
 		base.AssertExpectations(t)
 	})
 }

--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -111,6 +111,10 @@ func (s *IdentityService) ValidateAPIKey(ctx context.Context, key string) (*doma
 	return apiKey, nil
 }
 
+func (s *IdentityService) GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	return s.repo.GetAPIKeyByID(ctx, id)
+}
+
 func (s *IdentityService) ListKeys(ctx context.Context, userID uuid.UUID) ([]*domain.APIKey, error) {
 	uID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)

--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -218,13 +218,11 @@ func (s *IdentityService) RotateKey(ctx context.Context, userID uuid.UUID, id uu
 	return newKey, nil
 }
 
-// computeKeyHash returns the SHA-256 hex digest of an API key.
-//
-//nolint:codeql // SHA-256 is used as a stable key fingerprint, not password hashing.
-// API keys are machine-generated 32-char hex strings (~128 bits of entropy).
-// Using a memory-hard function (argon2/bcrypt) would slow validation
-// unnecessarily and does not improve security for high-entropy keys.
 func computeKeyHash(key string) string {
+	//nolint:codeql // SHA-256 is used as a stable key fingerprint, not password hashing.
+	// API keys are machine-generated 32-char hex strings (~128 bits of entropy).
+	// Using a memory-hard function (argon2/bcrypt) would slow validation
+	// unnecessarily and does not improve security for high-entropy keys.
 	h := sha256.New()
 	h.Write([]byte(key))
 	return hex.EncodeToString(h.Sum(nil))

--- a/internal/core/services/mock_iam_test.go
+++ b/internal/core/services/mock_iam_test.go
@@ -126,6 +126,11 @@ func (m *MockIdentityService) ValidateAPIKey(ctx context.Context, key string) (*
 	r0, _ := args.Get(0).(*domain.APIKey)
 	return r0, args.Error(1)
 }
+func (m *MockIdentityService) GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	args := m.Called(ctx, id)
+	r0, _ := args.Get(0).(*domain.APIKey)
+	return r0, args.Error(1)
+}
 func (m *MockIdentityService) ListKeys(ctx context.Context, userID uuid.UUID) ([]*domain.APIKey, error) {
 	args := m.Called(ctx, userID)
 	r0, _ := args.Get(0).([]*domain.APIKey)

--- a/internal/handlers/identity_handler_test.go
+++ b/internal/handlers/identity_handler_test.go
@@ -42,6 +42,14 @@ func (m *mockIdentityService) ValidateAPIKey(ctx context.Context, key string) (*
 	r0, _ := args.Get(0).(*domain.APIKey)
 	return r0, args.Error(1)
 }
+func (m *mockIdentityService) GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	r0, _ := args.Get(0).(*domain.APIKey)
+	return r0, args.Error(1)
+}
 func (m *mockIdentityService) ListKeys(ctx context.Context, userID uuid.UUID) ([]*domain.APIKey, error) {
 	args := m.Called(ctx, userID)
 	if args.Get(0) == nil {

--- a/internal/handlers/ws/ws_test.go
+++ b/internal/handlers/ws/ws_test.go
@@ -41,6 +41,14 @@ func (m *mockIdentityService) ValidateAPIKey(ctx context.Context, key string) (*
 	r0, _ := args.Get(0).(*domain.APIKey)
 	return r0, args.Error(1)
 }
+func (m *mockIdentityService) GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	r0, _ := args.Get(0).(*domain.APIKey)
+	return r0, args.Error(1)
+}
 func (m *mockIdentityService) ListKeys(ctx context.Context, userID uuid.UUID) ([]*domain.APIKey, error) {
 	args := m.Called(ctx, userID)
 	r0, _ := args.Get(0).([]*domain.APIKey)

--- a/internal/repositories/noop/adapters.go
+++ b/internal/repositories/noop/adapters.go
@@ -503,6 +503,9 @@ func (s *NoopIdentityService) CreateKey(ctx context.Context, userID uuid.UUID, n
 func (s *NoopIdentityService) ValidateAPIKey(ctx context.Context, key string) (*domain.APIKey, error) {
 	return &domain.APIKey{ID: uuid.New()}, nil
 }
+func (s *NoopIdentityService) GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	return &domain.APIKey{ID: id}, nil
+}
 func (s *NoopIdentityService) ListKeys(ctx context.Context, userID uuid.UUID) ([]*domain.APIKey, error) {
 	return []*domain.APIKey{}, nil
 }

--- a/pkg/httputil/httputil_test.go
+++ b/pkg/httputil/httputil_test.go
@@ -46,6 +46,14 @@ func (m *mockIdentityService) ValidateAPIKey(ctx context.Context, key string) (*
 	r0, _ := args.Get(0).(*domain.APIKey)
 	return r0, args.Error(1)
 }
+func (m *mockIdentityService) GetAPIKeyByID(ctx context.Context, id uuid.UUID) (*domain.APIKey, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	r0, _ := args.Get(0).(*domain.APIKey)
+	return r0, args.Error(1)
+}
 func (m *mockIdentityService) ListKeys(ctx context.Context, userID uuid.UUID) ([]*domain.APIKey, error) {
 	args := m.Called(ctx, userID)
 	r0, _ := args.Get(0).([]*domain.APIKey)


### PR DESCRIPTION
## Summary

- RevokeKey and RotateKey now fetch the key by ID before calling the base service, compute its SHA-256 hash, and delete the corresponding Redis cache entry
- This ensures revoked/rotated keys are immediately invalid rather than remaining valid until the 5-minute TTL expires
- Also adds `GetAPIKeyByID` to `ports.IdentityService` interface and implements it across all concrete types and mocks

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/core/services/... -short -run TestCachedIdentity`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Retrieve API key metadata by ID from the service.

* **Improvements**
  * Cache invalidation now removes stale API key entries when keys are revoked or rotated.

* **Tests**
  * Added and expanded unit tests to cover API key retrieval and cache invalidation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->