### PR TITLE
test(services): fix duplicate test execution in Phase 1 files

### DIFF
--- a/internal/core/services/cached_identity_unit_test.go
+++ b/internal/core/services/cached_identity_unit_test.go
@@ -17,11 +17,11 @@ import (
 )
 
 func TestCachedIdentityService_Unit(t *testing.T) {
-	t.Run("ValidateAPIKey", TestCachedIdentityService_ValidateAPIKey)
-	t.Run("OtherOps", TestCachedIdentityService_OtherOps)
+	t.Run("ValidateAPIKey", testCachedIdentityServiceValidateAPIKey)
+	t.Run("OtherOps", testCachedIdentityServiceOtherOps)
 }
 
-func TestCachedIdentityService_ValidateAPIKey(t *testing.T) {
+func testCachedIdentityServiceValidateAPIKey(t *testing.T) {
 	mr, err := miniredis.Run()
 	require.NoError(t, err)
 	defer mr.Close()
@@ -60,7 +60,7 @@ func TestCachedIdentityService_ValidateAPIKey(t *testing.T) {
 	base.AssertExpectations(t)
 }
 
-func TestCachedIdentityService_OtherOps(t *testing.T) {
+func testCachedIdentityServiceOtherOps(t *testing.T) {
 	base := new(MockIdentityService)
 	svc := services.NewCachedIdentityService(base, nil, slog.Default())
 	ctx := context.Background()

--- a/internal/core/services/dashboard_unit_test.go
+++ b/internal/core/services/dashboard_unit_test.go
@@ -16,12 +16,12 @@ import (
 )
 
 func TestDashboardService_Unit(t *testing.T) {
-	t.Run("GetStats", TestDashboardService_GetStats)
-	t.Run("GetSummary", TestDashboardService_GetSummary)
-	t.Run("GetRecentEvents", TestDashboardService_GetRecentEvents)
+	t.Run("GetStats", testDashboardServiceGetStats)
+	t.Run("GetSummary", testDashboardServiceGetSummary)
+	t.Run("GetRecentEvents", testDashboardServiceGetRecentEvents)
 }
 
-func TestDashboardService_GetStats(t *testing.T) {
+func testDashboardServiceGetStats(t *testing.T) {
 	instRepo := new(MockInstanceRepo)
 	volRepo := new(MockVolumeRepo)
 	vpcRepo := new(MockVpcRepo)
@@ -72,7 +72,7 @@ func TestDashboardService_GetStats(t *testing.T) {
 	})
 }
 
-func TestDashboardService_GetSummary(t *testing.T) {
+func testDashboardServiceGetSummary(t *testing.T) {
 	instRepo := new(MockInstanceRepo)
 	volRepo := new(MockVolumeRepo)
 	vpcRepo := new(MockVpcRepo)
@@ -139,7 +139,7 @@ func TestDashboardService_GetSummary(t *testing.T) {
 	})
 }
 
-func TestDashboardService_GetRecentEvents(t *testing.T) {
+func testDashboardServiceGetRecentEvents(t *testing.T) {
 	instRepo := new(MockInstanceRepo)
 	volRepo := new(MockVolumeRepo)
 	vpcRepo := new(MockVpcRepo)

--- a/internal/core/services/elastic_ip_unit_test.go
+++ b/internal/core/services/elastic_ip_unit_test.go
@@ -15,14 +15,14 @@ import (
 )
 
 func TestElasticIPService_Unit(t *testing.T) {
-	t.Run("AllocateIP", TestElasticIPService_AllocateIP)
-	t.Run("ReleaseIP", TestElasticIPService_ReleaseIP)
-	t.Run("AssociateIP", TestElasticIPService_AssociateIP)
-	t.Run("DisassociateIP", TestElasticIPService_DisassociateIP)
-	t.Run("ListAndGet", TestElasticIPService_ListAndGet)
+	t.Run("AllocateIP", testElasticIPServiceAllocateIP)
+	t.Run("ReleaseIP", testElasticIPServiceReleaseIP)
+	t.Run("AssociateIP", testElasticIPServiceAssociateIP)
+	t.Run("DisassociateIP", testElasticIPServiceDisassociateIP)
+	t.Run("ListAndGet", testElasticIPServiceListAndGet)
 }
 
-func TestElasticIPService_AllocateIP(t *testing.T) {
+func testElasticIPServiceAllocateIP(t *testing.T) {
 	repo := new(MockElasticIPRepo)
 	auditSvc := new(MockAuditService)
 	rbacSvc := new(MockRBACService)
@@ -45,7 +45,7 @@ func TestElasticIPService_AllocateIP(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestElasticIPService_ReleaseIP(t *testing.T) {
+func testElasticIPServiceReleaseIP(t *testing.T) {
 	repo := new(MockElasticIPRepo)
 	auditSvc := new(MockAuditService)
 	rbacSvc := new(MockRBACService)
@@ -68,7 +68,7 @@ func TestElasticIPService_ReleaseIP(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestElasticIPService_AssociateIP(t *testing.T) {
+func testElasticIPServiceAssociateIP(t *testing.T) {
 	repo := new(MockElasticIPRepo)
 	auditSvc := new(MockAuditService)
 	rbacSvc := new(MockRBACService)
@@ -119,7 +119,7 @@ func TestElasticIPService_AssociateIP(t *testing.T) {
 	})
 }
 
-func TestElasticIPService_DisassociateIP(t *testing.T) {
+func testElasticIPServiceDisassociateIP(t *testing.T) {
 	repo := new(MockElasticIPRepo)
 	auditSvc := new(MockAuditService)
 	rbacSvc := new(MockRBACService)
@@ -155,7 +155,7 @@ func TestElasticIPService_DisassociateIP(t *testing.T) {
 	})
 }
 
-func TestElasticIPService_ListAndGet(t *testing.T) {
+func testElasticIPServiceListAndGet(t *testing.T) {
 	repo := new(MockElasticIPRepo)
 	rbacSvc := new(MockRBACService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/services/function_unit_test.go
+++ b/internal/core/services/function_unit_test.go
@@ -19,13 +19,13 @@ import (
 )
 
 func TestFunctionService_Unit(t *testing.T) {
-	t.Run("BasicOps", TestFunctionServiceBasicOps)
-	t.Run("CreateFunction", TestFunctionServiceCreateFunction)
-	t.Run("InvokeFunction", TestFunctionServiceInvokeFunction)
-	t.Run("CreateFunction_UnsupportedRuntime", TestFunctionService_CreateFunction_UnsupportedRuntime)
+	t.Run("BasicOps", testFunctionServiceBasicOps)
+	t.Run("CreateFunction", testFunctionServiceCreateFunction)
+	t.Run("InvokeFunction", testFunctionServiceInvokeFunction)
+	t.Run("CreateFunction_UnsupportedRuntime", testFunctionServiceCreateFunctionUnsupportedRuntime)
 }
 
-func TestFunctionServiceBasicOps(t *testing.T) {
+func testFunctionServiceBasicOps(t *testing.T) {
 	repo := new(MockFunctionRepo)
 	compute := new(MockComputeBackend)
 	fileStore := new(MockFileStore)
@@ -80,7 +80,7 @@ func TestFunctionServiceBasicOps(t *testing.T) {
 	})
 }
 
-func TestFunctionServiceCreateFunction(t *testing.T) {
+func testFunctionServiceCreateFunction(t *testing.T) {
 	repo := new(MockFunctionRepo)
 	compute := new(MockComputeBackend)
 	fileStore := new(MockFileStore)
@@ -111,7 +111,7 @@ func TestFunctionServiceCreateFunction(t *testing.T) {
 	})
 }
 
-func TestFunctionServiceInvokeFunction(t *testing.T) {
+func testFunctionServiceInvokeFunction(t *testing.T) {
 	repo := new(MockFunctionRepo)
 	compute := new(MockComputeBackend)
 	fileStore := new(MockFileStore)
@@ -177,7 +177,7 @@ func TestFunctionServiceInvokeFunction(t *testing.T) {
 	})
 }
 
-func TestFunctionService_CreateFunction_UnsupportedRuntime(t *testing.T) {
+func testFunctionServiceCreateFunctionUnsupportedRuntime(t *testing.T) {
 	repo := new(MockFunctionRepo)
 	rbacSvc := new(MockRBACService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/internal/core/services/iam_evaluator_unit_test.go
+++ b/internal/core/services/iam_evaluator_unit_test.go
@@ -11,15 +11,15 @@ import (
 )
 
 func TestIAMEvaluator_Unit(t *testing.T) {
-	t.Run("Evaluate_Allow", TestIAMEvaluator_Evaluate_Allow)
-	t.Run("Evaluate_Deny", TestIAMEvaluator_Evaluate_Deny)
-	t.Run("Evaluate_NoMatch", TestIAMEvaluator_Evaluate_NoMatch)
-	t.Run("Evaluate_ExplicitDenyWins", TestIAMEvaluator_Evaluate_ExplicitDenyWins)
-	t.Run("Evaluate_WildcardAction", TestIAMEvaluator_Evaluate_WildcardAction)
-	t.Run("Evaluate_WildcardResource", TestIAMEvaluator_Evaluate_WildcardResource)
+	t.Run("Evaluate_Allow", testIAMEvaluatorEvaluateAllow)
+	t.Run("Evaluate_Deny", testIAMEvaluatorEvaluateDeny)
+	t.Run("Evaluate_NoMatch", testIAMEvaluatorEvaluateNoMatch)
+	t.Run("Evaluate_ExplicitDenyWins", testIAMEvaluatorEvaluateExplicitDenyWins)
+	t.Run("Evaluate_WildcardAction", testIAMEvaluatorEvaluateWildcardAction)
+	t.Run("Evaluate_WildcardResource", testIAMEvaluatorEvaluateWildcardResource)
 }
 
-func TestIAMEvaluator_Evaluate_Allow(t *testing.T) {
+func testIAMEvaluatorEvaluateAllow(t *testing.T) {
 	evaluator := services.NewIAMEvaluator()
 	ctx := context.Background()
 
@@ -40,7 +40,7 @@ func TestIAMEvaluator_Evaluate_Allow(t *testing.T) {
 	assert.Equal(t, domain.EffectAllow, effect)
 }
 
-func TestIAMEvaluator_Evaluate_Deny(t *testing.T) {
+func testIAMEvaluatorEvaluateDeny(t *testing.T) {
 	evaluator := services.NewIAMEvaluator()
 	ctx := context.Background()
 
@@ -61,7 +61,7 @@ func TestIAMEvaluator_Evaluate_Deny(t *testing.T) {
 	assert.Equal(t, domain.EffectDeny, effect)
 }
 
-func TestIAMEvaluator_Evaluate_NoMatch(t *testing.T) {
+func testIAMEvaluatorEvaluateNoMatch(t *testing.T) {
 	evaluator := services.NewIAMEvaluator()
 	ctx := context.Background()
 
@@ -82,7 +82,7 @@ func TestIAMEvaluator_Evaluate_NoMatch(t *testing.T) {
 	assert.Equal(t, domain.PolicyEffect(""), effect)
 }
 
-func TestIAMEvaluator_Evaluate_ExplicitDenyWins(t *testing.T) {
+func testIAMEvaluatorEvaluateExplicitDenyWins(t *testing.T) {
 	evaluator := services.NewIAMEvaluator()
 	ctx := context.Background()
 
@@ -108,7 +108,7 @@ func TestIAMEvaluator_Evaluate_ExplicitDenyWins(t *testing.T) {
 	assert.Equal(t, domain.EffectDeny, effect)
 }
 
-func TestIAMEvaluator_Evaluate_WildcardAction(t *testing.T) {
+func testIAMEvaluatorEvaluateWildcardAction(t *testing.T) {
 	evaluator := services.NewIAMEvaluator()
 	ctx := context.Background()
 
@@ -140,7 +140,7 @@ func TestIAMEvaluator_Evaluate_WildcardAction(t *testing.T) {
 	}
 }
 
-func TestIAMEvaluator_Evaluate_WildcardResource(t *testing.T) {
+func testIAMEvaluatorEvaluateWildcardResource(t *testing.T) {
 	evaluator := services.NewIAMEvaluator()
 	ctx := context.Background()
 

--- a/internal/core/services/pipeline_unit_test.go
+++ b/internal/core/services/pipeline_unit_test.go
@@ -107,7 +107,7 @@ func githubSignature(secret string, payload []byte) string {
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
 }
 
-func TestPipelineServiceTriggerBuildWebhookInvalidGitHubSignature(t *testing.T) {
+func testPipelineServiceTriggerBuildWebhookInvalidGitHubSignature(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -137,7 +137,7 @@ func TestPipelineServiceTriggerBuildWebhookInvalidGitHubSignature(t *testing.T) 
 	repo.AssertExpectations(t)
 }
 
-func TestPipelineServiceTriggerBuildWebhookDuplicateDeliveryIgnored(t *testing.T) {
+func testPipelineServiceTriggerBuildWebhookDuplicateDeliveryIgnored(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -170,7 +170,7 @@ func TestPipelineServiceTriggerBuildWebhookDuplicateDeliveryIgnored(t *testing.T
 	repo.AssertExpectations(t)
 }
 
-func TestPipelineServiceTriggerBuildWebhookBranchMismatchIgnored(t *testing.T) {
+func testPipelineServiceTriggerBuildWebhookBranchMismatchIgnored(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -203,7 +203,7 @@ func TestPipelineServiceTriggerBuildWebhookBranchMismatchIgnored(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
-func TestPipelineServiceTriggerBuildWebhookSuccessQueuesBuild(t *testing.T) {
+func testPipelineServiceTriggerBuildWebhookSuccessQueuesBuild(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -250,7 +250,7 @@ func TestPipelineServiceTriggerBuildWebhookSuccessQueuesBuild(t *testing.T) {
 	auditSvc.AssertExpectations(t)
 }
 
-func TestPipelineService_CreatePipeline(t *testing.T) {
+func testPipelineServiceCreatePipeline(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -298,7 +298,7 @@ func TestPipelineService_CreatePipeline(t *testing.T) {
 	})
 }
 
-func TestPipelineService_GetPipeline(t *testing.T) {
+func testPipelineServiceGetPipeline(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -333,7 +333,7 @@ func TestPipelineService_GetPipeline(t *testing.T) {
 	})
 }
 
-func TestPipelineService_ListPipelines(t *testing.T) {
+func testPipelineServiceListPipelines(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -360,7 +360,7 @@ func TestPipelineService_ListPipelines(t *testing.T) {
 	})
 }
 
-func TestPipelineService_UpdatePipeline(t *testing.T) {
+func testPipelineServiceUpdatePipeline(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -399,7 +399,7 @@ func TestPipelineService_UpdatePipeline(t *testing.T) {
 	})
 }
 
-func TestPipelineService_DeletePipeline(t *testing.T) {
+func testPipelineServiceDeletePipeline(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -436,7 +436,7 @@ func TestPipelineService_DeletePipeline(t *testing.T) {
 	})
 }
 
-func TestPipelineService_TriggerBuild(t *testing.T) {
+func testPipelineServiceTriggerBuild(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -486,7 +486,7 @@ func TestPipelineService_TriggerBuild(t *testing.T) {
 	})
 }
 
-func TestPipelineService_GetBuild(t *testing.T) {
+func testPipelineServiceGetBuild(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -521,7 +521,7 @@ func TestPipelineService_GetBuild(t *testing.T) {
 	})
 }
 
-func TestPipelineService_ListBuildsByPipeline(t *testing.T) {
+func testPipelineServiceListBuildsByPipeline(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -549,7 +549,7 @@ func TestPipelineService_ListBuildsByPipeline(t *testing.T) {
 	})
 }
 
-func TestPipelineService_ListBuildSteps(t *testing.T) {
+func testPipelineServiceListBuildSteps(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -577,7 +577,7 @@ func TestPipelineService_ListBuildSteps(t *testing.T) {
 	})
 }
 
-func TestPipelineService_ListBuildLogs(t *testing.T) {
+func testPipelineServiceListBuildLogs(t *testing.T) {
 	repo := new(MockPipelineRepository)
 	taskQueue := new(MockTaskQueue)
 	eventSvc := new(MockEventService)
@@ -606,20 +606,20 @@ func TestPipelineService_ListBuildLogs(t *testing.T) {
 }
 
 func TestPipelineService_Unit(t *testing.T) {
-	t.Run("TriggerBuildWebhook_InvalidSignature", TestPipelineServiceTriggerBuildWebhookInvalidGitHubSignature)
-	t.Run("TriggerBuildWebhook_DuplicateDelivery", TestPipelineServiceTriggerBuildWebhookDuplicateDeliveryIgnored)
-	t.Run("TriggerBuildWebhook_BranchMismatch", TestPipelineServiceTriggerBuildWebhookBranchMismatchIgnored)
-	t.Run("TriggerBuildWebhook_Success", TestPipelineServiceTriggerBuildWebhookSuccessQueuesBuild)
-	t.Run("CreatePipeline", TestPipelineService_CreatePipeline)
-	t.Run("GetPipeline", TestPipelineService_GetPipeline)
-	t.Run("ListPipelines", TestPipelineService_ListPipelines)
-	t.Run("UpdatePipeline", TestPipelineService_UpdatePipeline)
-	t.Run("DeletePipeline", TestPipelineService_DeletePipeline)
-	t.Run("TriggerBuild", TestPipelineService_TriggerBuild)
-	t.Run("GetBuild", TestPipelineService_GetBuild)
-	t.Run("ListBuildsByPipeline", TestPipelineService_ListBuildsByPipeline)
-	t.Run("ListBuildSteps", TestPipelineService_ListBuildSteps)
-	t.Run("ListBuildLogs", TestPipelineService_ListBuildLogs)
+	t.Run("TriggerBuildWebhook_InvalidSignature", testPipelineServiceTriggerBuildWebhookInvalidGitHubSignature)
+	t.Run("TriggerBuildWebhook_DuplicateDelivery", testPipelineServiceTriggerBuildWebhookDuplicateDeliveryIgnored)
+	t.Run("TriggerBuildWebhook_BranchMismatch", testPipelineServiceTriggerBuildWebhookBranchMismatchIgnored)
+	t.Run("TriggerBuildWebhook_Success", testPipelineServiceTriggerBuildWebhookSuccessQueuesBuild)
+	t.Run("CreatePipeline", testPipelineServiceCreatePipeline)
+	t.Run("GetPipeline", testPipelineServiceGetPipeline)
+	t.Run("ListPipelines", testPipelineServiceListPipelines)
+	t.Run("UpdatePipeline", testPipelineServiceUpdatePipeline)
+	t.Run("DeletePipeline", testPipelineServiceDeletePipeline)
+	t.Run("TriggerBuild", testPipelineServiceTriggerBuild)
+	t.Run("GetBuild", testPipelineServiceGetBuild)
+	t.Run("ListBuildsByPipeline", testPipelineServiceListBuildsByPipeline)
+	t.Run("ListBuildSteps", testPipelineServiceListBuildSteps)
+	t.Run("ListBuildLogs", testPipelineServiceListBuildLogs)
 }
 
 func stringPtr(s string) *string {


### PR DESCRIPTION
## Summary

- Rename `TestXxx` helpers to unexported `testXxx` to prevent Go test runner from discovering them standalone
- Keep `TestXxx_Unit` wrapper functions that call helpers via `t.Run()`
- Eliminates duplicate test execution while preserving `-run "Unit"` filtering

## Test plan

- [x] `go test ./internal/core/services/ -run "Unit"` passes
- [x] `go test ./internal/core/services/ -run "FunctionService_Unit"` passes
- [x] `go test ./internal/core/services/ -run "PipelineService_Unit"` passes