### PR TITLE
feat(database): add stop/start lifecycle operations

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Run Tests
         env:
           DATABASE_URL: postgres://cloud:cloud@127.0.0.1:5433/cloud?sslmode=disable
-        run: go test -v -coverprofile=coverage.out ./cmd/... ./internal/... ./pkg/...
+          TEST_DOCKER_NETWORK: cloud-network
+        run: |
+          docker network create ${TEST_DOCKER_NETWORK} || true
+          go test -p 1 -v -coverprofile=coverage.out ./cmd/... ./internal/... ./pkg/...
 
       - name: Check Coverage Threshold
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,15 +8,38 @@ jobs:
   coverage:
     name: Enforce Coverage
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: cloud
+          POSTGRES_PASSWORD: cloud
+          POSTGRES_DB: cloud
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U cloud"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v6
-      
+
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
           go-version: '1.25.0'
 
+      - name: Wait for Database
+        run: |
+          timeout 60s bash -c 'until pg_isready -h 127.0.0.1 -p 5433 -U cloud; do
+            echo "Waiting for postgres..."
+            sleep 2
+          done'
+
       - name: Run Tests
+        env:
+          DATABASE_URL: postgres://cloud:cloud@127.0.0.1:5433/cloud?sslmode=disable
         run: go test -v -coverprofile=coverage.out ./cmd/... ./internal/... ./pkg/...
 
       - name: Check Coverage Threshold

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Database Stop/Start Lifecycle**: New `POST /databases/:id/stop` and `POST /databases/:id/start` endpoints to pause/resume managed database instances while retaining data volumes.
 - **Integrated Managed Kubernetes (KaaS)**: Launched production-ready Kubernetes cluster management.
 - **High-Availability (HA) Control Plane**: Supported 3-node HA control plane with automated API Server Load Balancers.
 - **Asynchronous Durable Operations**: Introduced a Redis-backed **Task Queue** and **Cluster Worker** for long-running operations (Provision/Delete/Upgrade).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -723,6 +723,27 @@ Regenerate the database password and update it in both the database engine and V
 }
 ```
 
+### POST /databases/:id/stop
+Stop a running database instance. The data volume is retained.
+- **Constraints**: Cannot stop replicas (must promote first) or databases in CREATING/DELETING state.
+- **Response**:
+```json
+{
+  "message": "database stopped"
+}
+```
+
+### POST /databases/:id/start
+Start a stopped database instance.
+- **Constraints**: Database must be in STOPPED state.
+- **Workflow**: Starts container, waits for readiness, starts sidecars if enabled.
+- **Response**:
+```json
+{
+  "message": "database started"
+}
+```
+
 ---
 
 ## Global Load Balancers 🆕

--- a/docs/database.md
+++ b/docs/database.md
@@ -523,6 +523,36 @@ The `DatabaseFailoverWorker` provides automated recovery for failed primary inst
 #### Manual Promotion
 Replicas can be promoted manually via the API. Promoting a replica removes its link to the previous primary and converts it into a standalone Primary instance.
 
+### Managed Database Stop/Start Lifecycle
+
+The platform supports stopping and starting managed database instances to pause usage and save costs (similar to AWS RDS Stop/Start).
+
+#### Stop Operation
+The `POST /databases/:id/stop` endpoint stops a running database:
+1. **Validation**: Database must be RUNNING and not a REPLICA (replicas must be promoted first).
+2. **Container Stop**: The database container and all sidecars (PgBouncer, exporter) are stopped via Docker.
+3. **Status Update**: Database status transitions to `STOPPED`.
+4. **Data Persistence**: The underlying volume is retained — no data is lost.
+
+#### Start Operation
+The `POST /databases/:id/start` endpoint restarts a stopped database:
+1. **Validation**: Database must be in `STOPPED` state.
+2. **Container Start**: The database container is started with the existing volume.
+3. **Readiness Wait**: The service polls for the instance IP to confirm the database is reachable.
+4. **Sidecar Start**: PgBouncer and/or metrics exporter are started if enabled.
+5. **Status Update**: Database status transitions to `RUNNING`.
+
+#### Use Cases
+- **Cost Savings**: Stop dev/test databases overnight or when not in use.
+- **Pause Workflows**: Halt batch processing without deleting the database.
+- **Graceful Maintenance**: Stop before performing maintenance on the underlying host.
+
+#### Constraints
+- Cannot stop a REPLICA (must promote to primary first).
+- Cannot stop databases in CREATING, DELETING, or STOPPED state.
+- Cannot start databases that are not STOPPED.
+- Volumes persist indefinitely; manually delete the database to clean up storage.
+
 #### `caches` - Redis Instances
 ```sql
 CREATE TABLE caches (

--- a/docs/database.md
+++ b/docs/database.md
@@ -530,15 +530,15 @@ The platform supports stopping and starting managed database instances to pause 
 #### Stop Operation
 The `POST /databases/:id/stop` endpoint stops a running database:
 1. **Validation**: Database must be RUNNING and not a REPLICA (replicas must be promoted first).
-2. **Container Stop**: The database container and all sidecars (PgBouncer, exporter) are stopped via Docker.
+2. **Compute Stop**: The database container and all sidecars (PgBouncer, exporter) are stopped via the configured compute backend. If the main container fails to stop, the operation returns an error without updating status.
 3. **Status Update**: Database status transitions to `STOPPED`.
 4. **Data Persistence**: The underlying volume is retained — no data is lost.
 
 #### Start Operation
 The `POST /databases/:id/start` endpoint restarts a stopped database:
-1. **Validation**: Database must be in `STOPPED` state.
-2. **Container Start**: The database container is started with the existing volume.
-3. **Readiness Wait**: The service polls for the instance IP to confirm the database is reachable.
+1. **Validation**: Database must be in `STOPPED` state. The container ID must be present in the database record.
+2. **Compute Start**: The database container is started with the existing volume.
+3. **Readiness Wait**: The service polls until the instance has a non-empty IP address assigned. If readiness fails, the operation returns an error without updating status.
 4. **Sidecar Start**: PgBouncer and/or metrics exporter are started if enabled.
 5. **Status Update**: Database status transitions to `RUNNING`.
 

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -476,6 +476,8 @@ func registerDataRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		dbGroup.POST("/:id/snapshots", httputil.Permission(svcs.RBAC, domain.PermissionDBCreate), handlers.Database.CreateSnapshot)
 		dbGroup.GET("/:id/snapshots", httputil.Permission(svcs.RBAC, domain.PermissionDBRead), handlers.Database.ListSnapshots)
 		dbGroup.POST("/:id/rotate-credentials", httputil.Permission(svcs.RBAC, domain.PermissionDBUpdate), handlers.Database.RotateCredentials)
+		dbGroup.POST("/:id/stop", httputil.Permission(svcs.RBAC, domain.PermissionDBUpdate), handlers.Database.Stop)
+		dbGroup.POST("/:id/start", httputil.Permission(svcs.RBAC, domain.PermissionDBUpdate), handlers.Database.Start)
 	}
 
 	cacheGroup := r.Group("/caches")

--- a/internal/core/ports/database.go
+++ b/internal/core/ports/database.go
@@ -84,4 +84,8 @@ type DatabaseService interface {
 	RestoreDatabase(ctx context.Context, req RestoreDatabaseRequest) (*domain.Database, error)
 	// RotateCredentials regenerates the database password and updates it in the secrets manager.
 	RotateCredentials(ctx context.Context, id uuid.UUID, idempotencyKey string) error
+	// StopDatabase stops a running database instance, retaining its data volume.
+	StopDatabase(ctx context.Context, id uuid.UUID) error
+	// StartDatabase starts a stopped database instance.
+	StartDatabase(ctx context.Context, id uuid.UUID) error
 }

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -538,6 +538,121 @@ func (s *DatabaseService) ListDatabaseSnapshots(ctx context.Context, databaseID 
 	return s.snapshotRepo.ListByVolumeID(ctx, vol.ID)
 }
 
+func (s *DatabaseService) StopDatabase(ctx context.Context, id uuid.UUID) error {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionDBUpdate, id.String()); err != nil {
+		return err
+	}
+
+	db, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if db.Status != domain.DatabaseStatusRunning {
+		return errors.New(errors.InvalidInput, "database is not running")
+	}
+	if db.Role == domain.RoleReplica {
+		return errors.New(errors.InvalidInput, "cannot stop a replica database")
+	}
+
+	// Stop sidecars first
+	if db.ExporterContainerID != "" {
+		if err := s.compute.StopInstance(ctx, db.ExporterContainerID); err != nil {
+			s.logger.Warn("failed to stop exporter container", "container_id", db.ExporterContainerID, "error", err)
+		}
+	}
+	if db.PoolerContainerID != "" {
+		if err := s.compute.StopInstance(ctx, db.PoolerContainerID); err != nil {
+			s.logger.Warn("failed to stop pooler container", "container_id", db.PoolerContainerID, "error", err)
+		}
+	}
+
+	// Stop database container
+	if db.ContainerID != "" {
+		if err := s.compute.StopInstance(ctx, db.ContainerID); err != nil {
+			s.logger.Warn("failed to stop database container", "container_id", db.ContainerID, "error", err)
+		}
+	}
+
+	db.Status = domain.DatabaseStatusStopped
+	if err := s.repo.Update(ctx, db); err != nil {
+		return err
+	}
+
+	_ = s.eventSvc.RecordEvent(ctx, "DATABASE_STOP", db.ID.String(), "DATABASE", nil)
+	_ = s.auditSvc.Log(ctx, db.UserID, "database.stop", "database", db.ID.String(), map[string]interface{}{"name": db.Name})
+	platform.RDSInstancesTotal.WithLabelValues(string(db.Engine), "stopped").Inc()
+	platform.RDSInstancesTotal.WithLabelValues(string(db.Engine), "running").Dec()
+
+	return nil
+}
+
+func (s *DatabaseService) StartDatabase(ctx context.Context, id uuid.UUID) error {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionDBUpdate, id.String()); err != nil {
+		return err
+	}
+
+	db, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if db.Status != domain.DatabaseStatusStopped {
+		return errors.New(errors.InvalidInput, "database is not stopped")
+	}
+
+	// Start database container
+	if db.ContainerID != "" {
+		if err := s.compute.StartInstance(ctx, db.ContainerID); err != nil {
+			return errors.Wrap(errors.Internal, "failed to start database container", err)
+		}
+	}
+
+	// Wait for database to be ready
+	if err := s.waitForDatabaseReady(ctx, db); err != nil {
+		s.logger.Warn("database may not be fully ready", "id", db.ID, "error", err)
+	}
+
+	// Start sidecars if enabled
+	if db.ExporterContainerID != "" {
+		if err := s.compute.StartInstance(ctx, db.ExporterContainerID); err != nil {
+			s.logger.Warn("failed to start exporter container", "container_id", db.ExporterContainerID, "error", err)
+		}
+	}
+	if db.PoolingEnabled && db.PoolerContainerID != "" {
+		if err := s.compute.StartInstance(ctx, db.PoolerContainerID); err != nil {
+			s.logger.Warn("failed to start pooler container", "container_id", db.PoolerContainerID, "error", err)
+		}
+	}
+
+	db.Status = domain.DatabaseStatusRunning
+	if err := s.repo.Update(ctx, db); err != nil {
+		return err
+	}
+
+	_ = s.eventSvc.RecordEvent(ctx, "DATABASE_START", db.ID.String(), "DATABASE", nil)
+	_ = s.auditSvc.Log(ctx, db.UserID, "database.start", "database", db.ID.String(), map[string]interface{}{"name": db.Name})
+	platform.RDSInstancesTotal.WithLabelValues(string(db.Engine), "running").Inc()
+	platform.RDSInstancesTotal.WithLabelValues(string(db.Engine), "stopped").Dec()
+
+	return nil
+}
+
+func (s *DatabaseService) waitForDatabaseReady(ctx context.Context, db *domain.Database) error {
+	for i := 0; i < 30; i++ {
+		dbIP, _ := s.compute.GetInstanceIP(ctx, db.ContainerID)
+		if dbIP != "" {
+			return nil // Got IP, assume ready
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return errors.New(errors.Internal, "database did not become ready in time")
+}
+
 func (s *DatabaseService) RotateCredentials(ctx context.Context, id uuid.UUID, idempotencyKey string) error {
 	if idempotencyKey != "" {
 		s.rotationMu.Lock()

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -569,10 +569,10 @@ func (s *DatabaseService) StopDatabase(ctx context.Context, id uuid.UUID) error 
 		}
 	}
 
-	// Stop database container
+	// Stop database container; must succeed before marking as stopped.
 	if db.ContainerID != "" {
 		if err := s.compute.StopInstance(ctx, db.ContainerID); err != nil {
-			s.logger.Warn("failed to stop database container", "container_id", db.ContainerID, "error", err)
+			return errors.Wrap(errors.Internal, "failed to stop database container", err)
 		}
 	}
 
@@ -604,17 +604,18 @@ func (s *DatabaseService) StartDatabase(ctx context.Context, id uuid.UUID) error
 	if db.Status != domain.DatabaseStatusStopped {
 		return errors.New(errors.InvalidInput, "database is not stopped")
 	}
-
-	// Start database container
-	if db.ContainerID != "" {
-		if err := s.compute.StartInstance(ctx, db.ContainerID); err != nil {
-			return errors.Wrap(errors.Internal, "failed to start database container", err)
-		}
+	if db.ContainerID == "" {
+		return errors.New(errors.Internal, "database container ID is missing")
 	}
 
-	// Wait for database to be ready
+	// Start database container
+	if err := s.compute.StartInstance(ctx, db.ContainerID); err != nil {
+		return errors.Wrap(errors.Internal, "failed to start database container", err)
+	}
+
+	// Wait for database to be ready; return error if it fails.
 	if err := s.waitForDatabaseReady(ctx, db); err != nil {
-		s.logger.Warn("database may not be fully ready", "id", db.ID, "error", err)
+		return errors.Wrap(errors.Internal, "database failed to become ready", err)
 	}
 
 	// Start sidecars if enabled
@@ -643,12 +644,26 @@ func (s *DatabaseService) StartDatabase(ctx context.Context, id uuid.UUID) error
 }
 
 func (s *DatabaseService) waitForDatabaseReady(ctx context.Context, db *domain.Database) error {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
 	for i := 0; i < 30; i++ {
-		dbIP, _ := s.compute.GetInstanceIP(ctx, db.ContainerID)
-		if dbIP != "" {
-			return nil // Got IP, assume ready
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
 		}
-		time.Sleep(1 * time.Second)
+
+		dbIP, err := s.compute.GetInstanceIP(ctx, db.ContainerID)
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			continue
+		}
+		if dbIP != "" {
+			return nil
+		}
 	}
 	return errors.New(errors.Internal, "database did not become ready in time")
 }

--- a/internal/core/services/database_unit_test.go
+++ b/internal/core/services/database_unit_test.go
@@ -81,6 +81,7 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 		Logger:       slog.Default(),
 	})
 
+	userID := uuid.New()
 	ctx := context.Background()
 
 	t.Run("CreateDatabase_Success", func(t *testing.T) {
@@ -464,7 +465,6 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 
 	t.Run("ModifyDatabase_VolumeResize", func(t *testing.T) {
 		dbID := uuid.New()
-		userID := uuid.New()
 		db := &domain.Database{
 			ID:               dbID,
 			UserID:           userID,
@@ -497,6 +497,157 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, newSize, result.AllocatedStorage)
+	})
+
+	t.Run("StopDatabase_Success", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{
+			ID:       dbID,
+			UserID:   userID,
+			Status:   domain.DatabaseStatusRunning,
+			Role:     domain.RolePrimary,
+			Engine:   domain.EnginePostgres,
+			Name:     "test-stop-db",
+			ContainerID: "db-cid",
+			ExporterContainerID: "exp-cid",
+			PoolingEnabled: true,
+			PoolerContainerID: "pooler-cid",
+		}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+		mockCompute.On("StopInstance", mock.Anything, "exp-cid").Return(nil).Once()
+		mockCompute.On("StopInstance", mock.Anything, "pooler-cid").Return(nil).Once()
+		mockCompute.On("StopInstance", mock.Anything, "db-cid").Return(nil).Once()
+		mockRepo.On("Update", mock.Anything, mock.MatchedBy(func(d *domain.Database) bool {
+			return d.Status == domain.DatabaseStatusStopped
+		})).Return(nil).Once()
+		mockEventSvc.On("RecordEvent", mock.Anything, "DATABASE_STOP", dbID.String(), "DATABASE", mock.Anything).Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "database.stop", "database", dbID.String(), mock.Anything).Return(nil).Once()
+
+		err := svc.StopDatabase(ctx, dbID)
+		require.NoError(t, err)
+	})
+
+	t.Run("StopDatabase_NotRunning", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{ID: dbID, Status: domain.DatabaseStatusStopped, Role: domain.RolePrimary}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+
+		err := svc.StopDatabase(ctx, dbID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not running")
+	})
+
+	t.Run("StopDatabase_Replica", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{ID: dbID, Status: domain.DatabaseStatusRunning, Role: domain.RoleReplica}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+
+		err := svc.StopDatabase(ctx, dbID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "replica")
+	})
+
+	t.Run("StopDatabase_ComputeError", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{
+			ID:       dbID,
+			UserID:   userID,
+			Status:   domain.DatabaseStatusRunning,
+			Role:     domain.RolePrimary,
+			ContainerID: "db-cid",
+		}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+		mockCompute.On("StopInstance", mock.Anything, "db-cid").Return(fmt.Errorf("stop failed")).Once()
+
+		err := svc.StopDatabase(ctx, dbID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "stop failed")
+	})
+
+	t.Run("StartDatabase_Success", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{
+			ID:       dbID,
+			UserID:   userID,
+			Status:   domain.DatabaseStatusStopped,
+			Role:     domain.RolePrimary,
+			Engine:   domain.EnginePostgres,
+			Name:     "test-start-db",
+			ContainerID: "db-cid",
+			PoolingEnabled: true,
+			PoolerContainerID: "pooler-cid",
+		}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+		mockCompute.On("StartInstance", mock.Anything, "db-cid").Return(nil).Once()
+		mockCompute.On("GetInstanceIP", mock.Anything, "db-cid").Return("10.0.0.5", nil).Once()
+		mockCompute.On("StartInstance", mock.Anything, "pooler-cid").Return(nil).Once()
+		mockRepo.On("Update", mock.Anything, mock.MatchedBy(func(d *domain.Database) bool {
+			return d.Status == domain.DatabaseStatusRunning
+		})).Return(nil).Once()
+		mockEventSvc.On("RecordEvent", mock.Anything, "DATABASE_START", dbID.String(), "DATABASE", mock.Anything).Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "database.start", "database", dbID.String(), mock.Anything).Return(nil).Once()
+
+		err := svc.StartDatabase(ctx, dbID)
+		require.NoError(t, err)
+	})
+
+	t.Run("StartDatabase_NotStopped", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{ID: dbID, Status: domain.DatabaseStatusRunning, Role: domain.RolePrimary}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+
+		err := svc.StartDatabase(ctx, dbID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not stopped")
+	})
+
+	t.Run("StartDatabase_MissingContainerID", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{ID: dbID, Status: domain.DatabaseStatusStopped, Role: domain.RolePrimary, ContainerID: ""}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+
+		err := svc.StartDatabase(ctx, dbID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "container ID is missing")
+	})
+
+	t.Run("StartDatabase_ComputeError", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{
+			ID:       dbID,
+			UserID:   userID,
+			Status:   domain.DatabaseStatusStopped,
+			Role:     domain.RolePrimary,
+			ContainerID: "db-cid",
+		}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+		mockCompute.On("StartInstance", mock.Anything, "db-cid").Return(fmt.Errorf("start failed")).Once()
+
+		err := svc.StartDatabase(ctx, dbID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "start failed")
+	})
+
+	t.Run("StartDatabase_ReadinessTimeout", func(t *testing.T) {
+		dbID := uuid.New()
+		db := &domain.Database{
+			ID:       dbID,
+			UserID:   userID,
+			Status:   domain.DatabaseStatusStopped,
+			Role:     domain.RolePrimary,
+			ContainerID: "cid-timeout",
+		}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+		mockCompute.On("StartInstance", mock.Anything, "cid-timeout").Return(nil).Once()
+		mockCompute.On("GetInstanceIP", mock.Anything, "cid-timeout").Return("", nil).Once()
+		mockCompute.On("GetInstanceIP", mock.Anything, "cid-timeout").Return("", nil).Maybe()
+		mockRepo.On("Update", mock.Anything, mock.Anything).Return(nil).Maybe()
+		mockEventSvc.On("RecordEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		mockAuditSvc.On("Log", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+		err := svc.StartDatabase(ctx, dbID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "did not become ready")
 	})
 }
 

--- a/internal/handlers/database_handler.go
+++ b/internal/handlers/database_handler.go
@@ -143,6 +143,36 @@ func (h *DatabaseHandler) Delete(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, gin.H{"message": "database deleted"})
 }
 
+func (h *DatabaseHandler) Stop(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, invalidDatabaseIDMsg))
+		return
+	}
+
+	if err := h.svc.StopDatabase(c.Request.Context(), id); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"message": "database stopped"})
+}
+
+func (h *DatabaseHandler) Start(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, invalidDatabaseIDMsg))
+		return
+	}
+
+	if err := h.svc.StartDatabase(c.Request.Context(), id); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"message": "database started"})
+}
+
 // ModifyDatabaseRequest is the payload for updating a database.
 type ModifyDatabaseRequest struct {
 	Parameters       map[string]string `json:"parameters"`

--- a/internal/handlers/database_handler_test.go
+++ b/internal/handlers/database_handler_test.go
@@ -121,6 +121,16 @@ func (m *mockDatabaseService) RotateCredentials(ctx context.Context, id uuid.UUI
 	return args.Error(0)
 }
 
+func (m *mockDatabaseService) StopDatabase(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *mockDatabaseService) StartDatabase(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
 func setupDatabaseHandlerTest(_ *testing.T) (*mockDatabaseService, *DatabaseHandler, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockDatabaseService)
@@ -609,4 +619,72 @@ func TestDatabaseHandlerRotateCredentials(t *testing.T) {
 			svc.AssertExpectations(t)
 		})
 	}
+}
+
+func TestDatabaseHandlerStop(t *testing.T) {
+	t.Parallel()
+	svc, handler, r := setupDatabaseHandlerTest(t)
+	defer svc.AssertExpectations(t)
+
+	r.POST("/databases/:id/stop", handler.Stop)
+
+	id := uuid.New()
+
+	t.Run("Success", func(t *testing.T) {
+		svc.On("StopDatabase", mock.Anything, id).Return(nil).Once()
+		req, _ := http.NewRequest(http.MethodPost, "/databases/"+id.String()+"/stop", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, strings.ToLower(w.Body.String()), "database stopped")
+	})
+
+	t.Run("InvalidID", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "/databases/invalid-uuid/stop", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("ServiceError", func(t *testing.T) {
+		svc.On("StopDatabase", mock.Anything, id).Return(errors.New(errors.Internal, "cannot stop")).Once()
+		req, _ := http.NewRequest(http.MethodPost, "/databases/"+id.String()+"/stop", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+}
+
+func TestDatabaseHandlerStart(t *testing.T) {
+	t.Parallel()
+	svc, handler, r := setupDatabaseHandlerTest(t)
+	defer svc.AssertExpectations(t)
+
+	r.POST("/databases/:id/start", handler.Start)
+
+	id := uuid.New()
+
+	t.Run("Success", func(t *testing.T) {
+		svc.On("StartDatabase", mock.Anything, id).Return(nil).Once()
+		req, _ := http.NewRequest(http.MethodPost, "/databases/"+id.String()+"/start", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, strings.ToLower(w.Body.String()), "database started")
+	})
+
+	t.Run("InvalidID", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, "/databases/invalid-uuid/start", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("ServiceError", func(t *testing.T) {
+		svc.On("StartDatabase", mock.Anything, id).Return(errors.New(errors.Internal, "cannot start")).Once()
+		req, _ := http.NewRequest(http.MethodPost, "/databases/"+id.String()+"/start", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
 }

--- a/internal/workers/database_failover_worker_test.go
+++ b/internal/workers/database_failover_worker_test.go
@@ -121,6 +121,14 @@ func (m *mockDatabaseService) RotateCredentials(ctx context.Context, id uuid.UUI
 	args := m.Called(ctx, id, idempotencyKey)
 	return args.Error(0)
 }
+func (m *mockDatabaseService) StopDatabase(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+func (m *mockDatabaseService) StartDatabase(ctx context.Context, id uuid.UUID) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
 
 func TestDatabaseFailoverWorker(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary
- Add `POST /databases/:id/stop` and `POST /databases/:id/start` endpoints for managed database lifecycle
- Implement service methods with container start/stop, sidecar management, and status transitions
- Add handler unit tests for stop/start operations
- Document new endpoints in api-reference.md and database.md

## Test plan
- [x] Unit tests for handler (Stop/InvalidID/ServiceError, Start/InvalidID/ServiceError)
- [x] All existing database handler tests pass

## Checklist
- [x] Handler tests added
- [x] API reference updated
- [x] Database guide updated
- [x] Changelog updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stop and start endpoints for managed database instances, enabling pause and resume operations while preserving data volumes and storage.
  * Stopped databases can be restarted; certain database configurations cannot be stopped (replicas, databases in transition states).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->