### PR TITLE
fix(database): add rollback on vault failure in RotateCredentials

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -407,7 +407,7 @@ Users can trigger automated password rotation for their database instances.
 - **Workflow**:
     1.  **Generate Password**: A new 16-character secure password is generated.
     2.  **Engine Update**: The `ALTER USER` command is executed inside the database container first to apply the new password.
-    3.  **Update Vault**: The new secret is written to Vault. (Note: A failure here may leave the database and Vault out of sync).
+    3.  **Update Vault**: The new secret is written to Vault. If Vault store fails after the DB password has been changed, the system automatically rolls back the database password to the original value to maintain consistency.
     4.  **Sidecar Update**: Sidecars such as PgBouncer/pooler are automatically recreated to apply the new credentials only when they are present.
     5.  **Audit**: The rotation event is recorded in the system events and audit logs.
 

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -750,9 +750,13 @@ func (s *DatabaseService) waitForDatabaseReady(ctx context.Context, db *domain.D
 func (s *DatabaseService) RotateCredentials(ctx context.Context, id uuid.UUID, idempotencyKey string) error {
 	if idempotencyKey != "" {
 		s.rotationMu.Lock()
-		if cachedAt, ok := s.rotationCache[idempotencyKey]; ok && time.Since(cachedAt) < s.rotationCacheTTL {
-			s.rotationMu.Unlock()
-			return nil // Already rotated
+		if cachedAt, ok := s.rotationCache[idempotencyKey]; ok {
+			if time.Since(cachedAt) < s.rotationCacheTTL {
+				s.rotationMu.Unlock()
+				return nil // Already rotated
+			}
+			// Expired entry - remove it to prevent unbounded map growth
+			delete(s.rotationCache, idempotencyKey)
 		}
 		s.rotationMu.Unlock()
 	}

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -509,11 +509,20 @@ func (s *DatabaseService) PromoteToPrimary(ctx context.Context, id uuid.UUID) er
 	var cmd []string
 	switch db.Engine {
 	case domain.EnginePostgres:
-		// Use pg_promote() function via psql
-		cmd = []string{"psql", "-h", "127.0.0.1", "-U", db.Username, "-d", "postgres", "-c", "SELECT pg_promote();"}
+		// Use pg_ctl promote - recommended approach for PostgreSQL replica promotion
+		cmd = []string{"pg_ctl", "promote", "-D", "/var/lib/postgresql/data"}
 	case domain.EngineMySQL:
-		// Stop replication and reset replica configuration
-		cmd = []string{"mysql", "-u", "root", "-p" + db.Password, "-e", "STOP REPLICA; RESET REPLICA ALL;"}
+		// Fetch current password from Vault (db.Password may be stale after rotation)
+		password := db.Password
+		if db.CredentialPath != "" {
+			secret, err := s.secrets.GetSecret(ctx, db.CredentialPath)
+			if err == nil && secret != nil {
+				if p, ok := secret["password"].(string); ok {
+					password = p
+				}
+			}
+		}
+		cmd = []string{"mysql", "-u", "root", "-p" + password, "-e", "STOP REPLICA; RESET REPLICA ALL;"}
 	default:
 		return errors.New(errors.Internal, "unsupported engine for promotion")
 	}

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -53,7 +53,9 @@ type DatabaseService struct {
 	volumeEncryption  ports.VolumeEncryptionService
 	logger            *slog.Logger
 	vaultMountPath    string
-	// Simple in-memory idempotency cache for rotation with TTL-based eviction
+	// In-memory idempotency cache for rotation. Stores timestamp of last rotation attempt.
+	// Expired entries are deleted on lookup to prevent unbounded growth, but this does
+	// not guarantee all expired entries are reaped.
 	rotationCache     map[string]time.Time
 	rotationCacheTTL time.Duration
 	rotationMu        sync.Mutex
@@ -814,9 +816,10 @@ func (s *DatabaseService) RotateCredentials(ctx context.Context, id uuid.UUID, i
 		rollbackCmd := s.buildPasswordChangeCmd(db.Engine, db.Username, currentPassword)
 		if _, rollbackErr := s.compute.Exec(ctx, db.ContainerID, rollbackCmd); rollbackErr != nil {
 			// Rollback also failed - system is in critical state requiring manual intervention
+			// Wrap rollbackErr as cause so operators can see why rollback failed
 			return errors.Wrap(errors.Internal,
-				"credential rotation failed and rollback also failed - manual intervention required",
-				err)
+				fmt.Sprintf("credential rotation failed and rollback also failed - manual intervention required (vault store error: %v)", err),
+				rollbackErr)
 		}
 		return errors.Wrap(errors.Internal, "vault store failed, DB password rolled back", err)
 	}

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -509,8 +509,9 @@ func (s *DatabaseService) PromoteToPrimary(ctx context.Context, id uuid.UUID) er
 	var cmd []string
 	switch db.Engine {
 	case domain.EnginePostgres:
-		// Use pg_ctl promote - recommended approach for PostgreSQL replica promotion
-		cmd = []string{"pg_ctl", "promote", "-D", "/var/lib/postgresql/data"}
+		// Use postgres --promote to promote the replica
+		// This sends a fast promotion signal to the running server
+		cmd = []string{"postgres", "--promote"}
 	case domain.EngineMySQL:
 		// Fetch current password from Vault (db.Password may be stale after rotation)
 		password := db.Password

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -53,8 +53,9 @@ type DatabaseService struct {
 	volumeEncryption  ports.VolumeEncryptionService
 	logger            *slog.Logger
 	vaultMountPath    string
-	// Simple in-memory idempotency cache for rotation
-	rotationCache     map[string]bool
+	// Simple in-memory idempotency cache for rotation with TTL-based eviction
+	rotationCache     map[string]time.Time
+	rotationCacheTTL time.Duration
 	rotationMu        sync.Mutex
 }
 
@@ -94,7 +95,8 @@ func NewDatabaseService(params DatabaseServiceParams) *DatabaseService {
 		volumeEncryption: params.VolumeEncryption,
 		logger:           params.Logger,
 		vaultMountPath:   params.VaultMountPath,
-		rotationCache:    make(map[string]bool),
+		rotationCache:    make(map[string]time.Time),
+		rotationCacheTTL: 24 * time.Hour,
 	}
 }
 
@@ -502,6 +504,24 @@ func (s *DatabaseService) PromoteToPrimary(ctx context.Context, id uuid.UUID) er
 	if db.Role == domain.RolePrimary {
 		return errors.New(errors.InvalidInput, "database is already a primary")
 	}
+
+	// Execute database engine promotion command in container
+	var cmd []string
+	switch db.Engine {
+	case domain.EnginePostgres:
+		// Use pg_promote() function via psql
+		cmd = []string{"psql", "-h", "127.0.0.1", "-U", db.Username, "-d", "postgres", "-c", "SELECT pg_promote();"}
+	case domain.EngineMySQL:
+		// Stop replication and reset replica configuration
+		cmd = []string{"mysql", "-u", "root", "-p" + db.Password, "-e", "STOP REPLICA; RESET REPLICA ALL;"}
+	default:
+		return errors.New(errors.Internal, "unsupported engine for promotion")
+	}
+
+	if _, err := s.compute.Exec(ctx, db.ContainerID, cmd); err != nil {
+		return errors.Wrap(errors.Internal, "failed to promote database engine", err)
+	}
+
 	db.Role = domain.RolePrimary
 	db.PrimaryID = nil
 	if err := s.repo.Update(ctx, db); err != nil {
@@ -720,7 +740,7 @@ func (s *DatabaseService) waitForDatabaseReady(ctx context.Context, db *domain.D
 func (s *DatabaseService) RotateCredentials(ctx context.Context, id uuid.UUID, idempotencyKey string) error {
 	if idempotencyKey != "" {
 		s.rotationMu.Lock()
-		if s.rotationCache[idempotencyKey] {
+		if cachedAt, ok := s.rotationCache[idempotencyKey]; ok && time.Since(cachedAt) < s.rotationCacheTTL {
 			s.rotationMu.Unlock()
 			return nil // Already rotated
 		}
@@ -811,7 +831,7 @@ func (s *DatabaseService) RotateCredentials(ctx context.Context, id uuid.UUID, i
 
 	if idempotencyKey != "" {
 		s.rotationMu.Lock()
-		s.rotationCache[idempotencyKey] = true
+		s.rotationCache[idempotencyKey] = time.Now()
 		s.rotationMu.Unlock()
 	}
 

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -810,9 +810,15 @@ func (s *DatabaseService) RotateCredentials(ctx context.Context, id uuid.UUID, i
 		vaultPath = s.getVaultPath(db.ID)
 	}
 	if err := s.secrets.StoreSecret(ctx, vaultPath, map[string]interface{}{"password": newPassword}); err != nil {
-		// Note: At this point DB password is changed but Vault update failed.
-		// The system is out of sync. Fallback password in DB record remains old.
-		return errors.Wrap(errors.Internal, "database password updated but failed to store in vault", err)
+		// Vault store failed but DB already has new password - rollback to original
+		rollbackCmd := s.buildPasswordChangeCmd(db.Engine, db.Username, currentPassword)
+		if _, rollbackErr := s.compute.Exec(ctx, db.ContainerID, rollbackCmd); rollbackErr != nil {
+			// Rollback also failed - system is in critical state requiring manual intervention
+			return errors.Wrap(errors.Internal,
+				"credential rotation failed and rollback also failed - manual intervention required",
+				err)
+		}
+		return errors.Wrap(errors.Internal, "vault store failed, DB password rolled back", err)
 	}
 
 	// 3. Update DB record if needed (metadata or path)
@@ -1034,6 +1040,16 @@ func (s *DatabaseService) getPoolerConfig(engine domain.DatabaseEngine, dbIP, us
 		return PoolerImage, env, PoolerInternalPort
 	}
 	return "", nil, ""
+}
+
+func (s *DatabaseService) buildPasswordChangeCmd(engine domain.DatabaseEngine, username, password string) []string {
+	switch engine {
+	case domain.EnginePostgres:
+		return []string{"psql", "-h", "127.0.0.1", "-U", username, "-d", "postgres", "-c", fmt.Sprintf("ALTER USER %s WITH PASSWORD '%s';", username, password)}
+	case domain.EngineMySQL:
+		return []string{"mysql", "-u", "root", "-p" + password, "-e", fmt.Sprintf("ALTER USER '%s'@'%%' IDENTIFIED BY '%s';", username, password)}
+	}
+	return nil
 }
 
 func (s *DatabaseService) buildEngineCmd(engine domain.DatabaseEngine, parameters map[string]string) []string {

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -509,9 +509,9 @@ func (s *DatabaseService) PromoteToPrimary(ctx context.Context, id uuid.UUID) er
 	var cmd []string
 	switch db.Engine {
 	case domain.EnginePostgres:
-		// Use postgres --promote to promote the replica
-		// This sends a fast promotion signal to the running server
-		cmd = []string{"postgres", "--promote"}
+		// Create promotion trigger file - PostgreSQL monitors this file
+		// and exits recovery mode when it appears
+		cmd = []string{"touch", "/var/lib/postgresql/data/promote"}
 	case domain.EngineMySQL:
 		// Fetch current password from Vault (db.Password may be stale after rotation)
 		password := db.Password

--- a/internal/core/services/database_unit_test.go
+++ b/internal/core/services/database_unit_test.go
@@ -142,8 +142,9 @@ func TestDatabaseServiceUnitExtended(t *testing.T) {
 
 	t.Run("PromoteToPrimary", func(t *testing.T) {
 		dbID := uuid.New()
-		db := &domain.Database{ID: dbID, Role: domain.RoleReplica}
+		db := &domain.Database{ID: dbID, Role: domain.RoleReplica, Engine: domain.EnginePostgres, Username: "user", Password: "pass", ContainerID: "test-container"}
 		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
+		mockCompute.On("Exec", mock.Anything, "test-container", mock.Anything).Return("", nil).Once()
 		mockRepo.On("Update", mock.Anything, mock.MatchedBy(func(d *domain.Database) bool {
 			return d.Role == domain.RolePrimary
 		})).Return(nil).Once()

--- a/internal/core/services/database_vault_test.go
+++ b/internal/core/services/database_vault_test.go
@@ -99,17 +99,22 @@ func TestDatabaseService_RotateCredentials(t *testing.T) {
 		mockRepo.AssertExpectations(t)
 	})
 
-	t.Run("RotateCredentials_VaultFailure", func(t *testing.T) {
+	t.Run("RotateCredentials_VaultFailure_WithRollback", func(t *testing.T) {
 		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
 		mockSecrets.On("GetSecret", mock.Anything, db.CredentialPath).Return(map[string]interface{}{"password": "old-pass"}, nil).Once()
+		// First Exec: ALTER USER with new password (succeeds)
 		mockCompute.On("Exec", mock.Anything, db.ContainerID, mock.Anything).Return("ALTER ROLE", nil).Once()
+		// Vault store fails
 		mockSecrets.On("StoreSecret", mock.Anything, db.CredentialPath, mock.Anything).Return(fmt.Errorf("vault error")).Once()
+		// Second Exec: rollback to original password (succeeds)
+		mockCompute.On("Exec", mock.Anything, db.ContainerID, mock.Anything).Return("ALTER ROLE", nil).Once()
 
 		err := svc.RotateCredentials(ctx, dbID, "")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "database password updated but failed to store in vault")
+		assert.Contains(t, err.Error(), "vault store failed, DB password rolled back")
 
 		mockSecrets.AssertExpectations(t)
+		mockCompute.AssertExpectations(t)
 		mockRepo.AssertExpectations(t)
 	})
 }

--- a/internal/repositories/noop/adapters.go
+++ b/internal/repositories/noop/adapters.go
@@ -759,3 +759,24 @@ func (s *NoopDatabaseService) ListDatabaseSnapshots(ctx context.Context, databas
 func (s *NoopDatabaseService) RestoreDatabase(ctx context.Context, req ports.RestoreDatabaseRequest) (*domain.Database, error) {
 	return &domain.Database{ID: uuid.New(), Name: req.NewName, Role: domain.RolePrimary}, nil
 }
+func (s *NoopDatabaseService) CreateReplica(ctx context.Context, primaryID uuid.UUID, name string) (*domain.Database, error) {
+	return &domain.Database{ID: uuid.New(), Name: name, Role: domain.RoleReplica}, nil
+}
+func (s *NoopDatabaseService) PromoteToPrimary(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+func (s *NoopDatabaseService) GetDatabase(ctx context.Context, id uuid.UUID) (*domain.Database, error) {
+	return &domain.Database{ID: id, Name: "noop-db", Role: domain.RolePrimary}, nil
+}
+func (s *NoopDatabaseService) ListDatabases(ctx context.Context) ([]*domain.Database, error) {
+	return []*domain.Database{}, nil
+}
+func (s *NoopDatabaseService) RotateCredentials(ctx context.Context, id uuid.UUID, idempotencyKey string) error {
+	return nil
+}
+func (s *NoopDatabaseService) StopDatabase(ctx context.Context, id uuid.UUID) error {
+	return nil
+}
+func (s *NoopDatabaseService) StartDatabase(ctx context.Context, id uuid.UUID) error {
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add automatic rollback when vault store fails after DB password change
- Previously the system would be left in an inconsistent state (DB has new password, vault has old)
- Added `buildPasswordChangeCmd` helper for generating password change/rollback commands
- Updated test to verify rollback behavior on vault failure

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/services/... -run RotateCredentials`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Credential rotation now includes automatic database password rollback if Vault write fails, maintaining consistency between the database and secrets manager
- Database promotion to primary now executes engine-specific operations: PostgreSQL creates a promotion trigger file; MySQL stops replication

**Documentation**
- Updated credential rotation workflow documentation to reflect automatic rollback behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->