### PR TITLE
test(services): add _Unit wrappers for CronWorker and ContainerWorker

### DIFF
--- a/cmd/cloud/autoscaling.go
+++ b/cmd/cloud/autoscaling.go
@@ -85,9 +85,9 @@ var asgListCmd = &cobra.Command{
 
 		for _, g := range groups {
 			instances := fmt.Sprintf("%d / %d / %d / %d", g.CurrentCount, g.DesiredCount, g.MinInstances, g.MaxInstances)
-			table.Append([]string{g.ID, g.Name, instances, g.Status})
+			_ = table.Append([]string{g.ID, g.Name, instances, g.Status})
 		}
-		table.Render()
+		_ = table.Render()
 	},
 }
 

--- a/cmd/cloud/billing.go
+++ b/cmd/cloud/billing.go
@@ -36,9 +36,9 @@ var billingSummaryCmd = &cobra.Command{
 		table := tablewriter.NewWriter(os.Stdout)
 		table.Header([]string{"RESOURCE TYPE", "AMOUNT"})
 		for t, amt := range summary.UsageByType {
-			table.Append([]string{string(t), fmt.Sprintf("%.2f", amt)})
+			_ = table.Append([]string{string(t), fmt.Sprintf("%.2f", amt)})
 		}
-		table.Render()
+		_ = table.Render()
 	},
 }
 
@@ -67,7 +67,7 @@ var billingUsageCmd = &cobra.Command{
 		table.Header([]string{"RESOURCE ID", "TYPE", "QUANTITY", "UNIT", "START TIME"})
 
 		for _, r := range records {
-			table.Append([]string{
+			_ = table.Append([]string{
 				truncateID(r.ResourceID.String()),
 				string(r.ResourceType),
 				fmt.Sprintf("%.2f", r.Quantity),
@@ -75,7 +75,7 @@ var billingUsageCmd = &cobra.Command{
 				r.StartTime.Format("2006-01-02 15:04"),
 			})
 		}
-		table.Render()
+		_ = table.Render()
 	},
 }
 

--- a/internal/autoscaler/server_test.go
+++ b/internal/autoscaler/server_test.go
@@ -23,7 +23,7 @@ func TestAutoscalerServer_Refresh(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, fmt.Sprintf("/clusters/%s", clusterID), r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING"}}`, clusterID)
+			_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING"}}`, clusterID)
 		}))
 		defer ts.Close()
 
@@ -38,7 +38,7 @@ func TestAutoscalerServer_Refresh(t *testing.T) {
 	t.Run("Status_Repairing", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"data": {"id": "%s", "status": "repairing"}}`, clusterID)
+			_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "repairing"}}`, clusterID)
 		}))
 		defer ts.Close()
 
@@ -57,7 +57,7 @@ func TestAutoscalerServer_NodeGroups(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{
+			_, _ = fmt.Fprintf(w, `{
 				"data": {
 					"id": "%s",
 					"node_groups": [
@@ -86,9 +86,9 @@ func TestAutoscalerServer_NodeGroupForNode(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			if r.URL.Path == fmt.Sprintf("/instances/%s", instanceID) {
-				fmt.Fprintf(w, `{"data": {"id": "%s", "metadata": {"thecloud.io/node-group": "pool-1"}} }`, instanceID)
+				_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "metadata": {"thecloud.io/node-group": "pool-1"}} }`, instanceID)
 			} else {
-				fmt.Fprintf(w, `{
+				_, _ = fmt.Fprintf(w, `{
 					"data": {
 						"id": "%s",
 						"node_groups": [{"name": "pool-1", "min_size": 1, "max_size": 10}]
@@ -116,7 +116,7 @@ func TestAutoscalerServer_NodeGroupTargetSize(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{
+			_, _ = fmt.Fprintf(w, `{
 				"data": {
 					"id": "%s",
 					"node_groups": [{"name": "pool-1", "current_size": 5}]
@@ -142,10 +142,10 @@ func TestAutoscalerServer_NodeGroupIncreaseSize(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			switch r.Method {
 			case "GET":
-				fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 2, "max_size": 10}]}}`, clusterID)
+				_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 2, "max_size": 10}]}}`, clusterID)
 			case "PUT":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, `{"data": {}}`)
+				_, _ = fmt.Fprint(w, `{"data": {}}`)
 			}
 		}))
 		defer ts.Close()
@@ -167,15 +167,15 @@ func TestAutoscalerServer_NodeGroupDeleteNodes(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			switch {
 			case r.Method == "GET" && r.URL.Path == "/clusters/"+clusterID:
-				fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 2, "min_size": 1}]}}`, clusterID)
+				_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 2, "min_size": 1}]}}`, clusterID)
 			case r.Method == "GET" && r.URL.Path == "/instances":
-				fmt.Fprintf(w, `{"data": [{"id": "%s", "metadata": {"thecloud.io/cluster-id": "%s", "thecloud.io/node-group": "pool-1"}}]}`, instanceID, clusterID)
+				_, _ = fmt.Fprintf(w, `{"data": [{"id": "%s", "metadata": {"thecloud.io/cluster-id": "%s", "thecloud.io/node-group": "pool-1"}}]}`, instanceID, clusterID)
 			case r.Method == "DELETE":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, `{"data": {}}`)
+				_, _ = fmt.Fprint(w, `{"data": {}}`)
 			case r.Method == "PUT":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, `{"data": {}}`)
+				_, _ = fmt.Fprint(w, `{"data": {}}`)
 			}
 		}))
 		defer ts.Close()
@@ -198,7 +198,7 @@ func TestAutoscalerServer_NodeGroupNodes(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"data": [{"id": "%s", "metadata": {"thecloud.io/cluster-id": "%s", "thecloud.io/node-group": "pool-1"}, "status": "RUNNING"}]}`, instanceID, clusterID)
+			_, _ = fmt.Fprintf(w, `{"data": [{"id": "%s", "metadata": {"thecloud.io/cluster-id": "%s", "thecloud.io/node-group": "pool-1"}, "status": "RUNNING"}]}`, instanceID, clusterID)
 		}))
 		defer ts.Close()
 
@@ -220,10 +220,10 @@ func TestAutoscalerServer_NodeGroupDecreaseTargetSize(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			switch r.Method {
 			case "GET":
-				fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 5, "min_size": 1}]}}`, clusterID)
+				_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 5, "min_size": 1}]}}`, clusterID)
 			case "PUT":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, `{"data": {}}`)
+				_, _ = fmt.Fprint(w, `{"data": {}}`)
 			}
 		}))
 		defer ts.Close()

--- a/internal/core/services/container_worker_unit_test.go
+++ b/internal/core/services/container_worker_unit_test.go
@@ -1,0 +1,166 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// mockInstanceSvc is a minimal mock of ports.InstanceService.
+type mockInstanceSvc struct {
+	mock.Mock
+}
+
+func (m *mockInstanceSvc) LaunchInstance(ctx context.Context, params ports.LaunchParams) (*domain.Instance, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Instance), args.Error(1)
+}
+
+func (m *mockInstanceSvc) LaunchInstanceWithOptions(ctx context.Context, opts ports.CreateInstanceOptions) (*domain.Instance, error) {
+	args := m.Called(ctx, opts)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Instance), args.Error(1)
+}
+
+func (m *mockInstanceSvc) StartInstance(ctx context.Context, idOrName string) error {
+	args := m.Called(ctx, idOrName)
+	return args.Error(0)
+}
+
+func (m *mockInstanceSvc) StopInstance(ctx context.Context, idOrName string) error {
+	args := m.Called(ctx, idOrName)
+	return args.Error(0)
+}
+
+func (m *mockInstanceSvc) TerminateInstance(ctx context.Context, idOrName string) error {
+	args := m.Called(ctx, idOrName)
+	return args.Error(0)
+}
+
+func (m *mockInstanceSvc) ListInstances(ctx context.Context) ([]*domain.Instance, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Instance), args.Error(1)
+}
+
+func (m *mockInstanceSvc) GetInstance(ctx context.Context, idOrName string) (*domain.Instance, error) {
+	args := m.Called(ctx, idOrName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Instance), args.Error(1)
+}
+
+func (m *mockInstanceSvc) GetInstanceLogs(ctx context.Context, idOrName string) (string, error) {
+	args := m.Called(ctx, idOrName)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockInstanceSvc) GetInstanceStats(ctx context.Context, idOrName string) (*domain.InstanceStats, error) {
+	args := m.Called(ctx, idOrName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.InstanceStats), args.Error(1)
+}
+
+func (m *mockInstanceSvc) GetConsoleURL(ctx context.Context, idOrName string) (string, error) {
+	args := m.Called(ctx, idOrName)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockInstanceSvc) Exec(ctx context.Context, idOrName string, cmd []string) (string, error) {
+	args := m.Called(ctx, idOrName, cmd)
+	return args.String(0), args.Error(1)
+}
+
+func (m *mockInstanceSvc) UpdateInstanceMetadata(ctx context.Context, id uuid.UUID, metadata, labels map[string]string) error {
+	args := m.Called(ctx, id, metadata, labels)
+	return args.Error(0)
+}
+
+// mockEventSvc is a minimal mock of ports.EventService.
+type mockEventSvc struct {
+	mock.Mock
+}
+
+func (m *mockEventSvc) RecordEvent(ctx context.Context, eType, resourceID, resourceType string, meta map[string]interface{}) error {
+	args := m.Called(ctx, eType, resourceID, resourceType, meta)
+	return args.Error(0)
+}
+
+func (m *mockEventSvc) ListEvents(ctx context.Context, limit int) ([]*domain.Event, error) {
+	args := m.Called(ctx, limit)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Event), args.Error(1)
+}
+
+// setupContainerWorkerTest creates a ContainerWorker with mock dependencies.
+func setupContainerWorkerTest(t *testing.T) (*services.ContainerWorker, *MockContainerRepository, *mockInstanceSvc, *mockEventSvc) {
+	t.Helper()
+	repo := new(MockContainerRepository)
+	instanceSvc := new(mockInstanceSvc)
+	eventSvc := new(mockEventSvc)
+	worker := services.NewContainerWorker(repo, instanceSvc, eventSvc)
+	return worker, repo, instanceSvc, eventSvc
+}
+
+func TestContainerWorker_Unit(t *testing.T) {
+	t.Run("Reconcile", testContainerWorkerReconcile)
+	t.Run("Reconcile_ListDeploymentsError", testContainerWorkerReconcileListDeploymentsError)
+}
+
+func testContainerWorkerReconcile(t *testing.T) {
+	worker, repo, instanceSvc, _ := setupContainerWorkerTest(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	depID := uuid.New()
+	instID := uuid.New()
+
+	dep := &domain.Deployment{
+		ID:           depID,
+		UserID:       userID,
+		Name:         "test-deployment",
+		Status:       domain.DeploymentStatusReady,
+		Replicas:     1,
+		CurrentCount: 1,
+		Image:        "nginx:latest",
+		InstanceType: "t2.micro",
+	}
+	inst := &domain.Instance{ID: instID, Status: domain.StatusRunning}
+
+	repo.On("ListAllDeployments", mock.Anything).Return([]*domain.Deployment{dep}, nil).Once()
+	repo.On("GetContainers", mock.Anything, depID).Return([]uuid.UUID{instID}, nil).Once()
+	instanceSvc.On("GetInstance", mock.Anything, instID.String()).Return(inst, nil).Once()
+
+	worker.Reconcile(ctx)
+
+	repo.AssertExpectations(t)
+	instanceSvc.AssertExpectations(t)
+}
+
+func testContainerWorkerReconcileListDeploymentsError(t *testing.T) {
+	worker, repo, _, _ := setupContainerWorkerTest(t)
+	ctx := context.Background()
+
+	repo.On("ListAllDeployments", mock.Anything).Return(nil, assert.AnError).Maybe()
+
+	// Reconcile logs the error and returns gracefully.
+	worker.Reconcile(ctx)
+}
+

--- a/internal/core/services/container_worker_unit_test.go
+++ b/internal/core/services/container_worker_unit_test.go
@@ -6,118 +6,21 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
-	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
-// mockInstanceSvc is a minimal mock of ports.InstanceService.
-type mockInstanceSvc struct {
-	mock.Mock
-}
-
-func (m *mockInstanceSvc) LaunchInstance(ctx context.Context, params ports.LaunchParams) (*domain.Instance, error) {
-	args := m.Called(ctx, params)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*domain.Instance), args.Error(1)
-}
-
-func (m *mockInstanceSvc) LaunchInstanceWithOptions(ctx context.Context, opts ports.CreateInstanceOptions) (*domain.Instance, error) {
-	args := m.Called(ctx, opts)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*domain.Instance), args.Error(1)
-}
-
-func (m *mockInstanceSvc) StartInstance(ctx context.Context, idOrName string) error {
-	args := m.Called(ctx, idOrName)
-	return args.Error(0)
-}
-
-func (m *mockInstanceSvc) StopInstance(ctx context.Context, idOrName string) error {
-	args := m.Called(ctx, idOrName)
-	return args.Error(0)
-}
-
-func (m *mockInstanceSvc) TerminateInstance(ctx context.Context, idOrName string) error {
-	args := m.Called(ctx, idOrName)
-	return args.Error(0)
-}
-
-func (m *mockInstanceSvc) ListInstances(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]*domain.Instance), args.Error(1)
-}
-
-func (m *mockInstanceSvc) GetInstance(ctx context.Context, idOrName string) (*domain.Instance, error) {
-	args := m.Called(ctx, idOrName)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*domain.Instance), args.Error(1)
-}
-
-func (m *mockInstanceSvc) GetInstanceLogs(ctx context.Context, idOrName string) (string, error) {
-	args := m.Called(ctx, idOrName)
-	return args.String(0), args.Error(1)
-}
-
-func (m *mockInstanceSvc) GetInstanceStats(ctx context.Context, idOrName string) (*domain.InstanceStats, error) {
-	args := m.Called(ctx, idOrName)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*domain.InstanceStats), args.Error(1)
-}
-
-func (m *mockInstanceSvc) GetConsoleURL(ctx context.Context, idOrName string) (string, error) {
-	args := m.Called(ctx, idOrName)
-	return args.String(0), args.Error(1)
-}
-
-func (m *mockInstanceSvc) Exec(ctx context.Context, idOrName string, cmd []string) (string, error) {
-	args := m.Called(ctx, idOrName, cmd)
-	return args.String(0), args.Error(1)
-}
-
-func (m *mockInstanceSvc) UpdateInstanceMetadata(ctx context.Context, id uuid.UUID, metadata, labels map[string]string) error {
-	args := m.Called(ctx, id, metadata, labels)
-	return args.Error(0)
-}
-
-// mockEventSvc is a minimal mock of ports.EventService.
-type mockEventSvc struct {
-	mock.Mock
-}
-
-func (m *mockEventSvc) RecordEvent(ctx context.Context, eType, resourceID, resourceType string, meta map[string]interface{}) error {
-	args := m.Called(ctx, eType, resourceID, resourceType, meta)
-	return args.Error(0)
-}
-
-func (m *mockEventSvc) ListEvents(ctx context.Context, limit int) ([]*domain.Event, error) {
-	args := m.Called(ctx, limit)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).([]*domain.Event), args.Error(1)
-}
+// mockInstanceSvc reuses MockInstanceService to avoid duplicating mock behavior.
+type mockInstanceSvc = MockInstanceService
 
 // setupContainerWorkerTest creates a ContainerWorker with mock dependencies.
-func setupContainerWorkerTest(t *testing.T) (*services.ContainerWorker, *MockContainerRepository, *mockInstanceSvc) {
+func setupContainerWorkerTest(t *testing.T) (*services.ContainerWorker, *MockContainerRepository, *MockInstanceService) {
 	t.Helper()
 	repo := new(MockContainerRepository)
 	instanceSvc := new(mockInstanceSvc)
-	eventSvc := new(mockEventSvc)
+	eventSvc := new(MockEventService)
 	worker := services.NewContainerWorker(repo, instanceSvc, eventSvc)
-	_ = eventSvc // satisfy linter: eventSvc is a dependency but not exercised by Reconcile tests
 	return worker, repo, instanceSvc
 }
 
@@ -159,9 +62,9 @@ func testContainerWorkerReconcileListDeploymentsError(t *testing.T) {
 	worker, repo, _ := setupContainerWorkerTest(t)
 	ctx := context.Background()
 
-	repo.On("ListAllDeployments", mock.Anything).Return(nil, assert.AnError).Maybe()
+	repo.On("ListAllDeployments", mock.Anything).Return(nil, assert.AnError).Once()
 
-	// Reconcile logs the error and returns gracefully.
 	worker.Reconcile(ctx)
-}
 
+	repo.AssertExpectations(t)
+}

--- a/internal/core/services/container_worker_unit_test.go
+++ b/internal/core/services/container_worker_unit_test.go
@@ -111,13 +111,14 @@ func (m *mockEventSvc) ListEvents(ctx context.Context, limit int) ([]*domain.Eve
 }
 
 // setupContainerWorkerTest creates a ContainerWorker with mock dependencies.
-func setupContainerWorkerTest(t *testing.T) (*services.ContainerWorker, *MockContainerRepository, *mockInstanceSvc, *mockEventSvc) {
+func setupContainerWorkerTest(t *testing.T) (*services.ContainerWorker, *MockContainerRepository, *mockInstanceSvc) {
 	t.Helper()
 	repo := new(MockContainerRepository)
 	instanceSvc := new(mockInstanceSvc)
 	eventSvc := new(mockEventSvc)
 	worker := services.NewContainerWorker(repo, instanceSvc, eventSvc)
-	return worker, repo, instanceSvc, eventSvc
+	_ = eventSvc // satisfy linter: eventSvc is a dependency but not exercised by Reconcile tests
+	return worker, repo, instanceSvc
 }
 
 func TestContainerWorker_Unit(t *testing.T) {
@@ -126,7 +127,7 @@ func TestContainerWorker_Unit(t *testing.T) {
 }
 
 func testContainerWorkerReconcile(t *testing.T) {
-	worker, repo, instanceSvc, _ := setupContainerWorkerTest(t)
+	worker, repo, instanceSvc := setupContainerWorkerTest(t)
 	ctx := context.Background()
 	userID := uuid.New()
 	depID := uuid.New()
@@ -155,7 +156,7 @@ func testContainerWorkerReconcile(t *testing.T) {
 }
 
 func testContainerWorkerReconcileListDeploymentsError(t *testing.T) {
-	worker, repo, _, _ := setupContainerWorkerTest(t)
+	worker, repo, _ := setupContainerWorkerTest(t)
 	ctx := context.Background()
 
 	repo.On("ListAllDeployments", mock.Anything).Return(nil, assert.AnError).Maybe()

--- a/internal/core/services/cron_worker_unit_test.go
+++ b/internal/core/services/cron_worker_unit_test.go
@@ -1,0 +1,44 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupCronWorkerTest(t *testing.T) (*services.CronWorker, *MockCronRepository) {
+	t.Helper()
+	repo := new(MockCronRepository)
+	worker := services.NewCronWorker(repo)
+	return worker, repo
+}
+
+func TestCronWorker_Unit(t *testing.T) {
+	t.Run("ProcessJobs_Empty", testCronWorkerProcessJobsEmpty)
+	t.Run("ProcessJobs_ClaimError", testCronWorkerProcessJobsClaimError)
+}
+
+func testCronWorkerProcessJobsEmpty(t *testing.T) {
+	worker, repo := setupCronWorkerTest(t)
+	ctx := context.Background()
+
+	repo.On("ClaimNextJobsToRun", mock.Anything, services.ClaimTimeout).Return([]*domain.CronJob{}, nil).Once()
+
+	worker.ProcessJobs(ctx)
+
+	repo.AssertExpectations(t)
+}
+
+func testCronWorkerProcessJobsClaimError(t *testing.T) {
+	worker, repo := setupCronWorkerTest(t)
+	ctx := context.Background()
+
+	repo.On("ClaimNextJobsToRun", mock.Anything, services.ClaimTimeout).Return(nil, assert.AnError).Maybe()
+
+	worker.ProcessJobs(ctx)
+}
+

--- a/internal/core/services/cron_worker_unit_test.go
+++ b/internal/core/services/cron_worker_unit_test.go
@@ -37,8 +37,10 @@ func testCronWorkerProcessJobsClaimError(t *testing.T) {
 	worker, repo := setupCronWorkerTest(t)
 	ctx := context.Background()
 
-	repo.On("ClaimNextJobsToRun", mock.Anything, services.ClaimTimeout).Return(nil, assert.AnError).Maybe()
+	repo.On("ClaimNextJobsToRun", mock.Anything, services.ClaimTimeout).Return(nil, assert.AnError).Once()
 
 	worker.ProcessJobs(ctx)
+
+	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary
- Add `TestCronWorker_Unit` wrapper to `cron_worker_unit_test.go` with `ProcessJobs_Empty` and `ProcessJobs_ClaimError` subtests
- Add `TestContainerWorker_Unit` wrapper to `container_worker_unit_test.go` with `Reconcile` and `Reconcile_ListDeploymentsError` subtests
- Both follow the established `_Unit` wrapper pattern for consistent test targeting

## Test plan
- [x] `go test ./internal/core/services/ -run "CronWorker_Unit" -v` — passes
- [x] `go test ./internal/core/services/ -run "ContainerWorker_Unit" -v` — passes
- [x] `go build ./internal/core/services/` — clean build