### PR TITLE
test(services): add _Unit wrapper pattern for 6 services

### DIFF
--- a/internal/core/services/cached_identity_unit_test.go
+++ b/internal/core/services/cached_identity_unit_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCachedIdentityService_Unit(t *testing.T) {
+	t.Run("ValidateAPIKey", TestCachedIdentityService_ValidateAPIKey)
+	t.Run("OtherOps", TestCachedIdentityService_OtherOps)
+}
+
 func TestCachedIdentityService_ValidateAPIKey(t *testing.T) {
 	mr, err := miniredis.Run()
 	require.NoError(t, err)

--- a/internal/core/services/dashboard_unit_test.go
+++ b/internal/core/services/dashboard_unit_test.go
@@ -7,12 +7,19 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/mock"
 )
+
+func TestDashboardService_Unit(t *testing.T) {
+	t.Run("GetStats", TestDashboardService_GetStats)
+	t.Run("GetSummary", TestDashboardService_GetSummary)
+	t.Run("GetRecentEvents", TestDashboardService_GetRecentEvents)
+}
 
 func TestDashboardService_GetStats(t *testing.T) {
 	instRepo := new(MockInstanceRepo)
@@ -61,6 +68,125 @@ func TestDashboardService_GetStats(t *testing.T) {
 		instRepo.On("List", ctx).Return(nil, fmt.Errorf("db fail")).Once()
 
 		_, err := svc.GetStats(ctx)
+		require.Error(t, err)
+	})
+}
+
+func TestDashboardService_GetSummary(t *testing.T) {
+	instRepo := new(MockInstanceRepo)
+	volRepo := new(MockVolumeRepo)
+	vpcRepo := new(MockVpcRepo)
+	eventRepo := new(MockEventRepo)
+	rbacSvc := new(MockRBACService)
+
+	svc := services.NewDashboardService(rbacSvc, instRepo, volRepo, vpcRepo, eventRepo, slog.Default())
+
+	t.Run("Success", func(t *testing.T) {
+		userID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+		ctx = appcontext.WithTenantID(ctx, tenantID)
+		rbacSvc.On("Authorize", mock.Anything, userID, tenantID, domain.PermissionDashboardRead, "*").Return(nil)
+
+		instances := []*domain.Instance{
+			{ID: uuid.New(), Status: domain.StatusRunning},
+			{ID: uuid.New(), Status: domain.StatusStopped},
+		}
+		volumes := []*domain.Volume{
+			{ID: uuid.New(), SizeGB: 10, InstanceID: &instances[0].ID},
+			{ID: uuid.New(), SizeGB: 20},
+		}
+		vpcs := []*domain.VPC{{ID: uuid.New()}, {ID: uuid.New()}}
+
+		instRepo.On("List", ctx).Return(instances, nil).Once()
+		volRepo.On("List", ctx).Return(volumes, nil).Once()
+		vpcRepo.On("List", ctx).Return(vpcs, nil).Once()
+
+		summary, err := svc.GetSummary(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, 2, summary.TotalInstances)
+		assert.Equal(t, 1, summary.RunningInstances)
+		assert.Equal(t, 1, summary.StoppedInstances)
+		assert.Equal(t, 2, summary.TotalVolumes)
+		assert.Equal(t, 1, summary.AttachedVolumes)
+		assert.Equal(t, 30*1024, summary.TotalStorageMB)
+		assert.Equal(t, 2, summary.TotalVPCs)
+	})
+
+	t.Run("InstanceRepoError", func(t *testing.T) {
+		userID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+		ctx = appcontext.WithTenantID(ctx, tenantID)
+		rbacSvc.On("Authorize", mock.Anything, userID, tenantID, domain.PermissionDashboardRead, "*").Return(nil)
+
+		instRepo.On("List", ctx).Return(nil, fmt.Errorf("db fail")).Once()
+
+		_, err := svc.GetSummary(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db fail")
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		userID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+		ctx = appcontext.WithTenantID(ctx, tenantID)
+		rbacSvc.On("Authorize", mock.Anything, userID, tenantID, domain.PermissionDashboardRead, "*").Return(fmt.Errorf("forbidden")).Once()
+
+		_, err := svc.GetSummary(ctx)
+		require.Error(t, err)
+	})
+}
+
+func TestDashboardService_GetRecentEvents(t *testing.T) {
+	instRepo := new(MockInstanceRepo)
+	volRepo := new(MockVolumeRepo)
+	vpcRepo := new(MockVpcRepo)
+	eventRepo := new(MockEventRepo)
+	rbacSvc := new(MockRBACService)
+
+	svc := services.NewDashboardService(rbacSvc, instRepo, volRepo, vpcRepo, eventRepo, slog.Default())
+
+	t.Run("Success", func(t *testing.T) {
+		userID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+		ctx = appcontext.WithTenantID(ctx, tenantID)
+		rbacSvc.On("Authorize", mock.Anything, userID, tenantID, domain.PermissionDashboardRead, "*").Return(nil)
+
+		events := []*domain.Event{
+			{ID: uuid.New(), Action: "action1"},
+			{ID: uuid.New(), Action: "action2"},
+		}
+		eventRepo.On("List", ctx, 5).Return(events, nil).Once()
+
+		result, err := svc.GetRecentEvents(ctx, 5)
+		require.NoError(t, err)
+		assert.Len(t, result, 2)
+	})
+
+	t.Run("RepoError", func(t *testing.T) {
+		userID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+		ctx = appcontext.WithTenantID(ctx, tenantID)
+		rbacSvc.On("Authorize", mock.Anything, userID, tenantID, domain.PermissionDashboardRead, "*").Return(nil)
+
+		eventRepo.On("List", ctx, 10).Return(nil, fmt.Errorf("db fail")).Once()
+
+		_, err := svc.GetRecentEvents(ctx, 10)
+		require.Error(t, err)
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		userID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+		ctx = appcontext.WithTenantID(ctx, tenantID)
+		rbacSvc.On("Authorize", mock.Anything, userID, tenantID, domain.PermissionDashboardRead, "*").Return(fmt.Errorf("forbidden")).Once()
+
+		_, err := svc.GetRecentEvents(ctx, 10)
 		require.Error(t, err)
 	})
 }

--- a/internal/core/services/elastic_ip_unit_test.go
+++ b/internal/core/services/elastic_ip_unit_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestElasticIPService_Unit(t *testing.T) {
+	t.Run("AllocateIP", TestElasticIPService_AllocateIP)
+	t.Run("ReleaseIP", TestElasticIPService_ReleaseIP)
+	t.Run("AssociateIP", TestElasticIPService_AssociateIP)
+	t.Run("DisassociateIP", TestElasticIPService_DisassociateIP)
+	t.Run("ListAndGet", TestElasticIPService_ListAndGet)
+}
+
 func TestElasticIPService_AllocateIP(t *testing.T) {
 	repo := new(MockElasticIPRepo)
 	auditSvc := new(MockAuditService)

--- a/internal/core/services/function_unit_test.go
+++ b/internal/core/services/function_unit_test.go
@@ -18,6 +18,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestFunctionService_Unit(t *testing.T) {
+	t.Run("BasicOps", TestFunctionServiceBasicOps)
+	t.Run("CreateFunction", TestFunctionServiceCreateFunction)
+	t.Run("InvokeFunction", TestFunctionServiceInvokeFunction)
+	t.Run("CreateFunction_UnsupportedRuntime", TestFunctionService_CreateFunction_UnsupportedRuntime)
+}
+
 func TestFunctionServiceBasicOps(t *testing.T) {
 	repo := new(MockFunctionRepo)
 	compute := new(MockComputeBackend)

--- a/internal/core/services/iam_evaluator_unit_test.go
+++ b/internal/core/services/iam_evaluator_unit_test.go
@@ -1,0 +1,172 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIAMEvaluator_Unit(t *testing.T) {
+	t.Run("Evaluate_Allow", TestIAMEvaluator_Evaluate_Allow)
+	t.Run("Evaluate_Deny", TestIAMEvaluator_Evaluate_Deny)
+	t.Run("Evaluate_NoMatch", TestIAMEvaluator_Evaluate_NoMatch)
+	t.Run("Evaluate_ExplicitDenyWins", TestIAMEvaluator_Evaluate_ExplicitDenyWins)
+	t.Run("Evaluate_WildcardAction", TestIAMEvaluator_Evaluate_WildcardAction)
+	t.Run("Evaluate_WildcardResource", TestIAMEvaluator_Evaluate_WildcardResource)
+}
+
+func TestIAMEvaluator_Evaluate_Allow(t *testing.T) {
+	evaluator := services.NewIAMEvaluator()
+	ctx := context.Background()
+
+	policies := []*domain.Policy{
+		{
+			Statements: []domain.Statement{
+				{
+					Effect:   domain.EffectAllow,
+					Action:   []string{"instance:launch", "instance:stop"},
+					Resource: []string{"*"},
+				},
+			},
+		},
+	}
+
+	effect, err := evaluator.Evaluate(ctx, policies, "instance:launch", "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0", nil)
+	require.NoError(t, err)
+	assert.Equal(t, domain.EffectAllow, effect)
+}
+
+func TestIAMEvaluator_Evaluate_Deny(t *testing.T) {
+	evaluator := services.NewIAMEvaluator()
+	ctx := context.Background()
+
+	policies := []*domain.Policy{
+		{
+			Statements: []domain.Statement{
+				{
+					Effect:   domain.EffectDeny,
+					Action:   []string{"instance:launch"},
+					Resource: []string{"*"},
+				},
+			},
+		},
+	}
+
+	effect, err := evaluator.Evaluate(ctx, policies, "instance:launch", "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0", nil)
+	require.NoError(t, err)
+	assert.Equal(t, domain.EffectDeny, effect)
+}
+
+func TestIAMEvaluator_Evaluate_NoMatch(t *testing.T) {
+	evaluator := services.NewIAMEvaluator()
+	ctx := context.Background()
+
+	policies := []*domain.Policy{
+		{
+			Statements: []domain.Statement{
+				{
+					Effect:   domain.EffectAllow,
+					Action:   []string{"volume:create"},
+					Resource: []string{"*"},
+				},
+			},
+		},
+	}
+
+	effect, err := evaluator.Evaluate(ctx, policies, "instance:launch", "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0", nil)
+	require.NoError(t, err)
+	assert.Equal(t, domain.PolicyEffect(""), effect)
+}
+
+func TestIAMEvaluator_Evaluate_ExplicitDenyWins(t *testing.T) {
+	evaluator := services.NewIAMEvaluator()
+	ctx := context.Background()
+
+	policies := []*domain.Policy{
+		{
+			Statements: []domain.Statement{
+				{
+					Effect:   domain.EffectAllow,
+					Action:   []string{"instance:launch"},
+					Resource: []string{"*"},
+				},
+				{
+					Effect:   domain.EffectDeny,
+					Action:   []string{"instance:launch"},
+					Resource: []string{"*"},
+				},
+			},
+		},
+	}
+
+	effect, err := evaluator.Evaluate(ctx, policies, "instance:launch", "arn:aws:ec2:us-east-1:123456789012:instance/i-1234567890abcdef0", nil)
+	require.NoError(t, err)
+	assert.Equal(t, domain.EffectDeny, effect)
+}
+
+func TestIAMEvaluator_Evaluate_WildcardAction(t *testing.T) {
+	evaluator := services.NewIAMEvaluator()
+	ctx := context.Background()
+
+	policies := []*domain.Policy{
+		{
+			Statements: []domain.Statement{
+				{
+					Effect:   domain.EffectAllow,
+					Action:   []string{"instance:*"},
+					Resource: []string{"*"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		action   string
+		resource string
+		expected domain.PolicyEffect
+	}{
+		{"instance:launch", "*", domain.EffectAllow},
+		{"instance:stop", "*", domain.EffectAllow},
+		{"instance:terminate", "*", domain.EffectAllow},
+	}
+
+	for _, tt := range tests {
+		effect, err := evaluator.Evaluate(ctx, policies, tt.action, tt.resource, nil)
+		require.NoError(t, err)
+		assert.Equal(t, tt.expected, effect, "action %s should match", tt.action)
+	}
+}
+
+func TestIAMEvaluator_Evaluate_WildcardResource(t *testing.T) {
+	evaluator := services.NewIAMEvaluator()
+	ctx := context.Background()
+
+	policies := []*domain.Policy{
+		{
+			Statements: []domain.Statement{
+				{
+					Effect:   domain.EffectAllow,
+					Action:   []string{"instance:launch"},
+					Resource: []string{"*"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		resource string
+		expected domain.PolicyEffect
+	}{
+		{"*", domain.EffectAllow},
+	}
+
+	for _, tt := range tests {
+		effect, err := evaluator.Evaluate(ctx, policies, "instance:launch", tt.resource, nil)
+		require.NoError(t, err)
+		assert.Equal(t, tt.expected, effect, "resource %s should match", tt.resource)
+	}
+}

--- a/internal/core/services/pipeline_unit_test.go
+++ b/internal/core/services/pipeline_unit_test.go
@@ -605,6 +605,23 @@ func TestPipelineService_ListBuildLogs(t *testing.T) {
 	})
 }
 
+func TestPipelineService_Unit(t *testing.T) {
+	t.Run("TriggerBuildWebhook_InvalidSignature", TestPipelineServiceTriggerBuildWebhookInvalidGitHubSignature)
+	t.Run("TriggerBuildWebhook_DuplicateDelivery", TestPipelineServiceTriggerBuildWebhookDuplicateDeliveryIgnored)
+	t.Run("TriggerBuildWebhook_BranchMismatch", TestPipelineServiceTriggerBuildWebhookBranchMismatchIgnored)
+	t.Run("TriggerBuildWebhook_Success", TestPipelineServiceTriggerBuildWebhookSuccessQueuesBuild)
+	t.Run("CreatePipeline", TestPipelineService_CreatePipeline)
+	t.Run("GetPipeline", TestPipelineService_GetPipeline)
+	t.Run("ListPipelines", TestPipelineService_ListPipelines)
+	t.Run("UpdatePipeline", TestPipelineService_UpdatePipeline)
+	t.Run("DeletePipeline", TestPipelineService_DeletePipeline)
+	t.Run("TriggerBuild", TestPipelineService_TriggerBuild)
+	t.Run("GetBuild", TestPipelineService_GetBuild)
+	t.Run("ListBuildsByPipeline", TestPipelineService_ListBuildsByPipeline)
+	t.Run("ListBuildSteps", TestPipelineService_ListBuildSteps)
+	t.Run("ListBuildLogs", TestPipelineService_ListBuildLogs)
+}
+
 func stringPtr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
## Summary
- Add `TestXxx_Unit` wrapper functions so tests are captured by `go test -run "Unit"`
- Create new `iam_evaluator_unit_test.go` (was no test file)
- Add missing dashboard tests for `GetSummary` and `GetRecentEvents`

## Test plan
- [x] `go test -run "Unit" ./internal/core/services/ -coverprofile=/tmp/p1.out` passes
- [x] All 6 services (function, pipeline, elastic_ip, cached_identity, dashboard, iam_evaluator) show >0% coverage
- [x] `go test ./internal/core/services/` (full suite) passes

## Files changed

| File | Change |
|------|--------|
| `function_unit_test.go` | +7 lines — `TestFunctionService_Unit` wrapper |
| `pipeline_unit_test.go` | +17 lines — `TestPipelineService_Unit` wrapper (14 tests) |
| `elastic_ip_unit_test.go` | +8 lines — `TestElasticIPService_Unit` wrapper |
| `cached_identity_unit_test.go` | +5 lines — `TestCachedIdentityService_Unit` wrapper |
| `dashboard_unit_test.go` | +126 lines — `GetSummary`, `GetRecentEvents` tests + wrapper |
| `iam_evaluator_unit_test.go` | new file — 6 test cases for `Evaluate`, `matches`, `matchPattern` |