### PR TITLE
test(services): add basic _Unit wrappers to 4 Extended-only services

### DIFF
--- a/internal/core/services/auth_unit_test.go
+++ b/internal/core/services/auth_unit_test.go
@@ -14,7 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAuthService_Unit_Extended(t *testing.T) {
+func TestAuthService_Unit(t *testing.T) {
+	t.Run("Extended", testAuthServiceUnitExtended)
+}
+
+func testAuthServiceUnitExtended(t *testing.T) {
 	mockUserRepo := new(MockUserRepo)
 	mockIdentitySvc := new(MockIdentityService)
 	mockAuditSvc := new(MockAuditService)

--- a/internal/core/services/cache_unit_test.go
+++ b/internal/core/services/cache_unit_test.go
@@ -55,7 +55,11 @@ func (m *MockCacheRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return m.Called(ctx, id).Error(0)
 }
 
-func TestCacheService_Unit_Extended(t *testing.T) {
+func TestCacheService_Unit(t *testing.T) {
+	t.Run("Extended", testCacheServiceUnitExtended)
+}
+
+func testCacheServiceUnitExtended(t *testing.T) {
 	repo := new(MockCacheRepository)
 	compute := new(MockComputeBackend)
 	eventSvc := new(MockEventService)

--- a/internal/core/services/database_unit_test.go
+++ b/internal/core/services/database_unit_test.go
@@ -54,7 +54,11 @@ func (m *DatabaseUnitMockRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return m.Called(ctx, id).Error(0)
 }
 
-func TestDatabaseServiceUnitExtended(t *testing.T) {
+func TestDatabaseService_Unit(t *testing.T) {
+	t.Run("Extended", testDatabaseServiceUnitExtended)
+}
+
+func testDatabaseServiceUnitExtended(t *testing.T) {
 	mockRepo := new(DatabaseUnitMockRepo)
 	mockCompute := new(MockComputeBackend)
 	mockVpcRepo := new(MockVpcRepo)

--- a/internal/core/services/dns_unit_test.go
+++ b/internal/core/services/dns_unit_test.go
@@ -107,7 +107,12 @@ func (m *MockDNSBackend) ListRecords(ctx context.Context, zoneID string) ([]port
 	return r0, args.Error(1)
 }
 
-func TestDNSService_Unit_Extended(t *testing.T) {
+func TestDNSService_Unit(t *testing.T) {
+	t.Run("Extended", testDNSServiceUnitExtended)
+	t.Run("GetZoneByVPC", testGetZoneByVPC)
+}
+
+func testDNSServiceUnitExtended(t *testing.T) {
 	repo := new(MockDNSRepository)
 	backend := new(MockDNSBackend)
 	vpcRepo := new(MockVpcRepo)
@@ -268,8 +273,8 @@ func TestDNSService_Unit_Extended(t *testing.T) {
 	})
 }
 
-// TestGetZoneByVPC tests the GetZoneByVPC method with table-driven cases
-func TestGetZoneByVPC(t *testing.T) {
+// testGetZoneByVPC tests the GetZoneByVPC method with table-driven cases
+func testGetZoneByVPC(t *testing.T) {
 	repo := new(MockDNSRepository)
 	backend := new(MockDNSBackend)
 	vpcRepo := new(MockVpcRepo)


### PR DESCRIPTION
## Summary

Add basic `TestXxx_Unit` wrappers to 4 services that previously only had `TestXxx_Unit_Extended` wrappers (no basic wrapper):

- `dns` → `TestDNSService_Unit` (calls `testDNSServiceUnitExtended` and `testGetZoneByVPC`)
- `auth` → `TestAuthService_Unit` (calls `testAuthServiceUnitExtended`)
- `cache` → `TestCacheService_Unit` (calls `testCacheServiceUnitExtended`)
- `database` → `TestDatabaseService_Unit` (calls `testDatabaseServiceUnitExtended`)

Also renames Extended helpers to unexported `testXxxUnitExtended` to prevent standalone discovery by `go test`.

## Test plan

- [x] `go test ./internal/core/services/ -run "Unit" -v | grep -E "DNSService_Unit|AuthService_Unit|CacheService_Unit|DatabaseService_Unit"` — all 4 wrappers matched and pass