### PR TITLE
fix: make cron job claiming transactional with claim timeout

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -628,14 +628,19 @@ CREATE TABLE subscriptions (
 CREATE TABLE cron_jobs (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    tenant_id UUID NOT NULL DEFAULT auth.jwt_token().tenant_id,
     name VARCHAR(255) NOT NULL,
     schedule VARCHAR(100) NOT NULL,
-    function_id UUID REFERENCES functions(id) ON DELETE SET NULL,
-    http_endpoint TEXT,
-    status VARCHAR(50) DEFAULT 'ACTIVE',
+    target_url TEXT NOT NULL,
+    target_method VARCHAR(10) NOT NULL DEFAULT 'POST',
+    target_payload TEXT,
+    status VARCHAR(50) NOT NULL DEFAULT 'ACTIVE',
     last_run_at TIMESTAMPTZ,
     next_run_at TIMESTAMPTZ,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    claimed_until TIMESTAMPTZ,  -- visibility timeout for distributed claiming
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(user_id, name)
 );
 
 CREATE TABLE cron_job_runs (

--- a/docs/project-review-findings.md
+++ b/docs/project-review-findings.md
@@ -158,7 +158,9 @@ Recommendation:
 
 Severity: High
 
-What is wrong:
+Status: ✅ RESOLVED (PR #134)
+
+What was wrong:
 - `internal/repositories/postgres/cron_repo.go:74-80` uses `FOR UPDATE SKIP LOCKED` outside a transaction.
 - `internal/core/services/cron_worker.go:52-62,90-115` fetches due jobs, runs them, and updates next execution later.
 

--- a/docs/services/cloud-cron.md
+++ b/docs/services/cloud-cron.md
@@ -3,13 +3,17 @@
 CloudCron allows you to run recurring tasks using standard Cron syntax.
 
 ## Internal Workings
-- **Worker**: A background goroutine (`CronWorker`) polls the database every 10 seconds for jobs whose `next_run_at <= NOW()`.
+- **Worker**: A background goroutine (`CronWorker`) polls every 10 seconds for due jobs via `ClaimNextJobsToRun`.
+- **Transactional claiming**: Jobs are claimed atomically using `FOR UPDATE SKIP LOCKED` inside a `BEGIN...COMMIT` transaction. The `next_run_at` is set to a far-future value (1 year) and a `claimed_until` timestamp is recorded to prevent double-execution across workers.
+- **Atomic completion**: After execution, `CompleteJobRun` atomically inserts the run record and advances `next_run_at` to the true next scheduled time — in a single transaction.
+- **Crash recovery**: A reaper runs every 1 minute to reset stale claims where `claimed_until` has expired (worker died mid-execution). Those jobs are immediately re-queued.
 - **Parsing**: Uses the `robfig/cron/v3` library for reliable cron expression parsing.
-- **Execution**: All jobs are currently "HTTP Targets" - they trigger an HTTP/REST call to a user-defined URL.
+- **Execution**: All jobs are currently "HTTP Targets" — they trigger an HTTP/REST call to a user-defined URL.
 
 ## Features
 - **Run History**: Every execution's status, code, and duration are recorded in `cron_job_runs`.
 - **States**: Jobs can be `ACTIVE` or `PAUSED`.
+- **Multi-worker safe**: Due to transactional claiming with claim timeouts, the same job cannot be executed by multiple workers simultaneously.
 
 ## CLI Usage
 ```bash

--- a/internal/core/domain/cron.go
+++ b/internal/core/domain/cron.go
@@ -32,6 +32,7 @@ type CronJob struct {
 	Status        CronStatus `json:"status"`
 	LastRunAt     *time.Time `json:"last_run_at"`
 	NextRunAt     *time.Time `json:"next_run_at"`
+	ClaimedUntil  *time.Time `json:"claimed_until"` // Visibility timeout for distributed claiming
 	CreatedAt     time.Time  `json:"created_at"`
 	UpdatedAt     time.Time  `json:"updated_at"`
 }

--- a/internal/core/ports/cron.go
+++ b/internal/core/ports/cron.go
@@ -3,6 +3,7 @@ package ports
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
@@ -21,12 +22,14 @@ type CronRepository interface {
 	// DeleteJob removes a cron job from persistent storage.
 	DeleteJob(ctx context.Context, id uuid.UUID) error
 
-	// For the scheduler worker
-
-	// GetNextJobsToRun returns a slice of jobs that are due for execution according to their schedule.
-	GetNextJobsToRun(ctx context.Context) ([]*domain.CronJob, error)
-	// SaveJobRun records the execution result and metadata of a completed cron task.
-	SaveJobRun(ctx context.Context, run *domain.CronJobRun) error
+	// ClaimNextJobsToRun atomically selects jobs due for execution,
+	// marks them as claimed (next_run_at = far future), and returns them.
+	// Uses FOR UPDATE SKIP LOCKED within a transaction.
+	ClaimNextJobsToRun(ctx context.Context, lockTimeout time.Duration) ([]*domain.CronJob, error)
+	// CompleteJobRun atomically records the run result and updates next_run_at.
+	CompleteJobRun(ctx context.Context, run *domain.CronJobRun, job *domain.CronJob, nextRunAt time.Time) error
+	// ReapStaleClaims resets jobs whose claim expired without completion.
+	ReapStaleClaims(ctx context.Context) (int, error)
 }
 
 // CronService provides business logic for managing scheduled background tasks.

--- a/internal/core/services/cron_worker.go
+++ b/internal/core/services/cron_worker.go
@@ -15,6 +15,8 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
+const ClaimTimeout = 5 * time.Minute
+
 // CronWorker executes scheduled jobs and records run results.
 type CronWorker struct {
 	repo   ports.CronRepository
@@ -34,7 +36,9 @@ func NewCronWorker(repo ports.CronRepository) *CronWorker {
 func (w *CronWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 	ticker := time.NewTicker(10 * time.Second)
+	reaperTicker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
+	defer reaperTicker.Stop()
 
 	log.Println("CloudCron Worker started")
 
@@ -45,19 +49,21 @@ func (w *CronWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
 			return
 		case <-ticker.C:
 			w.ProcessJobs(ctx)
+		case <-reaperTicker.C:
+			w.reapStaleClaims(ctx)
 		}
 	}
 }
 
 func (w *CronWorker) ProcessJobs(ctx context.Context) {
-	jobs, err := w.repo.GetNextJobsToRun(ctx)
+	jobs, err := w.repo.ClaimNextJobsToRun(ctx, ClaimTimeout)
 	if err != nil {
-		log.Printf("CronWorker: failed to fetch jobs: %v", err)
+		log.Printf("CronWorker: failed to claim jobs: %v", err)
 		return
 	}
 
 	for _, job := range jobs {
-		go w.runJob(context.Background(), job)
+		w.runJob(ctx, job)
 	}
 }
 
@@ -66,7 +72,7 @@ func (w *CronWorker) runJob(ctx context.Context, job *domain.CronJob) {
 
 	req, err := http.NewRequestWithContext(ctx, job.TargetMethod, job.TargetURL, bytes.NewBufferString(job.TargetPayload))
 	if err != nil {
-		w.recordRun(ctx, job, "FAILED", 0, err.Error(), time.Since(start))
+		w.completeRun(ctx, job, "FAILED", 0, err.Error(), time.Since(start))
 		return
 	}
 
@@ -74,7 +80,7 @@ func (w *CronWorker) runJob(ctx context.Context, job *domain.CronJob) {
 	duration := time.Since(start)
 
 	if err != nil {
-		w.recordRun(ctx, job, "FAILED", 0, err.Error(), duration)
+		w.completeRun(ctx, job, "FAILED", 0, err.Error(), duration)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -84,10 +90,10 @@ func (w *CronWorker) runJob(ctx context.Context, job *domain.CronJob) {
 		status = "FAILED"
 	}
 
-	w.recordRun(ctx, job, status, resp.StatusCode, resp.Status, duration)
+	w.completeRun(ctx, job, status, resp.StatusCode, resp.Status, duration)
 }
 
-func (w *CronWorker) recordRun(ctx context.Context, job *domain.CronJob, status string, code int, response string, duration time.Duration) {
+func (w *CronWorker) completeRun(ctx context.Context, job *domain.CronJob, status string, code int, response string, duration time.Duration) {
 	run := &domain.CronJobRun{
 		ID:         uuid.New(),
 		JobID:      job.ID,
@@ -98,19 +104,20 @@ func (w *CronWorker) recordRun(ctx context.Context, job *domain.CronJob, status 
 		StartedAt:  time.Now().Add(-duration),
 	}
 
-	if err := w.repo.SaveJobRun(ctx, run); err != nil {
-		log.Printf("CronWorker: failed to save job run: %v", err)
-	}
-
-	// Update job state
 	sched, _ := w.parser.Parse(job.Schedule)
 	now := time.Now()
 	nextRun := sched.Next(now)
 
-	job.LastRunAt = &now
-	job.NextRunAt = &nextRun
+	if err := w.repo.CompleteJobRun(ctx, run, job, nextRun); err != nil {
+		log.Printf("CronWorker: failed to complete job run: %v", err)
+	}
+}
 
-	if err := w.repo.UpdateJob(ctx, job); err != nil {
-		log.Printf("CronWorker: failed to update job state: %v", err)
+func (w *CronWorker) reapStaleClaims(ctx context.Context) {
+	count, err := w.repo.ReapStaleClaims(ctx)
+	if err != nil {
+		log.Printf("CronWorker: failed to reap stale claims: %v", err)
+	} else if count > 0 {
+		log.Printf("CronWorker: reclaimed %d stale claims", count)
 	}
 }

--- a/internal/core/services/cron_worker.go
+++ b/internal/core/services/cron_worker.go
@@ -104,9 +104,15 @@ func (w *CronWorker) completeRun(ctx context.Context, job *domain.CronJob, statu
 		StartedAt:  time.Now().Add(-duration),
 	}
 
-	sched, _ := w.parser.Parse(job.Schedule)
 	now := time.Now()
-	nextRun := sched.Next(now)
+	nextRun := now.Add(24 * time.Hour)
+
+	sched, err := w.parser.Parse(job.Schedule)
+	if err != nil {
+		log.Printf("CronWorker: invalid schedule for job %s: %q: %v; using fallback next run at %s", job.ID, job.Schedule, err, nextRun.Format(time.RFC3339))
+	} else {
+		nextRun = sched.Next(now)
+	}
 
 	if err := w.repo.CompleteJobRun(ctx, run, job, nextRun); err != nil {
 		log.Printf("CronWorker: failed to complete job run: %v", err)

--- a/internal/core/services/cron_worker_test.go
+++ b/internal/core/services/cron_worker_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
@@ -36,20 +35,13 @@ func TestCronWorkerProcessJobs(t *testing.T) {
 		Schedule:     "* * * * *", // Every minute
 	}
 
-	repo.On("GetNextJobsToRun", ctx).Return([]*domain.CronJob{job}, nil)
+	repo.On("ClaimNextJobsToRun", ctx, services.ClaimTimeout).Return([]*domain.CronJob{job}, nil)
 
-	repo.On("SaveJobRun", mock.Anything, mock.MatchedBy(func(run *domain.CronJobRun) bool {
+	repo.On("CompleteJobRun", mock.Anything, mock.MatchedBy(func(run *domain.CronJobRun) bool {
 		return run.JobID == jobID && run.Status == "SUCCESS" && run.StatusCode == 200
-	})).Return(nil)
-
-	repo.On("UpdateJob", mock.Anything, mock.MatchedBy(func(j *domain.CronJob) bool {
-		return j.ID == jobID && j.LastRunAt != nil && j.NextRunAt != nil
-	})).Return(nil)
+	}), mock.Anything, mock.Anything).Return(nil)
 
 	worker.ProcessJobs(ctx)
-
-	// Wait briefly for goroutines to finish since runJob is called in a goroutine
-	time.Sleep(100 * time.Millisecond)
 
 	repo.AssertExpectations(t)
 }
@@ -70,19 +62,13 @@ func TestCronWorkerProcessJobs_RequestFailure(t *testing.T) {
 		Schedule:     "* * * * *",
 	}
 
-	repo.On("GetNextJobsToRun", ctx).Return([]*domain.CronJob{job}, nil)
+	repo.On("ClaimNextJobsToRun", ctx, services.ClaimTimeout).Return([]*domain.CronJob{job}, nil)
 
-	repo.On("SaveJobRun", mock.Anything, mock.MatchedBy(func(run *domain.CronJobRun) bool {
+	repo.On("CompleteJobRun", mock.Anything, mock.MatchedBy(func(run *domain.CronJobRun) bool {
 		return run.JobID == jobID && run.Status == "FAILED"
-	})).Return(nil)
-
-	repo.On("UpdateJob", mock.Anything, mock.MatchedBy(func(j *domain.CronJob) bool {
-		return j.ID == jobID
-	})).Return(nil)
+	}), mock.Anything, mock.Anything).Return(nil)
 
 	worker.ProcessJobs(ctx)
-
-	time.Sleep(100 * time.Millisecond)
 
 	repo.AssertExpectations(t)
 }
@@ -107,17 +93,13 @@ func TestCronWorkerProcessJobs_HTTPError(t *testing.T) {
 		Schedule:     "* * * * *",
 	}
 
-	repo.On("GetNextJobsToRun", ctx).Return([]*domain.CronJob{job}, nil)
+	repo.On("ClaimNextJobsToRun", ctx, services.ClaimTimeout).Return([]*domain.CronJob{job}, nil)
 
-	repo.On("SaveJobRun", mock.Anything, mock.MatchedBy(func(run *domain.CronJobRun) bool {
+	repo.On("CompleteJobRun", mock.Anything, mock.MatchedBy(func(run *domain.CronJobRun) bool {
 		return run.JobID == jobID && run.Status == "FAILED" && run.StatusCode == 500
-	})).Return(nil)
-
-	repo.On("UpdateJob", mock.Anything, mock.Anything).Return(nil)
+	}), mock.Anything, mock.Anything).Return(nil)
 
 	worker.ProcessJobs(ctx)
-
-	time.Sleep(100 * time.Millisecond)
 
 	repo.AssertExpectations(t)
 }

--- a/internal/core/services/mock_util_test.go
+++ b/internal/core/services/mock_util_test.go
@@ -126,15 +126,19 @@ func (m *MockCronRepo) UpdateJob(ctx context.Context, job *domain.CronJob) error
 func (m *MockCronRepo) DeleteJob(ctx context.Context, id uuid.UUID) error {
 	return m.Called(ctx, id).Error(0)
 }
-func (m *MockCronRepo) GetNextJobsToRun(ctx context.Context) ([]*domain.CronJob, error) {
-	args := m.Called(ctx)
+func (m *MockCronRepo) ClaimNextJobsToRun(ctx context.Context, lockTimeout time.Duration) ([]*domain.CronJob, error) {
+	args := m.Called(ctx, lockTimeout)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]*domain.CronJob), args.Error(1)
 }
-func (m *MockCronRepo) SaveJobRun(ctx context.Context, run *domain.CronJobRun) error {
-	return m.Called(ctx, run).Error(0)
+func (m *MockCronRepo) CompleteJobRun(ctx context.Context, run *domain.CronJobRun, job *domain.CronJob, nextRunAt time.Time) error {
+	return m.Called(ctx, run, job, nextRunAt).Error(0)
+}
+func (m *MockCronRepo) ReapStaleClaims(ctx context.Context) (int, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int), args.Error(1)
 }
 
 type MockCronRepository = MockCronRepo

--- a/internal/repositories/postgres/cron_repo.go
+++ b/internal/repositories/postgres/cron_repo.go
@@ -101,7 +101,6 @@ func (r *PostgresCronRepository) ClaimNextJobsToRun(ctx context.Context, lockTim
 
 	jobs, err := r.scanCronJobsWithTenant(rows)
 	if err != nil {
-		rows.Close()
 		return nil, err
 	}
 
@@ -190,6 +189,9 @@ func (r *PostgresCronRepository) ReapStaleClaims(ctx context.Context) (int, erro
 	count := 0
 	for rows.Next() {
 		count++
+	}
+	if err := rows.Err(); err != nil {
+		return 0, err
 	}
 	return count, tx.Commit(ctx)
 }

--- a/internal/repositories/postgres/cron_repo.go
+++ b/internal/repositories/postgres/cron_repo.go
@@ -3,6 +3,7 @@ package postgres
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -71,13 +72,126 @@ func (r *PostgresCronRepository) DeleteJob(ctx context.Context, id uuid.UUID) er
 	return err
 }
 
-func (r *PostgresCronRepository) GetNextJobsToRun(ctx context.Context) ([]*domain.CronJob, error) {
-	query := `SELECT id, user_id, name, schedule, target_url, target_method, target_payload, status, last_run_at, next_run_at, created_at, updated_at FROM cron_jobs WHERE status = 'ACTIVE' AND next_run_at <= NOW() FOR UPDATE SKIP LOCKED`
-	rows, err := r.db.Query(ctx, query)
+func (r *PostgresCronRepository) ClaimNextJobsToRun(ctx context.Context, lockTimeout time.Duration) ([]*domain.CronJob, error) {
+	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
-	return r.scanCronJobs(rows)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	now := time.Now()
+	claimExpiry := now.Add(lockTimeout)
+	farFuture := now.Add(365 * 24 * time.Hour)
+
+	selectQuery := `
+		SELECT id, user_id, name, schedule, target_url, target_method, target_payload,
+		       status, last_run_at, next_run_at, tenant_id, created_at, updated_at
+		FROM cron_jobs
+		WHERE status = 'ACTIVE'
+		  AND next_run_at <= NOW()
+		  AND (claimed_until IS NULL OR claimed_until <= NOW())
+		ORDER BY next_run_at ASC
+		LIMIT 10
+		FOR UPDATE SKIP LOCKED
+	`
+	rows, err := tx.Query(ctx, selectQuery)
+	if err != nil {
+		return nil, err
+	}
+
+	jobs, err := r.scanCronJobsWithTenant(rows)
+	if err != nil {
+		rows.Close()
+		return nil, err
+	}
+
+	if len(jobs) == 0 {
+		return nil, tx.Commit(ctx)
+	}
+
+	ids := make([]uuid.UUID, len(jobs))
+	for i, job := range jobs {
+		ids[i] = job.ID
+	}
+
+	updateQuery := `
+		UPDATE cron_jobs
+		SET next_run_at = $1, claimed_until = $2, updated_at = NOW()
+		WHERE id = ANY($3)
+	`
+	_, err = tx.Exec(ctx, updateQuery, farFuture, claimExpiry, ids)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+
+	for _, job := range jobs {
+		job.NextRunAt = &farFuture
+		job.ClaimedUntil = &claimExpiry
+	}
+	return jobs, nil
+}
+
+func (r *PostgresCronRepository) CompleteJobRun(ctx context.Context, run *domain.CronJobRun, job *domain.CronJob, nextRunAt time.Time) error {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	insertQuery := `
+		INSERT INTO cron_job_runs (id, job_id, status, status_code, response, duration_ms, started_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`
+	_, err = tx.Exec(ctx, insertQuery, run.ID, run.JobID, run.Status, run.StatusCode, run.Response, run.DurationMs, run.StartedAt)
+	if err != nil {
+		return err
+	}
+
+	updateQuery := `
+		UPDATE cron_jobs
+		SET last_run_at = $1, next_run_at = $2, claimed_until = NULL, updated_at = $3
+		WHERE id = $4
+	`
+	_, err = tx.Exec(ctx, updateQuery, run.StartedAt, nextRunAt, time.Now(), job.ID)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (r *PostgresCronRepository) ReapStaleClaims(ctx context.Context) (int, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	query := `
+		UPDATE cron_jobs
+		SET claimed_until = NULL,
+		    next_run_at = NOW(),
+		    updated_at = NOW()
+		WHERE claimed_until IS NOT NULL
+		  AND claimed_until < NOW()
+		  AND next_run_at > NOW() + INTERVAL '1 day'
+		RETURNING id
+	`
+	rows, err := tx.Query(ctx, query)
+	if err != nil {
+		return 0, err
+	}
+	defer rows.Close()
+
+	count := 0
+	for rows.Next() {
+		count++
+	}
+	return count, tx.Commit(ctx)
 }
 
 func (r *PostgresCronRepository) scanCronJob(row pgx.Row) (*domain.CronJob, error) {
@@ -104,11 +218,49 @@ func (r *PostgresCronRepository) scanCronJob(row pgx.Row) (*domain.CronJob, erro
 	return &job, nil
 }
 
+func (r *PostgresCronRepository) scanCronJobWithTenant(row pgx.Row) (*domain.CronJob, error) {
+	var job domain.CronJob
+	var status string
+	err := row.Scan(
+		&job.ID,
+		&job.UserID,
+		&job.Name,
+		&job.Schedule,
+		&job.TargetURL,
+		&job.TargetMethod,
+		&job.TargetPayload,
+		&status,
+		&job.LastRunAt,
+		&job.NextRunAt,
+		&job.TenantID,
+		&job.CreatedAt,
+		&job.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	job.Status = domain.CronStatus(status)
+	return &job, nil
+}
+
 func (r *PostgresCronRepository) scanCronJobs(rows pgx.Rows) ([]*domain.CronJob, error) {
 	defer rows.Close()
 	var jobs []*domain.CronJob
 	for rows.Next() {
 		job, err := r.scanCronJob(rows)
+		if err != nil {
+			return nil, err
+		}
+		jobs = append(jobs, job)
+	}
+	return jobs, nil
+}
+
+func (r *PostgresCronRepository) scanCronJobsWithTenant(rows pgx.Rows) ([]*domain.CronJob, error) {
+	defer rows.Close()
+	var jobs []*domain.CronJob
+	for rows.Next() {
+		job, err := r.scanCronJobWithTenant(rows)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/repositories/postgres/cron_repo_test.go
+++ b/internal/repositories/postgres/cron_repo_test.go
@@ -64,7 +64,7 @@ func TestPostgresCronRepository(t *testing.T) {
 		}
 		require.NoError(t, repo.CreateJob(ctx, job))
 
-		jobs, err := repo.GetNextJobsToRun(context.Background())
+		jobs, err := repo.ClaimNextJobsToRun(context.Background(), 5*time.Minute)
 		require.NoError(t, err)
 		assert.NotEmpty(t, jobs)
 	})

--- a/internal/repositories/postgres/migrations/104_add_cron_claim_fields.down.sql
+++ b/internal/repositories/postgres/migrations/104_add_cron_claim_fields.down.sql
@@ -1,2 +1,3 @@
 -- +goose Down
+DROP INDEX IF EXISTS idx_cron_jobs_claimed_until;
 ALTER TABLE cron_jobs DROP COLUMN IF EXISTS claimed_until;

--- a/internal/repositories/postgres/migrations/104_add_cron_claim_fields.down.sql
+++ b/internal/repositories/postgres/migrations/104_add_cron_claim_fields.down.sql
@@ -1,0 +1,2 @@
+-- +goose Down
+ALTER TABLE cron_jobs DROP COLUMN IF EXISTS claimed_until;

--- a/internal/repositories/postgres/migrations/104_add_cron_claim_fields.up.sql
+++ b/internal/repositories/postgres/migrations/104_add_cron_claim_fields.up.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- Add claim tracking for distributed cron job execution
+ALTER TABLE cron_jobs ADD COLUMN IF NOT EXISTS claimed_until TIMESTAMPTZ;
+
+-- Index to find stale claims efficiently
+CREATE INDEX IF NOT EXISTS idx_cron_jobs_claimed_until ON cron_jobs(claimed_until)
+    WHERE claimed_until IS NOT NULL;


### PR DESCRIPTION
## Summary

- **`FOR UPDATE SKIP LOCKED` was useless** — ran outside any transaction, so no row lock was ever acquired. Multiple workers could execute the same job.
- **Atomic claiming**: `ClaimNextJobsToRun` now uses `BEGIN → SELECT FOR UPDATE SKIP LOCKED → UPDATE claimed_until + far-future next_run_at → COMMIT` in one transaction.
- **Atomic completion**: `CompleteJobRun` combines run record insert + job state update in one transaction — no more separate non-atomic `SaveJobRun` + `UpdateJob` calls.
- **Crash recovery**: `ReapStaleClaims` resets jobs where `claimed_until` expired mid-execution (worker died). Reaper runs every 1 minute.
- **Removed fire-and-forget**: `runJob` is now synchronous — completion is tracked before returning.

## Changes

| File | Change |
|------|--------|
| `domain/cron.go` | Add `ClaimedUntil` field |
| `ports/cron.go` | Replace `GetNextJobsToRun`/`SaveJobRun` with `ClaimNextJobsToRun`/`CompleteJobRun`/`ReapStaleClaims` |
| `cron_repo.go` | Transactional `ClaimNextJobsToRun`, `CompleteJobRun`, `ReapStaleClaims` |
| `cron_worker.go` | Use `ClaimNextJobsToRun`, sync execution, add reaper ticker |
| `cron_worker_test.go` | Update mocks to new interface |
| `mock_util_test.go` | Update `MockCronRepo` to new interface |
| `cron_repo_test.go` | Update integration test to new method |
| `migrations/104_*` | Add `claimed_until` column |

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/core/services/... -short -run TestCronWorker`

Fixes finding #7.