### PR TITLE
fix: set TenantID and DefaultTenantID on API key creation

### DIFF
--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -76,7 +76,10 @@ func (s *IdentityService) CreateKey(ctx context.Context, userID uuid.UUID, name 
 		Name:             name,
 		CreatedAt:        time.Now(),
 		TenantID:         tenantID,
-		DefaultTenantID:  &tenantID,
+		DefaultTenantID:  nil,
+	}
+	if tenantID != uuid.Nil {
+		apiKey.DefaultTenantID = &tenantID
 	}
 
 	if err := s.repo.CreateAPIKey(ctx, apiKey); err != nil {

--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -69,12 +69,14 @@ func (s *IdentityService) CreateKey(ctx context.Context, userID uuid.UUID, name 
 	keyStr := "thecloud_" + hex.EncodeToString(b)
 
 	apiKey := &domain.APIKey{
-		ID:        uuid.New(),
-		UserID:    userID,
-		Key:       keyStr,
-		KeyHash:   computeKeyHash(keyStr),
-		Name:      name,
-		CreatedAt: time.Now(),
+		ID:               uuid.New(),
+		UserID:           userID,
+		Key:              keyStr,
+		KeyHash:          computeKeyHash(keyStr),
+		Name:             name,
+		CreatedAt:        time.Now(),
+		TenantID:         tenantID,
+		DefaultTenantID:  &tenantID,
 	}
 
 	if err := s.repo.CreateAPIKey(ctx, apiKey); err != nil {

--- a/internal/core/services/identity_test.go
+++ b/internal/core/services/identity_test.go
@@ -41,6 +41,7 @@ func setupIdentityServiceTest(t *testing.T) (*services.IdentityService, *postgre
 func TestIdentityService_CreateKey(t *testing.T) {
 	svc, repo, rbacSvc, ctx := setupIdentityServiceTest(t); _ = rbacSvc
 	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
 
 	t.Run("Success", func(t *testing.T) {
 		rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
@@ -51,11 +52,17 @@ func TestIdentityService_CreateKey(t *testing.T) {
 		assert.Equal(t, name, key.Name)
 		assert.Equal(t, userID, key.UserID)
 		assert.Contains(t, key.Key, "thecloud_")
+		assert.Equal(t, tenantID, key.TenantID)
+		assert.NotNil(t, key.DefaultTenantID)
+		assert.Equal(t, tenantID, *key.DefaultTenantID)
 
 		// Verify in DB
 		dbKey, err := repo.GetAPIKeyByID(ctx, key.ID)
 		require.NoError(t, err)
 		assert.Equal(t, key.Key, dbKey.Key)
+		assert.Equal(t, tenantID, dbKey.TenantID)
+		assert.NotNil(t, dbKey.DefaultTenantID)
+		assert.Equal(t, tenantID, *dbKey.DefaultTenantID)
 	})
 }
 

--- a/internal/repositories/postgres/identity_repo.go
+++ b/internal/repositories/postgres/identity_repo.go
@@ -24,10 +24,10 @@ func NewIdentityRepository(db DB) *IdentityRepository {
 
 func (r *IdentityRepository) CreateAPIKey(ctx context.Context, key *domain.APIKey) error {
 	query := `
-		INSERT INTO api_keys (id, user_id, tenant_id, key, key_hash, name, created_at, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+		INSERT INTO api_keys (id, user_id, tenant_id, key, key_hash, name, created_at, expires_at, default_tenant_id)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
-	_, err := r.db.Exec(ctx, query, key.ID, key.UserID, key.TenantID, key.Key, key.KeyHash, key.Name, key.CreatedAt, key.ExpiresAt)
+	_, err := r.db.Exec(ctx, query, key.ID, key.UserID, key.TenantID, key.Key, key.KeyHash, key.Name, key.CreatedAt, key.ExpiresAt, key.DefaultTenantID)
 	if err != nil {
 		return errors.Wrap(errors.Internal, "failed to create api key", err)
 	}

--- a/internal/repositories/postgres/identity_repo_unit_test.go
+++ b/internal/repositories/postgres/identity_repo_unit_test.go
@@ -31,7 +31,7 @@ func TestIdentityRepository_CreateAPIKey(t *testing.T) {
 	}
 
 	mock.ExpectExec("INSERT INTO api_keys").
-		WithArgs(apiKey.ID, apiKey.UserID, apiKey.TenantID, apiKey.Key, apiKey.KeyHash, apiKey.Name, apiKey.CreatedAt, apiKey.ExpiresAt).
+		WithArgs(apiKey.ID, apiKey.UserID, apiKey.TenantID, apiKey.Key, apiKey.KeyHash, apiKey.Name, apiKey.CreatedAt, apiKey.ExpiresAt, apiKey.DefaultTenantID).
 		WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
 	err = repo.CreateAPIKey(context.Background(), apiKey)


### PR DESCRIPTION
## Summary

Fixes finding #4: `CreateKey` extracts `tenantID` from context but never assigns it to the `APIKey` struct. Now sets both `TenantID` and `DefaultTenantID` so newly created keys participate in automatic tenant resolution during authentication.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/core/services/... -short -run "Cached|IdentityService_Unit"`
- [x] `go test ./internal/handlers/... -short -run "Identity"`
- [x] `golangci-lint run ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API keys now support multi-tenant functionality, tracking tenant ownership and allowing configuration of a default tenant for API access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->