### PR TITLE
fix(services): rename orphaned test helpers to follow Unit naming

### DIFF
--- a/cmd/cloud/autoscaling.go
+++ b/cmd/cloud/autoscaling.go
@@ -85,9 +85,9 @@ var asgListCmd = &cobra.Command{
 
 		for _, g := range groups {
 			instances := fmt.Sprintf("%d / %d / %d / %d", g.CurrentCount, g.DesiredCount, g.MinInstances, g.MaxInstances)
-			table.Append([]string{g.ID, g.Name, instances, g.Status})
+			_ = table.Append([]string{g.ID, g.Name, instances, g.Status})
 		}
-		table.Render()
+		_ = table.Render()
 	},
 }
 

--- a/cmd/cloud/billing.go
+++ b/cmd/cloud/billing.go
@@ -36,9 +36,9 @@ var billingSummaryCmd = &cobra.Command{
 		table := tablewriter.NewWriter(os.Stdout)
 		table.Header([]string{"RESOURCE TYPE", "AMOUNT"})
 		for t, amt := range summary.UsageByType {
-			table.Append([]string{string(t), fmt.Sprintf("%.2f", amt)})
+			_ = table.Append([]string{string(t), fmt.Sprintf("%.2f", amt)})
 		}
-		table.Render()
+		_ = table.Render()
 	},
 }
 
@@ -67,7 +67,7 @@ var billingUsageCmd = &cobra.Command{
 		table.Header([]string{"RESOURCE ID", "TYPE", "QUANTITY", "UNIT", "START TIME"})
 
 		for _, r := range records {
-			table.Append([]string{
+			_ = table.Append([]string{
 				truncateID(r.ResourceID.String()),
 				string(r.ResourceType),
 				fmt.Sprintf("%.2f", r.Quantity),
@@ -75,7 +75,7 @@ var billingUsageCmd = &cobra.Command{
 				r.StartTime.Format("2006-01-02 15:04"),
 			})
 		}
-		table.Render()
+		_ = table.Render()
 	},
 }
 

--- a/internal/autoscaler/server_test.go
+++ b/internal/autoscaler/server_test.go
@@ -23,7 +23,7 @@ func TestAutoscalerServer_Refresh(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, fmt.Sprintf("/clusters/%s", clusterID), r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING"}}`, clusterID)
+			_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING"}}`, clusterID)
 		}))
 		defer ts.Close()
 
@@ -38,7 +38,7 @@ func TestAutoscalerServer_Refresh(t *testing.T) {
 	t.Run("Status_Repairing", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"data": {"id": "%s", "status": "repairing"}}`, clusterID)
+			_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "repairing"}}`, clusterID)
 		}))
 		defer ts.Close()
 
@@ -57,7 +57,7 @@ func TestAutoscalerServer_NodeGroups(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{
+			_, _ = fmt.Fprintf(w, `{
 				"data": {
 					"id": "%s",
 					"node_groups": [
@@ -86,9 +86,9 @@ func TestAutoscalerServer_NodeGroupForNode(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			if r.URL.Path == fmt.Sprintf("/instances/%s", instanceID) {
-				fmt.Fprintf(w, `{"data": {"id": "%s", "metadata": {"thecloud.io/node-group": "pool-1"}} }`, instanceID)
+				_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "metadata": {"thecloud.io/node-group": "pool-1"}} }`, instanceID)
 			} else {
-				fmt.Fprintf(w, `{
+				_, _ = fmt.Fprintf(w, `{
 					"data": {
 						"id": "%s",
 						"node_groups": [{"name": "pool-1", "min_size": 1, "max_size": 10}]
@@ -116,7 +116,7 @@ func TestAutoscalerServer_NodeGroupTargetSize(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{
+			_, _ = fmt.Fprintf(w, `{
 				"data": {
 					"id": "%s",
 					"node_groups": [{"name": "pool-1", "current_size": 5}]
@@ -142,10 +142,10 @@ func TestAutoscalerServer_NodeGroupIncreaseSize(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			switch r.Method {
 			case "GET":
-				fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 2, "max_size": 10}]}}`, clusterID)
+				_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 2, "max_size": 10}]}}`, clusterID)
 			case "PUT":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, `{"data": {}}`)
+				_, _ = fmt.Fprint(w, `{"data": {}}`)
 			}
 		}))
 		defer ts.Close()
@@ -167,15 +167,15 @@ func TestAutoscalerServer_NodeGroupDeleteNodes(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			switch {
 			case r.Method == "GET" && r.URL.Path == "/clusters/"+clusterID:
-				fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 2, "min_size": 1}]}}`, clusterID)
+				_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 2, "min_size": 1}]}}`, clusterID)
 			case r.Method == "GET" && r.URL.Path == "/instances":
-				fmt.Fprintf(w, `{"data": [{"id": "%s", "metadata": {"thecloud.io/cluster-id": "%s", "thecloud.io/node-group": "pool-1"}}]}`, instanceID, clusterID)
+				_, _ = fmt.Fprintf(w, `{"data": [{"id": "%s", "metadata": {"thecloud.io/cluster-id": "%s", "thecloud.io/node-group": "pool-1"}}]}`, instanceID, clusterID)
 			case r.Method == "DELETE":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, `{"data": {}}`)
+				_, _ = fmt.Fprint(w, `{"data": {}}`)
 			case r.Method == "PUT":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, `{"data": {}}`)
+				_, _ = fmt.Fprint(w, `{"data": {}}`)
 			}
 		}))
 		defer ts.Close()
@@ -198,7 +198,7 @@ func TestAutoscalerServer_NodeGroupNodes(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `{"data": [{"id": "%s", "metadata": {"thecloud.io/cluster-id": "%s", "thecloud.io/node-group": "pool-1"}, "status": "RUNNING"}]}`, instanceID, clusterID)
+			_, _ = fmt.Fprintf(w, `{"data": [{"id": "%s", "metadata": {"thecloud.io/cluster-id": "%s", "thecloud.io/node-group": "pool-1"}, "status": "RUNNING"}]}`, instanceID, clusterID)
 		}))
 		defer ts.Close()
 
@@ -220,10 +220,10 @@ func TestAutoscalerServer_NodeGroupDecreaseTargetSize(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			switch r.Method {
 			case "GET":
-				fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 5, "min_size": 1}]}}`, clusterID)
+				_, _ = fmt.Fprintf(w, `{"data": {"id": "%s", "status": "RUNNING", "node_groups": [{"name": "pool-1", "current_size": 5, "min_size": 1}]}}`, clusterID)
 			case "PUT":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprint(w, `{"data": {}}`)
+				_, _ = fmt.Fprint(w, `{"data": {}}`)
 			}
 		}))
 		defer ts.Close()

--- a/internal/core/services/cloudlogs_unit_test.go
+++ b/internal/core/services/cloudlogs_unit_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testCloudLogsServiceIngestLogs(t *testing.T) {
+func testCloudLogsServiceUnitIngestLogs(t *testing.T) {
 	mockRepo := new(MockLogRepository)
 	mockRBAC := new(MockRBACService)
 	svc := services.NewCloudLogsService(mockRepo, mockRBAC, slog.Default())
@@ -44,7 +44,7 @@ func testCloudLogsServiceIngestLogs(t *testing.T) {
 }
 
 func TestCloudLogsService_Unit(t *testing.T) {
-	t.Run("IngestLogs", testCloudLogsServiceIngestLogs)
+	t.Run("IngestLogs", testCloudLogsServiceUnitIngestLogs)
 	t.Run("SearchLogs", testCloudLogsServiceSearchLogsUnit)
 	t.Run("RunRetentionPolicy", testCloudLogsServiceRunRetentionPolicyUnit)
 }

--- a/internal/core/services/container_worker_unit_test.go
+++ b/internal/core/services/container_worker_unit_test.go
@@ -1,0 +1,70 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// mockInstanceSvc reuses MockInstanceService to avoid duplicating mock behavior.
+type mockInstanceSvc = MockInstanceService
+
+// setupContainerWorkerTest creates a ContainerWorker with mock dependencies.
+func setupContainerWorkerTest(t *testing.T) (*services.ContainerWorker, *MockContainerRepository, *MockInstanceService) {
+	t.Helper()
+	repo := new(MockContainerRepository)
+	instanceSvc := new(mockInstanceSvc)
+	eventSvc := new(MockEventService)
+	worker := services.NewContainerWorker(repo, instanceSvc, eventSvc)
+	return worker, repo, instanceSvc
+}
+
+func TestContainerWorker_Unit(t *testing.T) {
+	t.Run("Reconcile", testContainerWorkerReconcile)
+	t.Run("Reconcile_ListDeploymentsError", testContainerWorkerReconcileListDeploymentsError)
+}
+
+func testContainerWorkerReconcile(t *testing.T) {
+	worker, repo, instanceSvc := setupContainerWorkerTest(t)
+	ctx := context.Background()
+	userID := uuid.New()
+	depID := uuid.New()
+	instID := uuid.New()
+
+	dep := &domain.Deployment{
+		ID:           depID,
+		UserID:       userID,
+		Name:         "test-deployment",
+		Status:       domain.DeploymentStatusReady,
+		Replicas:     1,
+		CurrentCount: 1,
+		Image:        "nginx:latest",
+		InstanceType: "t2.micro",
+	}
+	inst := &domain.Instance{ID: instID, Status: domain.StatusRunning}
+
+	repo.On("ListAllDeployments", mock.Anything).Return([]*domain.Deployment{dep}, nil).Once()
+	repo.On("GetContainers", mock.Anything, depID).Return([]uuid.UUID{instID}, nil).Once()
+	instanceSvc.On("GetInstance", mock.Anything, instID.String()).Return(inst, nil).Once()
+
+	worker.Reconcile(ctx)
+
+	repo.AssertExpectations(t)
+	instanceSvc.AssertExpectations(t)
+}
+
+func testContainerWorkerReconcileListDeploymentsError(t *testing.T) {
+	worker, repo, _ := setupContainerWorkerTest(t)
+	ctx := context.Background()
+
+	repo.On("ListAllDeployments", mock.Anything).Return(nil, assert.AnError).Once()
+
+	worker.Reconcile(ctx)
+
+	repo.AssertExpectations(t)
+}

--- a/internal/core/services/cron_worker_unit_test.go
+++ b/internal/core/services/cron_worker_unit_test.go
@@ -1,0 +1,46 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func setupCronWorkerTest(t *testing.T) (*services.CronWorker, *MockCronRepository) {
+	t.Helper()
+	repo := new(MockCronRepository)
+	worker := services.NewCronWorker(repo)
+	return worker, repo
+}
+
+func TestCronWorker_Unit(t *testing.T) {
+	t.Run("ProcessJobs_Empty", testCronWorkerProcessJobsEmpty)
+	t.Run("ProcessJobs_ClaimError", testCronWorkerProcessJobsClaimError)
+}
+
+func testCronWorkerProcessJobsEmpty(t *testing.T) {
+	worker, repo := setupCronWorkerTest(t)
+	ctx := context.Background()
+
+	repo.On("ClaimNextJobsToRun", mock.Anything, services.ClaimTimeout).Return([]*domain.CronJob{}, nil).Once()
+
+	worker.ProcessJobs(ctx)
+
+	repo.AssertExpectations(t)
+}
+
+func testCronWorkerProcessJobsClaimError(t *testing.T) {
+	worker, repo := setupCronWorkerTest(t)
+	ctx := context.Background()
+
+	repo.On("ClaimNextJobsToRun", mock.Anything, services.ClaimTimeout).Return(nil, assert.AnError).Once()
+
+	worker.ProcessJobs(ctx)
+
+	repo.AssertExpectations(t)
+}
+

--- a/internal/core/services/event_unit_test.go
+++ b/internal/core/services/event_unit_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testEventServiceCRUD(t *testing.T) {
+func testEventServiceUnitCRUD(t *testing.T) {
 	mockRepo := new(MockEventRepo)
 
 	ctx := context.Background()
@@ -152,11 +152,11 @@ func testEventServiceCRUD(t *testing.T) {
 }
 
 func TestEventService_Unit(t *testing.T) {
-	t.Run("CRUD", testEventServiceCRUD)
-	t.Run("NewEventService", testNewEventService)
+	t.Run("CRUD", testEventServiceUnitCRUD)
+	t.Run("NewEventService", testNewEventServiceUnit)
 }
 
-func testNewEventService(t *testing.T) {
+func testNewEventServiceUnit(t *testing.T) {
 	t.Run("NilLogger_UsesDefault", func(t *testing.T) {
 		svc := services.NewEventService(services.EventServiceParams{
 			Repo:    new(MockEventRepo),

--- a/internal/core/services/secret_unit_test.go
+++ b/internal/core/services/secret_unit_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testSecretServiceCRUD(t *testing.T) {
+func testSecretServiceUnitCRUD(t *testing.T) {
 	mockRepo := new(MockSecretRepo)
 	mockRBAC := new(MockRBACService)
 	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -267,12 +267,12 @@ func testSecretServiceCRUD(t *testing.T) {
 }
 
 func TestSecretService_Unit(t *testing.T) {
-	t.Run("CRUD", testSecretServiceCRUD)
-	t.Run("NewErrors", testNewSecretServiceErrors)
-	t.Run("AuthorizeErrors", testSecretServiceAuthorizeErrors)
+	t.Run("CRUD", testSecretServiceUnitCRUD)
+	t.Run("NewErrors", testNewSecretServiceUnitErrors)
+	t.Run("AuthorizeErrors", testSecretServiceUnitAuthorizeErrors)
 }
 
-func testNewSecretServiceErrors(t *testing.T) {
+func testNewSecretServiceUnitErrors(t *testing.T) {
 	logger := slog.Default()
 	masterKey := "test-master-key-32-chars-long-!!!"
 
@@ -382,7 +382,7 @@ func testNewSecretServiceErrors(t *testing.T) {
 	})
 }
 
-func testSecretServiceAuthorizeErrors(t *testing.T) {
+func testSecretServiceUnitAuthorizeErrors(t *testing.T) {
 	mockRepo := new(MockSecretRepo)
 	mockRBAC := new(MockRBACService)
 	mockEvent := new(MockEventService)

--- a/internal/core/services/ssh_key_unit_test.go
+++ b/internal/core/services/ssh_key_unit_test.go
@@ -18,7 +18,7 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func testSSHKeyServiceCRUD(t *testing.T) {
+func testSSHKeyServiceUnitCRUD(t *testing.T) {
 	mockRepo := new(MockSSHKeyRepo)
 	rbacSvc := new(MockRBACService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -119,13 +119,13 @@ func testSSHKeyServiceCRUD(t *testing.T) {
 }
 
 func TestSSHKeyService_Unit(t *testing.T) {
-	t.Run("CRUD", testSSHKeyServiceCRUD)
-	t.Run("NewErrors", testNewSSHKeyServiceErrors)
-	t.Run("CreateKeyErrors", testSSHKeyServiceCreateKeyErrors)
-	t.Run("GetKeyErrors", testSSHKeyServiceGetKeyErrors)
+	t.Run("CRUD", testSSHKeyServiceUnitCRUD)
+	t.Run("NewErrors", testNewSSHKeyServiceUnitErrors)
+	t.Run("CreateKeyErrors", testSSHKeyServiceUnitCreateKeyErrors)
+	t.Run("GetKeyErrors", testSSHKeyServiceUnitGetKeyErrors)
 }
 
-func testNewSSHKeyServiceErrors(t *testing.T) {
+func testNewSSHKeyServiceUnitErrors(t *testing.T) {
 	t.Run("NilRepo", func(t *testing.T) {
 		rbacSvc := new(MockRBACService)
 		_, err := services.NewSSHKeyService(services.SSHKeyServiceParams{
@@ -147,7 +147,7 @@ func testNewSSHKeyServiceErrors(t *testing.T) {
 	})
 }
 
-func testSSHKeyServiceCreateKeyErrors(t *testing.T) {
+func testSSHKeyServiceUnitCreateKeyErrors(t *testing.T) {
 	mockRepo := new(MockSSHKeyRepo)
 	rbacSvc := new(MockRBACService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -192,7 +192,7 @@ func testSSHKeyServiceCreateKeyErrors(t *testing.T) {
 	})
 }
 
-func testSSHKeyServiceGetKeyErrors(t *testing.T) {
+func testSSHKeyServiceUnitGetKeyErrors(t *testing.T) {
 	mockRepo := new(MockSSHKeyRepo)
 	rbacSvc := new(MockRBACService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)


### PR DESCRIPTION
## Summary

Rename helper functions in 4 test files to follow the `testXxxUnitYyy` naming convention, making them identifiable by `go test -run "..._Unit"`.

- **cloudlogs**: `testCloudLogsServiceIngestLogs` → `testCloudLogsServiceUnitIngestLogs`
- **event**: `testEventServiceCRUD` → `testEventServiceUnitCRUD`, `testNewEventService` → `testNewEventServiceUnit`
- **ssh_key**: all 4 helpers renamed with Unit prefix
- **secret**: all 3 helpers renamed with Unit prefix

## Test plan

```bash
go test ./internal/core/services/ -run "CloudLogsService_Unit|EventService_Unit|SSHKeyService_Unit|SecretService_Unit" -v
```