### PR TITLE
chore(load-tests): make infrastructure tests opt-in via workflow_dispatch

### DIFF
--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -2,6 +2,12 @@ name: Load Testing
 
 on:
   workflow_dispatch:
+    inputs:
+      run_infrastructure_tests:
+        description: 'Run slow infrastructure tests (requires OVS kernel modules)'
+        required: false
+        default: false
+        type: boolean
   push:
     branches: [ main ]
     paths:
@@ -191,9 +197,12 @@ jobs:
         run: kill $API_PID 2>/dev/null || true
 
   # Slow infrastructure tests - runs in ~5 minutes
+  # Requires: OVS kernel modules (not available in GitHub Actions standard runners)
+  # Only runs when explicitly enabled via workflow_dispatch input
   api-slow:
     name: API Slow Infrastructure Tests
     runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.run_infrastructure_tests == 'true' }}
 
     services:
       postgres:


### PR DESCRIPTION
## Summary
- Add `run_infrastructure_tests` input to workflow_dispatch
- Infrastructure tests (api-slow) only run when explicitly enabled
- On push to main, only api-quick and api-storage run automatically
- Resolves CI noise from OVS kernel module limitations

## Test plan
- [ ] Verify PR merges cleanly
- [ ] Confirm Load Testing workflow runs on this PR with only api-quick and api-storage jobs
- [ ] Manually trigger Load Testing via workflow_dispatch to test infrastructure job gate