### PR TITLE
test(services): add GetImage tests and error cases for image.go

### DIFF
--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -83,11 +83,11 @@ func TestImageService_Unit(t *testing.T) {
 	t.Run("GetImage_Success", func(t *testing.T) {
 		imgID := uuid.New()
 		tenantID := uuid.New()
-		ctx := appcontext.WithTenantID(ctx, tenantID)
+		tenantCtx := appcontext.WithTenantID(ctx, tenantID)
 		img := &domain.Image{ID: imgID, UserID: userID, TenantID: &tenantID}
 		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
 
-		res, err := svc.GetImage(ctx, imgID)
+		res, err := svc.GetImage(tenantCtx, imgID)
 		require.NoError(t, err)
 		assert.Equal(t, imgID, res.ID)
 	})
@@ -105,11 +105,11 @@ func TestImageService_Unit(t *testing.T) {
 		imgID := uuid.New()
 		tenantID := uuid.New()
 		otherTenantID := uuid.New()
-		ctx := appcontext.WithTenantID(ctx, tenantID)
+		tenantCtx := appcontext.WithTenantID(ctx, tenantID)
 		img := &domain.Image{ID: imgID, UserID: userID, TenantID: &otherTenantID}
 		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
 
-		_, err := svc.GetImage(ctx, imgID)
+		_, err := svc.GetImage(tenantCtx, imgID)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})

--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -79,4 +79,64 @@ func TestImageService_Unit(t *testing.T) {
 		err := svc.DeleteImage(ctx, imgID)
 		require.NoError(t, err)
 	})
+
+	t.Run("GetImage_Success", func(t *testing.T) {
+		imgID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithTenantID(ctx, tenantID)
+		img := &domain.Image{ID: imgID, UserID: userID, TenantID: &tenantID}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+
+		res, err := svc.GetImage(ctx, imgID)
+		require.NoError(t, err)
+		assert.Equal(t, imgID, res.ID)
+	})
+
+	t.Run("GetImage_RepoError", func(t *testing.T) {
+		imgID := uuid.New()
+		repo.On("GetByID", mock.Anything, imgID).Return(nil, fmt.Errorf("db error")).Once()
+
+		_, err := svc.GetImage(ctx, imgID)
+		require.Error(t, err)
+	})
+
+	t.Run("GetImage_TenantMismatch", func(t *testing.T) {
+		imgID := uuid.New()
+		tenantID := uuid.New()
+		otherTenantID := uuid.New()
+		ctx := appcontext.WithTenantID(ctx, tenantID)
+		img := &domain.Image{ID: imgID, UserID: userID, TenantID: &otherTenantID}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+
+		_, err := svc.GetImage(ctx, imgID)
+		require.Error(t, err)
+		// Tenant mismatch returns "not found" error
+	})
+
+	t.Run("RegisterImage_RepoError", func(t *testing.T) {
+		repo.On("Create", mock.Anything, mock.Anything).Return(fmt.Errorf("db error")).Once()
+
+		_, err := svc.RegisterImage(ctx, "ubuntu-custom", "desc", "linux", "22.04", false)
+		require.Error(t, err)
+	})
+
+	t.Run("DeleteImage_RepoGetError", func(t *testing.T) {
+		imgID := uuid.New()
+		repo.On("GetByID", mock.Anything, imgID).Return(nil, fmt.Errorf("db error")).Once()
+
+		err := svc.DeleteImage(ctx, imgID)
+		require.Error(t, err)
+	})
+
+	t.Run("ListImages_Success", func(t *testing.T) {
+		images := []*domain.Image{
+			{ID: uuid.New(), UserID: userID},
+			{ID: uuid.New(), UserID: userID},
+		}
+		repo.On("List", mock.Anything, userID, true).Return(images, nil).Once()
+
+		res, err := svc.ListImages(ctx, userID, true)
+		require.NoError(t, err)
+		assert.Len(t, res, 2)
+	})
 }

--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -98,6 +98,7 @@ func TestImageService_Unit(t *testing.T) {
 
 		_, err := svc.GetImage(ctx, imgID)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
 	})
 
 	t.Run("GetImage_TenantMismatch", func(t *testing.T) {
@@ -110,7 +111,7 @@ func TestImageService_Unit(t *testing.T) {
 
 		_, err := svc.GetImage(ctx, imgID)
 		require.Error(t, err)
-		// Tenant mismatch returns "not found" error
+		assert.Contains(t, err.Error(), "not found")
 	})
 
 	t.Run("RegisterImage_RepoError", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Add unit tests for image.go:
- GetImage tests (0% -> 90%)
- RegisterImage_RepoError
- DeleteImage_RepoGetError
- GetImage_TenantMismatch

## Test plan
- [x] go test -run TestImageService_Unit passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for image service operations. New cases validate image retrieval, registration, deletion, and listing across success and error paths. Includes tests ensuring tenant access restrictions, repository error propagation, and correct handling of list results. These tests improve confidence in multi-scenario behavior and error handling for image-related workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->