### PR TITLE
feat(serverless): function update and environment variables

### DIFF
--- a/cmd/cloud/function.go
+++ b/cmd/cloud/function.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+	"github.com/poyrazk/thecloud/pkg/sdk"
 )
 
 var functionCmd = &cobra.Command{
@@ -179,6 +181,67 @@ var rmFnCmd = &cobra.Command{
 	},
 }
 
+var updateFnCmd = &cobra.Command{
+	Use:   "update [name/id]",
+	Short: "Update a function's configuration",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		id := args[0]
+		client := createClient(opts)
+
+		targetID := id
+		functions, err := client.ListFunctions()
+		if err == nil {
+			for _, f := range functions {
+				if f.Name == id {
+					targetID = f.ID
+					break
+				}
+			}
+		}
+
+		handler, _ := cmd.Flags().GetString("handler")
+		timeout, _ := cmd.Flags().GetInt("timeout")
+		memory, _ := cmd.Flags().GetInt("memory")
+		status, _ := cmd.Flags().GetString("status")
+		envVarsStr, _ := cmd.Flags().GetStringSlice("env")
+		hasEnvVars := cmd.Flags().Changed("env")
+
+		update := &sdk.FunctionUpdate{}
+		if cmd.Flags().Changed("handler") {
+			update.Handler = &handler
+		}
+		if cmd.Flags().Changed("timeout") {
+			update.Timeout = &timeout
+		}
+		if cmd.Flags().Changed("memory") {
+			update.MemoryMB = &memory
+		}
+		if cmd.Flags().Changed("status") {
+			update.Status = &status
+		}
+		if hasEnvVars {
+			envVars := make([]*sdk.EnvVar, len(envVarsStr))
+			for i, e := range envVarsStr {
+				parts := strings.SplitN(e, "=", 2)
+				if len(parts) != 2 {
+					return fmt.Errorf("env flag must be KEY=VALUE: %s", e)
+				}
+				envVars[i] = &sdk.EnvVar{Key: parts[0], Value: parts[1]}
+			}
+			update.EnvVars = envVars
+		}
+
+		fn, err := client.UpdateFunction(targetID, update)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Function %s updated (ID: %s)\n", fn.Name, fn.ID)
+		return nil
+	},
+}
+
 func init() {
 	createFnCmd.Flags().StringP("name", "n", "", "Function name")
 	createFnCmd.Flags().StringP("runtime", "r", "nodejs20", "Runtime (nodejs20, python312, go122, ruby33, java21)")
@@ -191,9 +254,16 @@ func init() {
 	invokeFnCmd.Flags().StringP("payload-file", "f", "", "Path to payload file")
 	invokeFnCmd.Flags().BoolP("async", "a", false, "Invoke asynchronously")
 
+	updateFnCmd.Flags().StringP("handler", "H", "", "Handler name")
+	updateFnCmd.Flags().IntP("timeout", "t", 0, "Timeout in seconds (1-900)")
+	updateFnCmd.Flags().IntP("memory", "m", 0, "Memory in MB (64-10240)")
+	updateFnCmd.Flags().StringP("status", "s", "", "Status (ACTIVE or INACTIVE)")
+	updateFnCmd.Flags().StringSliceP("env", "e", nil, "Environment variable KEY=VALUE (can be repeated)")
+
 	functionCmd.AddCommand(createFnCmd)
 	functionCmd.AddCommand(listFnCmd)
 	functionCmd.AddCommand(invokeFnCmd)
 	functionCmd.AddCommand(logsFnCmd)
 	functionCmd.AddCommand(rmFnCmd)
+	functionCmd.AddCommand(updateFnCmd)
 }

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -59,8 +59,33 @@ cloud fn invoke hello --payload '{"name": "Antigravity"}' --async
 Each invocation runs in a fresh Docker container with:
 - **No Network Access**: The container cannot reach the internet or other services.
 - **Read-Only Root Filesystem**: The container cannot modify its environment.
-- **Resource Limits**: 128MB RAM and 0.5 CPU by default.
+- **Resource Limits**: 128MB RAM and 0.5 CPU by default. Adjust with `cloud fn update --memory`.
 - **Process Limits**: A limit of 50 PIDs to prevent fork bombs.
+
+## Updating a Function
+
+You can update a function's handler, timeout, memory allocation, and environment variables without recreating it.
+
+### Update Timeout and Memory
+
+```bash
+cloud fn update hello --timeout 60 --memory 256
+```
+
+Timeout must be between 1 and 900 seconds. Memory must be between 64 and 10240 MB.
+
+### Update Environment Variables
+
+Environment variables are injected into the container at runtime and accessible via `process.env` (Node.js) or `os.environ` (Python).
+
+```bash
+cloud fn update hello --env DATABASE_URL=postgres://localhost/mydb --env DEBUG=true
+```
+
+To clear all environment variables, pass an empty env list:
+```bash
+cloud fn update hello --env ""
+```
 
 ## Viewing Logs
 
@@ -69,3 +94,15 @@ You can view the logs of the last 100 invocations:
 ```bash
 cloud fn logs hello
 ```
+
+## Environment Variables
+
+All functions have access to the following built-in environment variable:
+
+| Variable | Description |
+|----------|-------------|
+| `PAYLOAD` | The JSON payload passed during invocation |
+
+Custom environment variables are set at the function level via `cloud fn update --env KEY=VALUE`. They are available at runtime just like `PAYLOAD`.
+
+Functions run with a completely isolated network and a read-only filesystem. Environment variables are the only way to pass configuration to your function at runtime.

--- a/docs/prds/serverless-function-update-and-env-vars.md
+++ b/docs/prds/serverless-function-update-and-env-vars.md
@@ -1,0 +1,64 @@
+# PRD: CloudFunctions — Function Update & Environment Variables
+
+## Problem Statement
+
+CloudFunctions currently only supports two operations after creation: invoke and delete. Users cannot:
+
+- Adjust timeout or memory without deleting and recreating the function (which changes the function ID and breaks any references)
+- Set environment variables, meaning functions cannot connect to databases, access secrets, or receive runtime configuration without hardcoding values
+
+This blocks production use cases where runtime parameters change across environments (dev/staging/prod).
+
+## User Stories
+
+- **As a Developer**, I want to update a function's timeout and memory without deleting it, so that I can tune performance without breaking existing integrations.
+- **As a Developer**, I want to set environment variables for my function, so that it can connect to my database using `DATABASE_URL` without hardcoding credentials.
+- **As an Operator**, I want to enable/disable a function by toggling its status, so that I can temporarily halt execution without deleting the function.
+
+## Acceptance Criteria
+
+- [x] `PATCH /functions/:id` endpoint accepts partial updates (timeout, memory, handler, status, env_vars)
+- [x] New `env_vars` JSONB column stored in the `functions` table
+- [x] Environment variables are injected into the Docker container at invocation time as `KEY=value`
+- [x] `cloud fn update` CLI command supports `--timeout`, `--memory`, `--handler`, `--status`, `--env KEY=VALUE`
+- [x] Go SDK exposes `UpdateFunction` method
+- [x] Timeout validated 1–900 seconds; memory validated 64–10240 MB
+- [x] Audit log entry written on function update
+- [x] Unit and handler tests added
+
+## UX / CLI Design
+
+```bash
+# Update timeout and memory
+cloud fn update my-func --timeout 120 --memory 512
+
+# Set environment variables
+cloud fn update my-func --env DATABASE_URL=postgres://prod/db --env DEBUG=false
+
+# Disable a function
+cloud fn update my-func --status INACTIVE
+
+# View current configuration
+cloud fn list
+```
+
+**API:**
+
+```http
+PATCH /functions/:id
+Content-Type: application/json
+
+{
+  "timeout": 120,
+  "memory_mb": 512,
+  "env_vars": [
+    { "key": "DATABASE_URL", "value": "postgres://prod/db" }
+  ]
+}
+```
+
+## Out of Scope
+
+- Secret references in env vars (e.g. `$SECRET:my-api-key`) — tracked in a separate PR
+- Per-invocation timeout override — tracked in the concurrency limits PR
+- Function code re-deploy without ID change — tracked in a separate PR

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -10427,17 +10427,24 @@ const docTemplate = `{
                 }
             }
         }
+    },
+    "securityDefinitions": {
+        "APIKeyAuth": {
+            "type": "apiKey",
+            "name": "X-API-Key",
+            "in": "header"
+        }
     }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "",
+	Version:          "1.0",
 	Host:             "",
 	BasePath:         "",
 	Schemes:          []string{},
-	Title:            "",
-	Description:      "",
+	Title:            "The Cloud API",
+	Description:      "The Cloud - Multi-tenant Cloud Infrastructure Engine",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -2551,6 +2551,64 @@ const docTemplate = `{
                 }
             }
         },
+        "/functions/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Updates a function's timeout, memory, handler, status, or environment variables",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "functions"
+                ],
+                "summary": "Update function",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Function ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.FunctionUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Function"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/gateway/routes": {
             "get": {
                 "security": [
@@ -7588,6 +7646,17 @@ const docTemplate = `{
                 "EIPStatusReleased"
             ]
         },
+        "domain.EnvVar": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Event": {
             "type": "object",
             "properties": {
@@ -7613,6 +7682,59 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "tenant_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Function": {
+            "type": "object",
+            "properties": {
+                "code_path": {
+                    "description": "Path to code artifact",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "env_vars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.EnvVar"
+                    }
+                },
+                "handler": {
+                    "description": "Entry point (e.g. \"main.Handle\")",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "memory_mb": {
+                    "description": "Memory allocation",
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "description": "e.g. \"python3.9\", \"go1.21\"",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "e.g. \"DEPLOYING\", \"READY\"",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "description": "Execution timeout in seconds",
+                    "type": "integer"
+                },
+                "updated_at": {
                     "type": "string"
                 },
                 "user_id": {
@@ -8355,6 +8477,7 @@ const docTemplate = `{
                 "function:create",
                 "function:delete",
                 "function:read",
+                "function:update",
                 "cache:create",
                 "cache:delete",
                 "cache:read",
@@ -8467,6 +8590,7 @@ const docTemplate = `{
                 "PermissionFunctionCreate",
                 "PermissionFunctionDelete",
                 "PermissionFunctionRead",
+                "PermissionFunctionUpdate",
                 "PermissionCacheCreate",
                 "PermissionCacheDelete",
                 "PermissionCacheRead",
@@ -9871,6 +9995,20 @@ const docTemplate = `{
                 }
             }
         },
+        "httphandlers.EnvVarRequest": {
+            "type": "object",
+            "required": [
+                "key"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.ForgotPasswordRequest": {
             "type": "object",
             "required": [
@@ -9879,6 +10017,29 @@ const docTemplate = `{
             "properties": {
                 "email": {
                     "type": "string"
+                }
+            }
+        },
+        "httphandlers.FunctionUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "env_vars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/httphandlers.EnvVarRequest"
+                    }
+                },
+                "handler": {
+                    "type": "string"
+                },
+                "memory_mb": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "integer"
                 }
             }
         },
@@ -10266,24 +10427,17 @@ const docTemplate = `{
                 }
             }
         }
-    },
-    "securityDefinitions": {
-        "APIKeyAuth": {
-            "type": "apiKey",
-            "name": "X-API-Key",
-            "in": "header"
-        }
     }
 }`
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.0",
+	Version:          "",
 	Host:             "",
 	BasePath:         "",
 	Schemes:          []string{},
-	Title:            "The Cloud API",
-	Description:      "The Cloud - Multi-tenant Cloud Infrastructure Engine",
+	Title:            "",
+	Description:      "",
 	InfoInstanceName: "swagger",
 	SwaggerTemplate:  docTemplate,
 	LeftDelim:        "{{",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1,7 +1,10 @@
 {
     "swagger": "2.0",
     "info": {
-        "contact": {}
+        "description": "The Cloud - Multi-tenant Cloud Infrastructure Engine",
+        "title": "The Cloud API",
+        "contact": {},
+        "version": "1.0"
     },
     "paths": {
         "/api/dashboard/events": {
@@ -10415,6 +10418,13 @@
                     "$ref": "#/definitions/domain.ClusterStatus"
                 }
             }
+        }
+    },
+    "securityDefinitions": {
+        "APIKeyAuth": {
+            "type": "apiKey",
+            "name": "X-API-Key",
+            "in": "header"
         }
     }
 }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -1,10 +1,7 @@
 {
     "swagger": "2.0",
     "info": {
-        "description": "The Cloud - Multi-tenant Cloud Infrastructure Engine",
-        "title": "The Cloud API",
-        "contact": {},
-        "version": "1.0"
+        "contact": {}
     },
     "paths": {
         "/api/dashboard/events": {
@@ -2536,6 +2533,64 @@
                     },
                     "500": {
                         "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/functions/{id}": {
+            "patch": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Updates a function's timeout, memory, handler, status, or environment variables",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "functions"
+                ],
+                "summary": "Update function",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Function ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Update request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.FunctionUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Function"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
                         "schema": {
                             "$ref": "#/definitions/httputil.Response"
                         }
@@ -7580,6 +7635,17 @@
                 "EIPStatusReleased"
             ]
         },
+        "domain.EnvVar": {
+            "type": "object",
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.Event": {
             "type": "object",
             "properties": {
@@ -7605,6 +7671,59 @@
                     "type": "string"
                 },
                 "tenant_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.Function": {
+            "type": "object",
+            "properties": {
+                "code_path": {
+                    "description": "Path to code artifact",
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "env_vars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.EnvVar"
+                    }
+                },
+                "handler": {
+                    "description": "Entry point (e.g. \"main.Handle\")",
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "memory_mb": {
+                    "description": "Memory allocation",
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "runtime": {
+                    "description": "e.g. \"python3.9\", \"go1.21\"",
+                    "type": "string"
+                },
+                "status": {
+                    "description": "e.g. \"DEPLOYING\", \"READY\"",
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "description": "Execution timeout in seconds",
+                    "type": "integer"
+                },
+                "updated_at": {
                     "type": "string"
                 },
                 "user_id": {
@@ -8347,6 +8466,7 @@
                 "function:create",
                 "function:delete",
                 "function:read",
+                "function:update",
                 "cache:create",
                 "cache:delete",
                 "cache:read",
@@ -8459,6 +8579,7 @@
                 "PermissionFunctionCreate",
                 "PermissionFunctionDelete",
                 "PermissionFunctionRead",
+                "PermissionFunctionUpdate",
                 "PermissionCacheCreate",
                 "PermissionCacheDelete",
                 "PermissionCacheRead",
@@ -9863,6 +9984,20 @@
                 }
             }
         },
+        "httphandlers.EnvVarRequest": {
+            "type": "object",
+            "required": [
+                "key"
+            ],
+            "properties": {
+                "key": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.ForgotPasswordRequest": {
             "type": "object",
             "required": [
@@ -9871,6 +10006,29 @@
             "properties": {
                 "email": {
                     "type": "string"
+                }
+            }
+        },
+        "httphandlers.FunctionUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "env_vars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/httphandlers.EnvVarRequest"
+                    }
+                },
+                "handler": {
+                    "type": "string"
+                },
+                "memory_mb": {
+                    "type": "integer"
+                },
+                "status": {
+                    "type": "string"
+                },
+                "timeout": {
+                    "type": "integer"
                 }
             }
         },
@@ -10257,13 +10415,6 @@
                     "$ref": "#/definitions/domain.ClusterStatus"
                 }
             }
-        }
-    },
-    "securityDefinitions": {
-        "APIKeyAuth": {
-            "type": "apiKey",
-            "name": "X-API-Key",
-            "in": "header"
         }
     }
 }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2363,6 +2363,9 @@ definitions:
     type: object
 info:
   contact: {}
+  description: The Cloud - Multi-tenant Cloud Infrastructure Engine
+  title: The Cloud API
+  version: "1.0"
 paths:
   /api/dashboard/events:
     get:
@@ -6846,4 +6849,9 @@ paths:
       summary: Get VPC details
       tags:
       - vpcs
+securityDefinitions:
+  APIKeyAuth:
+    in: header
+    name: X-API-Key
+    type: apiKey
 swagger: "2.0"

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -377,6 +377,13 @@ definitions:
     - EIPStatusAllocated
     - EIPStatusAssociated
     - EIPStatusReleased
+  domain.EnvVar:
+    properties:
+      key:
+        type: string
+      value:
+        type: string
+    type: object
   domain.Event:
     properties:
       action:
@@ -395,6 +402,43 @@ definitions:
         description: Classification of the resource (e.g., "INSTANCE", "VPC")
         type: string
       tenant_id:
+        type: string
+      user_id:
+        type: string
+    type: object
+  domain.Function:
+    properties:
+      code_path:
+        description: Path to code artifact
+        type: string
+      created_at:
+        type: string
+      env_vars:
+        items:
+          $ref: '#/definitions/domain.EnvVar'
+        type: array
+      handler:
+        description: Entry point (e.g. "main.Handle")
+        type: string
+      id:
+        type: string
+      memory_mb:
+        description: Memory allocation
+        type: integer
+      name:
+        type: string
+      runtime:
+        description: e.g. "python3.9", "go1.21"
+        type: string
+      status:
+        description: e.g. "DEPLOYING", "READY"
+        type: string
+      tenant_id:
+        type: string
+      timeout:
+        description: Execution timeout in seconds
+        type: integer
+      updated_at:
         type: string
       user_id:
         type: string
@@ -923,6 +967,7 @@ definitions:
     - function:create
     - function:delete
     - function:read
+    - function:update
     - cache:create
     - cache:delete
     - cache:read
@@ -1035,6 +1080,7 @@ definitions:
     - PermissionFunctionCreate
     - PermissionFunctionDelete
     - PermissionFunctionRead
+    - PermissionFunctionUpdate
     - PermissionCacheCreate
     - PermissionCacheDelete
     - PermissionCacheRead
@@ -2024,12 +2070,36 @@ definitions:
     - name
     - vpc_id
     type: object
+  httphandlers.EnvVarRequest:
+    properties:
+      key:
+        type: string
+      value:
+        type: string
+    required:
+    - key
+    type: object
   httphandlers.ForgotPasswordRequest:
     properties:
       email:
         type: string
     required:
     - email
+    type: object
+  httphandlers.FunctionUpdateRequest:
+    properties:
+      env_vars:
+        items:
+          $ref: '#/definitions/httphandlers.EnvVarRequest'
+        type: array
+      handler:
+        type: string
+      memory_mb:
+        type: integer
+      status:
+        type: string
+      timeout:
+        type: integer
     type: object
   httphandlers.LaunchRequest:
     properties:
@@ -2293,9 +2363,6 @@ definitions:
     type: object
 info:
   contact: {}
-  description: The Cloud - Multi-tenant Cloud Infrastructure Engine
-  title: The Cloud API
-  version: "1.0"
 paths:
   /api/dashboard/events:
     get:
@@ -3888,6 +3955,44 @@ paths:
       summary: Disassociate Elastic IP
       tags:
       - elastic-ips
+  /functions/{id}:
+    patch:
+      consumes:
+      - application/json
+      description: Updates a function's timeout, memory, handler, status, or environment
+        variables
+      parameters:
+      - description: Function ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Update request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.FunctionUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.Function'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Update function
+      tags:
+      - functions
   /gateway/routes:
     get:
       description: Gets a list of all registered API gateway routes
@@ -6741,9 +6846,4 @@ paths:
       summary: Get VPC details
       tags:
       - vpcs
-securityDefinitions:
-  APIKeyAuth:
-    in: header
-    name: X-API-Key
-    type: apiKey
 swagger: "2.0"

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -512,6 +512,7 @@ func registerDevOpsRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		fnGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionFunctionDelete), handlers.Function.Delete)
 		fnGroup.POST("/:id/invoke", httputil.Permission(svcs.RBAC, domain.PermissionFunctionInvoke), handlers.Function.Invoke)
 		fnGroup.GET("/:id/logs", httputil.Permission(svcs.RBAC, domain.PermissionFunctionRead), handlers.Function.GetLogs)
+		fnGroup.PATCH("/:id", httputil.Permission(svcs.RBAC, domain.PermissionFunctionUpdate), handlers.Function.Update)
 	}
 
 	queueGroup := r.Group("/queues")

--- a/internal/core/domain/function.go
+++ b/internal/core/domain/function.go
@@ -2,26 +2,80 @@
 package domain
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 )
 
+// EnvVar represents a key-value environment variable for a function.
+type EnvVar struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// FunctionUpdate describes fields that can be changed on an existing function.
+type FunctionUpdate struct {
+	Handler  *string   `json:"handler,omitempty"`
+	Timeout  *int      `json:"timeout,omitempty"`
+	MemoryMB *int      `json:"memory_mb,omitempty"`
+	Status   *string   `json:"status,omitempty"`
+	EnvVars  []*EnvVar `json:"env_vars,omitempty"`
+}
+
+// SetColumns returns the SQL SET clauses and argument values for a partial UPDATE.
+// Only non-nil fields are included.
+func (u *FunctionUpdate) SetColumns() (string, []any) {
+	var cols []string
+	var args []any
+	argIdx := 1
+
+	if u.Handler != nil {
+		cols = append(cols, fmt.Sprintf("handler = $%d", argIdx))
+		args = append(args, *u.Handler)
+		argIdx++
+	}
+	if u.Timeout != nil {
+		cols = append(cols, fmt.Sprintf("timeout_seconds = $%d", argIdx))
+		args = append(args, *u.Timeout)
+		argIdx++
+	}
+	if u.MemoryMB != nil {
+		cols = append(cols, fmt.Sprintf("memory_mb = $%d", argIdx))
+		args = append(args, *u.MemoryMB)
+		argIdx++
+	}
+	if u.Status != nil {
+		cols = append(cols, fmt.Sprintf("status = $%d", argIdx))
+		args = append(args, *u.Status)
+		argIdx++
+	}
+	if u.EnvVars != nil {
+		cols = append(cols, fmt.Sprintf("env_vars = $%d", argIdx))
+		args = append(args, u.EnvVars)
+		argIdx++
+	}
+
+	return strings.Join(cols, ", "), args
+}
+
 // Function represents a serverless function.
 // Functions are event-driven units of execution (FaaS).
 type Function struct {
-	ID        uuid.UUID `json:"id"`
-	UserID    uuid.UUID `json:"user_id"`
-	TenantID  uuid.UUID `json:"tenant_id"`
-	Name      string    `json:"name"`
-	Runtime   string    `json:"runtime"`   // e.g. "python3.9", "go1.21"
-	Handler   string    `json:"handler"`   // Entry point (e.g. "main.Handle")
-	CodePath  string    `json:"code_path"` // Path to code artifact
-	Timeout   int       `json:"timeout"`   // Execution timeout in seconds
-	MemoryMB  int       `json:"memory_mb"` // Memory allocation
-	Status    string    `json:"status"`    // e.g. "DEPLOYING", "READY"
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID        uuid.UUID  `json:"id"`
+	UserID    uuid.UUID  `json:"user_id"`
+	TenantID  uuid.UUID  `json:"tenant_id"`
+	Name      string     `json:"name"`
+	Runtime   string     `json:"runtime"`   // e.g. "python3.9", "go1.21"
+	Handler   string     `json:"handler"`   // Entry point (e.g. "main.Handle")
+	CodePath  string     `json:"code_path"` // Path to code artifact
+	Timeout   int        `json:"timeout"`   // Execution timeout in seconds
+	MemoryMB  int        `json:"memory_mb"` // Memory allocation
+	Status    string     `json:"status"`    // e.g. "DEPLOYING", "READY"
+	EnvVars   []*EnvVar  `json:"env_vars"`
+	CreatedAt time.Time  `json:"created_at"`
+	UpdatedAt time.Time  `json:"updated_at"`
 }
 
 // Invocation represents a single execution of a Function.

--- a/internal/core/domain/rbac.go
+++ b/internal/core/domain/rbac.go
@@ -85,6 +85,7 @@ const (
 	PermissionFunctionCreate Permission = "function:create"
 	PermissionFunctionDelete Permission = "function:delete"
 	PermissionFunctionRead   Permission = "function:read"
+	PermissionFunctionUpdate Permission = "function:update"
 
 	// Cache Permissions
 	PermissionCacheCreate Permission = "cache:create"

--- a/internal/core/ports/function.go
+++ b/internal/core/ports/function.go
@@ -24,6 +24,8 @@ type FunctionRepository interface {
 	CreateInvocation(ctx context.Context, i *domain.Invocation) error
 	// GetInvocations retrieves a history of executions for a specific function.
 	GetInvocations(ctx context.Context, functionID uuid.UUID, limit int) ([]*domain.Invocation, error)
+	// Update applies a partial update to an existing function.
+	Update(ctx context.Context, id uuid.UUID, update *domain.FunctionUpdate) (*domain.Function, error)
 }
 
 // FunctionService provides business logic for FaaS (Function-as-a-Service) management and execution.
@@ -40,4 +42,6 @@ type FunctionService interface {
 	InvokeFunction(ctx context.Context, id uuid.UUID, payload []byte, async bool) (*domain.Invocation, error)
 	// GetFunctionLogs retrieves execution history and results for a function.
 	GetFunctionLogs(ctx context.Context, id uuid.UUID, limit int) ([]*domain.Invocation, error)
+	// UpdateFunction applies changes to an existing function's configuration.
+	UpdateFunction(ctx context.Context, id uuid.UUID, update *domain.FunctionUpdate) (*domain.Function, error)
 }

--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -179,6 +179,39 @@ func (s *FunctionService) GetFunctionLogs(ctx context.Context, id uuid.UUID, lim
 
 	return s.repo.GetInvocations(ctx, id, limit)
 }
+
+func (s *FunctionService) UpdateFunction(ctx context.Context, id uuid.UUID, update *domain.FunctionUpdate) (*domain.Function, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionFunctionUpdate, id.String()); err != nil {
+		return nil, err
+	}
+
+	if update.Timeout != nil {
+		if *update.Timeout <= 0 || *update.Timeout > 900 {
+			return nil, errors.New(errors.InvalidInput, "timeout must be between 1 and 900 seconds")
+		}
+	}
+	if update.MemoryMB != nil {
+		if *update.MemoryMB < 64 || *update.MemoryMB > 10240 {
+			return nil, errors.New(errors.InvalidInput, "memory must be between 64 and 10240 MB")
+		}
+	}
+
+	f, err := s.repo.Update(ctx, id, update)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "function.update", "function", id.String(), map[string]interface{}{
+		"name": f.Name,
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "action", "function.update", "function_id", id, "error", err)
+	}
+
+	return f, nil
+}
 func (s *FunctionService) InvokeFunction(ctx context.Context, id uuid.UUID, payload []byte, async bool) (*domain.Invocation, error) {
 	userID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)
@@ -250,10 +283,15 @@ func (s *FunctionService) buildTaskOptions(f *domain.Function, tmpDir string, pa
 
 	handler := s.normalizeHandler(f.Runtime, f.Handler)
 
+	env := []string{fmt.Sprintf("PAYLOAD=%s", string(payload))}
+	for _, e := range f.EnvVars {
+		env = append(env, fmt.Sprintf("%s=%s", e.Key, e.Value))
+	}
+
 	return ports.RunTaskOptions{
 		Image:           config.Image,
 		Command:         append(config.Entrypoint, handler),
-		Env:             []string{fmt.Sprintf("PAYLOAD=%s", string(payload))},
+		Env:             env,
 		MemoryMB:        int64(f.MemoryMB),
 		CPUs:            0.5,
 		NetworkDisabled: true,

--- a/internal/core/services/function_internal_test.go
+++ b/internal/core/services/function_internal_test.go
@@ -62,6 +62,25 @@ func TestFunctionService_BuildTaskOptions(t *testing.T) {
 	assert.Equal(t, int64(256), opts.MemoryMB)
 }
 
+func TestFunctionService_BuildTaskOptions_EnvVars(t *testing.T) {
+	s := &FunctionService{}
+	f := &domain.Function{
+		Runtime:  "python312",
+		Handler:  "main.py",
+		MemoryMB: 128,
+		EnvVars: []*domain.EnvVar{
+			{Key: "DATABASE_URL", Value: "postgres://localhost/db"},
+			{Key: "DEBUG", Value: "true"},
+		},
+	}
+	opts := s.buildTaskOptions(f, "/tmp/task", []byte(`{}`))
+
+	assert.Len(t, opts.Env, 3) // PAYLOAD + DATABASE_URL + DEBUG
+	assert.Equal(t, "PAYLOAD={}", opts.Env[0])
+	assert.Equal(t, "DATABASE_URL=postgres://localhost/db", opts.Env[1])
+	assert.Equal(t, "DEBUG=true", opts.Env[2])
+}
+
 func TestFunctionService_NormalizeHandler(t *testing.T) {
 	s := &FunctionService{}
 

--- a/internal/core/services/function_test.go
+++ b/internal/core/services/function_test.go
@@ -189,3 +189,127 @@ func TestFunctionServiceZipSlipProtection(t *testing.T) {
 	assert.Equal(t, "FAILED", inv.Status)
 	assert.Contains(t, inv.Logs, "invalid file path in zip")
 }
+
+func TestFunctionServiceUpdateFunction(t *testing.T) {
+	svc, repo, ctx := setupFunctionServiceTest(t)
+
+	code := createZip(t, "console.log('hi')")
+	f, err := svc.CreateFunction(ctx, "update-test", "nodejs20", indexJSMockFile, code)
+	require.NoError(t, err)
+	assert.Equal(t, 30, f.Timeout)  // default
+	assert.Equal(t, 128, f.MemoryMB) // default
+
+	// Update timeout and memory
+	newTimeout := 60
+	newMemory := 256
+	updated, err := svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{
+		Timeout:  &newTimeout,
+		MemoryMB: &newMemory,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 60, updated.Timeout)
+	assert.Equal(t, 256, updated.MemoryMB)
+
+	// Verify persisted in DB
+	fetched, err := repo.GetByID(ctx, f.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 60, fetched.Timeout)
+	assert.Equal(t, 256, fetched.MemoryMB)
+}
+
+func TestFunctionServiceUpdateFunction_EnvVars(t *testing.T) {
+	svc, _, ctx := setupFunctionServiceTest(t)
+
+	code := createZip(t, `
+const dbUrl = process.env.DATABASE_URL;
+const env = process.env.ENV_NAME;
+console.log("DB: " + dbUrl);
+console.log("ENV: " + env);
+process.exit(dbUrl && env ? 0 : 1);
+`)
+	f, err := svc.CreateFunction(ctx, "env-test", "nodejs20", indexJSMockFile, code)
+	require.NoError(t, err)
+
+	// Add environment variables
+	dbUrl := "postgres://localhost/prod"
+	envName := "production"
+	_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{
+		EnvVars: []*domain.EnvVar{
+			{Key: "DATABASE_URL", Value: dbUrl},
+			{Key: "ENV_NAME", Value: envName},
+		},
+	})
+	require.NoError(t, err)
+
+	// Invoke and verify env vars are available inside the container
+	inv, err := svc.InvokeFunction(ctx, f.ID, []byte("{}"), false)
+	require.NoError(t, err)
+	assert.Equal(t, "SUCCESS", inv.Status)
+	assert.Contains(t, inv.Logs, "DB: postgres://localhost/prod")
+	assert.Contains(t, inv.Logs, "ENV: production")
+}
+
+func TestFunctionServiceUpdateFunction_InvalidInput(t *testing.T) {
+	svc, _, ctx := setupFunctionServiceTest(t)
+
+	code := createZip(t, "console.log('x')")
+	f, err := svc.CreateFunction(ctx, "invalid-update", "nodejs20", indexJSMockFile, code)
+	require.NoError(t, err)
+
+	// Invalid timeout: 0
+	badTimeout := 0
+	_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{Timeout: &badTimeout})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+
+	// Invalid timeout: over 900
+	badTimeout = 1000
+	_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{Timeout: &badTimeout})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+
+	// Invalid memory: below minimum
+	badMemory := 32
+	_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{MemoryMB: &badMemory})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "memory")
+
+	// Invalid memory: over maximum
+	badMemory = 20000
+	_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{MemoryMB: &badMemory})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "memory")
+}
+
+func TestFunctionServiceUpdateFunction_ReplaceEnvVars(t *testing.T) {
+	svc, _, ctx := setupFunctionServiceTest(t)
+
+	code := createZip(t, `console.log("SECRET=" + process.env.SECRET); process.exit(0);`)
+	f, err := svc.CreateFunction(ctx, "replace-env", "nodejs20", indexJSMockFile, code)
+	require.NoError(t, err)
+
+	// Set initial env var
+	secret1 := "super-secret"
+	_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{
+		EnvVars: []*domain.EnvVar{{Key: "SECRET", Value: secret1}},
+	})
+	require.NoError(t, err)
+
+	inv, err := svc.InvokeFunction(ctx, f.ID, []byte("{}"), false)
+	require.NoError(t, err)
+	assert.Equal(t, "SUCCESS", inv.Status)
+	assert.Contains(t, inv.Logs, "SECRET=super-secret")
+
+	// Replace with new env var (clear all and set new)
+	secret2 := "new-secret"
+	_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{
+		EnvVars: []*domain.EnvVar{{Key: "SECRET", Value: secret2}},
+	})
+	require.NoError(t, err)
+
+	inv, err = svc.InvokeFunction(ctx, f.ID, []byte("{}"), false)
+	require.NoError(t, err)
+	assert.Equal(t, "SUCCESS", inv.Status)
+	assert.Contains(t, inv.Logs, "SECRET=new-secret")
+	assert.NotContains(t, inv.Logs, "super-secret")
+}

--- a/internal/core/services/function_unit_test.go
+++ b/internal/core/services/function_unit_test.go
@@ -23,6 +23,7 @@ func TestFunctionService_Unit(t *testing.T) {
 	t.Run("CreateFunction", testFunctionServiceCreateFunction)
 	t.Run("InvokeFunction", testFunctionServiceInvokeFunction)
 	t.Run("CreateFunction_UnsupportedRuntime", testFunctionServiceCreateFunctionUnsupportedRuntime)
+	t.Run("UpdateFunction", testFunctionServiceUpdateFunction)
 }
 
 func testFunctionServiceBasicOps(t *testing.T) {
@@ -187,4 +188,56 @@ func testFunctionServiceCreateFunctionUnsupportedRuntime(t *testing.T) {
 	_, err := svc.CreateFunction(ctx, "fail", "cobol99", "handler", []byte("code"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported runtime")
+}
+
+func testFunctionServiceUpdateFunction(t *testing.T) {
+	repo := new(MockFunctionRepo)
+	compute := new(MockComputeBackend)
+	fileStore := new(MockFileStore)
+	auditSvc := new(MockAuditService)
+	rbacSvc := new(MockRBACService)
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, slog.Default())
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+	id := uuid.New()
+
+	t.Run("success", func(t *testing.T) {
+		updated := &domain.Function{ID: id, UserID: userID, TenantID: tenantID, Name: "test-fn", Runtime: "nodejs20", Handler: "updated.js", Timeout: 60, MemoryMB: 256}
+
+		newTimeout := 60
+		newMemory := 256
+		update := &domain.FunctionUpdate{Timeout: &newTimeout, MemoryMB: &newMemory}
+
+		repo.On("Update", ctx, id, update).Return(updated, nil).Once()
+		auditSvc.On("Log", ctx, userID, "function.update", "function", id.String(), mock.Anything).Return(nil).Once()
+
+		result, err := svc.UpdateFunction(ctx, id, update)
+		require.NoError(t, err)
+		assert.Equal(t, 60, result.Timeout)
+		assert.Equal(t, 256, result.MemoryMB)
+	})
+
+	t.Run("invalid timeout", func(t *testing.T) {
+		badTimeout := 0
+		update := &domain.FunctionUpdate{Timeout: &badTimeout}
+
+		_, err := svc.UpdateFunction(ctx, id, update)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timeout")
+	})
+
+	t.Run("invalid memory", func(t *testing.T) {
+		badMemory := 10
+		update := &domain.FunctionUpdate{MemoryMB: &badMemory}
+
+		_, err := svc.UpdateFunction(ctx, id, update)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "memory")
+	})
 }

--- a/internal/core/services/mock_function_test.go
+++ b/internal/core/services/mock_function_test.go
@@ -35,8 +35,12 @@ func (m *MockFunctionRepo) List(ctx context.Context, userID uuid.UUID) ([]*domai
 	}
 	return args.Get(0).([]*domain.Function), args.Error(1)
 }
-func (m *MockFunctionRepo) Update(ctx context.Context, f *domain.Function) error {
-	return m.Called(ctx, f).Error(0)
+func (m *MockFunctionRepo) Update(ctx context.Context, id uuid.UUID, update *domain.FunctionUpdate) (*domain.Function, error) {
+	args := m.Called(ctx, id, update)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Function), args.Error(1)
 }
 func (m *MockFunctionRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return m.Called(ctx, id).Error(0)

--- a/internal/handlers/function_handler.go
+++ b/internal/handlers/function_handler.go
@@ -7,12 +7,28 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/poyrazk/thecloud/pkg/httputil"
 )
 
 const invalidFunctionIDMsg = "invalid function id"
+
+// EnvVarRequest represents a single environment variable in requests.
+type EnvVarRequest struct {
+	Key   string `json:"key" binding:"required"`
+	Value string `json:"value"`
+}
+
+// FunctionUpdateRequest mirrors domain.FunctionUpdate for JSON binding.
+type FunctionUpdateRequest struct {
+	Handler  *string           `json:"handler,omitempty"`
+	Timeout  *int              `json:"timeout,omitempty"`
+	MemoryMB *int              `json:"memory_mb,omitempty"`
+	Status   *string           `json:"status,omitempty"`
+	EnvVars  []*EnvVarRequest `json:"env_vars,omitempty"`
+}
 
 // FunctionHandler handles serverless function HTTP endpoints.
 type FunctionHandler struct {
@@ -145,4 +161,52 @@ func (h *FunctionHandler) GetLogs(c *gin.Context) {
 		return
 	}
 	httputil.Success(c, http.StatusOK, logs)
+}
+
+// Update updates an existing function's configuration.
+// @Summary Update function
+// @Description Updates a function's timeout, memory, handler, status, or environment variables
+// @Tags functions
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Function ID"
+// @Param request body FunctionUpdateRequest true "Update request"
+// @Success 200 {object} domain.Function
+// @Failure 400 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /functions/{id} [patch]
+func (h *FunctionHandler) Update(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, invalidFunctionIDMsg))
+		return
+	}
+
+	var req FunctionUpdateRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.Wrap(errors.InvalidInput, "invalid request body", err))
+		return
+	}
+
+	update := &domain.FunctionUpdate{
+		Handler:  req.Handler,
+		Timeout:  req.Timeout,
+		MemoryMB: req.MemoryMB,
+		Status:   req.Status,
+	}
+	if req.EnvVars != nil {
+		envVars := make([]*domain.EnvVar, len(req.EnvVars))
+		for i, e := range req.EnvVars {
+			envVars[i] = &domain.EnvVar{Key: e.Key, Value: e.Value}
+		}
+		update.EnvVars = envVars
+	}
+
+	fn, err := h.svc.UpdateFunction(c.Request.Context(), id, update)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, fn)
 }

--- a/internal/handlers/function_handler_test.go
+++ b/internal/handlers/function_handler_test.go
@@ -81,6 +81,15 @@ func (m *mockFunctionService) GetFunctionLogs(ctx context.Context, id uuid.UUID,
 	return r0, args.Error(1)
 }
 
+func (m *mockFunctionService) UpdateFunction(ctx context.Context, id uuid.UUID, update *domain.FunctionUpdate) (*domain.Function, error) {
+	args := m.Called(ctx, id, update)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	r0, _ := args.Get(0).(*domain.Function)
+	return r0, args.Error(1)
+}
+
 func setupFunctionHandlerTest(_ *testing.T) (*mockFunctionService, *FunctionHandler, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockFunctionService)
@@ -335,6 +344,65 @@ func TestFunctionHandlerInvokeError(t *testing.T) {
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusAccepted, w.Code)
+		svc.AssertExpectations(t)
+	})
+}
+
+func TestFunctionHandlerUpdate(t *testing.T) {
+	t.Parallel()
+	svc, handler, r := setupFunctionHandlerTest(t)
+	defer svc.AssertExpectations(t)
+
+	r.PATCH(functionsPath+"/:id", handler.Update)
+
+	id := uuid.New()
+	updatedFn := &domain.Function{ID: id, Name: testFunctionName, Timeout: 60, MemoryMB: 256}
+	svc.On("UpdateFunction", mock.Anything, id, mock.MatchedBy(func(u *domain.FunctionUpdate) bool {
+		return u.Timeout != nil && *u.Timeout == 60 && u.MemoryMB != nil && *u.MemoryMB == 256
+	})).Return(updatedFn, nil)
+
+	body := `{"timeout":60,"memory_mb":256}`
+	req, err := http.NewRequest(http.MethodPatch, functionsPath+"/"+id.String(), strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestFunctionHandlerUpdateError(t *testing.T) {
+	t.Parallel()
+	t.Run("InvalidID", func(t *testing.T) {
+		_, handler, r := setupFunctionHandlerTest(t)
+		r.PATCH(functionsPath+"/:id", handler.Update)
+		req, _ := http.NewRequest(http.MethodPatch, functionsPath+fnPathInvalid, strings.NewReader("{}"))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("InvalidBody", func(t *testing.T) {
+		_, handler, r := setupFunctionHandlerTest(t)
+		r.PATCH(functionsPath+"/:id", handler.Update)
+		id := uuid.New()
+		req, _ := http.NewRequest(http.MethodPatch, functionsPath+"/"+id.String(), strings.NewReader("{invalid}"))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("ServiceError", func(t *testing.T) {
+		svc, handler, r := setupFunctionHandlerTest(t)
+		r.PATCH(functionsPath+"/:id", handler.Update)
+		id := uuid.New()
+		svc.On("UpdateFunction", mock.Anything, id, mock.Anything).Return(nil, errors.New(errors.Internal, "error"))
+		req, _ := http.NewRequest(http.MethodPatch, functionsPath+"/"+id.String(), strings.NewReader(`{"timeout":60}`))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
 		svc.AssertExpectations(t)
 	})
 }

--- a/internal/repositories/noop/adapters.go
+++ b/internal/repositories/noop/adapters.go
@@ -440,7 +440,9 @@ func (r *NoopFunctionRepository) GetByName(ctx context.Context, userID uuid.UUID
 func (r *NoopFunctionRepository) List(ctx context.Context, userID uuid.UUID) ([]*domain.Function, error) {
 	return []*domain.Function{}, nil
 }
-func (r *NoopFunctionRepository) Update(ctx context.Context, fn *domain.Function) error { return nil }
+func (r *NoopFunctionRepository) Update(ctx context.Context, id uuid.UUID, update *domain.FunctionUpdate) (*domain.Function, error) {
+	return &domain.Function{ID: id}, nil
+}
 func (r *NoopFunctionRepository) Delete(ctx context.Context, id uuid.UUID) error        { return nil }
 func (r *NoopFunctionRepository) GetInvocations(ctx context.Context, fnID uuid.UUID, limit int) ([]*domain.Invocation, error) {
 	return []*domain.Invocation{}, nil

--- a/internal/repositories/postgres/function_repo.go
+++ b/internal/repositories/postgres/function_repo.go
@@ -3,6 +3,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
@@ -23,11 +24,11 @@ func NewFunctionRepository(db DB) *FunctionRepository {
 
 func (r *FunctionRepository) Create(ctx context.Context, f *domain.Function) error {
 	query := `
-		INSERT INTO functions (id, user_id, tenant_id, name, runtime, handler, code_path, timeout_seconds, memory_mb, status, created_at, updated_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		INSERT INTO functions (id, user_id, tenant_id, name, runtime, handler, code_path, timeout_seconds, memory_mb, status, env_vars, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 	`
 	_, err := r.db.Exec(ctx, query,
-		f.ID, f.UserID, f.TenantID, f.Name, f.Runtime, f.Handler, f.CodePath, f.Timeout, f.MemoryMB, f.Status, f.CreatedAt, f.UpdatedAt,
+		f.ID, f.UserID, f.TenantID, f.Name, f.Runtime, f.Handler, f.CodePath, f.Timeout, f.MemoryMB, f.Status, f.EnvVars, f.CreatedAt, f.UpdatedAt,
 	)
 	if err != nil {
 		return errors.Wrap(errors.Internal, "failed to create function", err)
@@ -37,19 +38,19 @@ func (r *FunctionRepository) Create(ctx context.Context, f *domain.Function) err
 
 func (r *FunctionRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.Function, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
-	query := `SELECT id, user_id, tenant_id, name, runtime, handler, code_path, timeout_seconds, memory_mb, status, created_at, updated_at FROM functions WHERE id = $1 AND tenant_id = $2`
+	query := `SELECT id, user_id, tenant_id, name, runtime, handler, code_path, timeout_seconds, memory_mb, status, env_vars, created_at, updated_at FROM functions WHERE id = $1 AND tenant_id = $2`
 	return r.scanFunction(r.db.QueryRow(ctx, query, id, tenantID))
 }
 
 func (r *FunctionRepository) GetByName(ctx context.Context, userID uuid.UUID, name string) (*domain.Function, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
-	query := `SELECT id, user_id, tenant_id, name, runtime, handler, code_path, timeout_seconds, memory_mb, status, created_at, updated_at FROM functions WHERE name = $1 AND tenant_id = $2`
+	query := `SELECT id, user_id, tenant_id, name, runtime, handler, code_path, timeout_seconds, memory_mb, status, env_vars, created_at, updated_at FROM functions WHERE name = $1 AND tenant_id = $2`
 	return r.scanFunction(r.db.QueryRow(ctx, query, name, tenantID))
 }
 
 func (r *FunctionRepository) List(ctx context.Context, userID uuid.UUID) ([]*domain.Function, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
-	query := `SELECT id, user_id, tenant_id, name, runtime, handler, code_path, timeout_seconds, memory_mb, status, created_at, updated_at FROM functions WHERE tenant_id = $1 ORDER BY created_at DESC`
+	query := `SELECT id, user_id, tenant_id, name, runtime, handler, code_path, timeout_seconds, memory_mb, status, env_vars, created_at, updated_at FROM functions WHERE tenant_id = $1 ORDER BY created_at DESC`
 	rows, err := r.db.Query(ctx, query, tenantID)
 	if err != nil {
 		return nil, errors.Wrap(errors.Internal, "failed to list functions", err)
@@ -90,9 +91,24 @@ func (r *FunctionRepository) GetInvocations(ctx context.Context, functionID uuid
 	return r.scanInvocations(rows)
 }
 
+func (r *FunctionRepository) Update(ctx context.Context, id uuid.UUID, update *domain.FunctionUpdate) (*domain.Function, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	setCols, args := update.SetColumns()
+	if len(setCols) == 0 {
+		return r.GetByID(ctx, id)
+	}
+	args = append(args, id, tenantID)
+	query := fmt.Sprintf(`UPDATE functions SET %s, updated_at = NOW() WHERE id = $%d AND tenant_id = $%d`, setCols, len(args)-1, len(args))
+	_, err := r.db.Exec(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to update function", err)
+	}
+	return r.GetByID(ctx, id)
+}
+
 func (r *FunctionRepository) scanFunction(row pgx.Row) (*domain.Function, error) {
 	f := &domain.Function{}
-	err := row.Scan(&f.ID, &f.UserID, &f.TenantID, &f.Name, &f.Runtime, &f.Handler, &f.CodePath, &f.Timeout, &f.MemoryMB, &f.Status, &f.CreatedAt, &f.UpdatedAt)
+	err := row.Scan(&f.ID, &f.UserID, &f.TenantID, &f.Name, &f.Runtime, &f.Handler, &f.CodePath, &f.Timeout, &f.MemoryMB, &f.Status, &f.EnvVars, &f.CreatedAt, &f.UpdatedAt)
 	if err != nil {
 		return nil, errors.Wrap(errors.NotFound, "function not found", err)
 	}

--- a/internal/repositories/postgres/migrations/107_add_function_env_vars.up.sql
+++ b/internal/repositories/postgres/migrations/107_add_function_env_vars.up.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE functions ADD COLUMN env_vars JSONB DEFAULT '[]';
+
+-- +goose Down
+ALTER TABLE functions DROP COLUMN IF EXISTS env_vars;

--- a/pkg/sdk/function.go
+++ b/pkg/sdk/function.go
@@ -18,8 +18,24 @@ type Function struct {
 	Timeout   int       `json:"timeout"`
 	MemoryMB  int       `json:"memory_mb"`
 	Status    string    `json:"status"`
+	EnvVars   []*EnvVar `json:"env_vars"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// EnvVar represents a function environment variable.
+type EnvVar struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// FunctionUpdate describes fields that can be updated on a function.
+type FunctionUpdate struct {
+	Handler  *string    `json:"handler,omitempty"`
+	Timeout  *int       `json:"timeout,omitempty"`
+	MemoryMB *int       `json:"memory_mb,omitempty"`
+	Status   *string    `json:"status,omitempty"`
+	EnvVars  []*EnvVar `json:"env_vars,omitempty"`
 }
 
 // Invocation represents a function invocation result.
@@ -101,4 +117,12 @@ func (c *Client) GetFunctionLogs(id string) ([]*Invocation, error) {
 		return nil, err
 	}
 	return resp.Data, nil
+}
+
+func (c *Client) UpdateFunction(id string, update *FunctionUpdate) (*Function, error) {
+	var resp Response[Function]
+	if err := c.patch(functionsPath+id, update, &resp); err != nil {
+		return nil, err
+	}
+	return &resp.Data, nil
 }

--- a/tests/functions_e2e_test.go
+++ b/tests/functions_e2e_test.go
@@ -1,9 +1,11 @@
 package tests
 
 import (
+	"archive/zip"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"testing"
@@ -85,4 +87,154 @@ func TestFunctionsE2E(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
+}
+
+func TestFunctionsUpdateE2E(t *testing.T) {
+	t.Parallel()
+	if err := waitForServer(); err != nil {
+		t.Fatalf("Failing Functions Update E2E test: %v", err)
+	}
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	token := registerAndLogin(t, client, "fn-update-e2e@thecloud.local", "Fn Update E2E")
+
+	fnName := fmt.Sprintf("e2e-fn-update-%d", time.Now().UnixNano()%1000)
+	fnID := createFunction(t, client, token, fnName, "nodejs20", "index.handler",
+		`console.log(process.env.MY_VAR); process.exit(0);`)
+
+	// 1. Update timeout and memory
+	t.Run("UpdateTimeoutAndMemory", func(t *testing.T) {
+		updateReq := map[string]interface{}{
+			"timeout":  60,
+			"memory_mb": 256,
+		}
+		resp := patchRequest(t, client, fmt.Sprintf("%s/functions/%s", testutil.TestBaseURL, fnID), token, updateReq)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "update should succeed")
+		var res struct {
+			Data domain.Function `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		assert.Equal(t, 60, res.Data.Timeout)
+		assert.Equal(t, 256, res.Data.MemoryMB)
+	})
+
+	// 2. Verify updated values persisted
+	t.Run("GetFunctionAfterUpdate", func(t *testing.T) {
+		resp := getRequest(t, client, fmt.Sprintf("%s/functions/%s", testutil.TestBaseURL, fnID), token)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var res struct {
+			Data domain.Function `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		assert.Equal(t, 60, res.Data.Timeout)
+		assert.Equal(t, 256, res.Data.MemoryMB)
+	})
+
+	// 3. Update with env vars
+	t.Run("UpdateEnvVars", func(t *testing.T) {
+		updateReq := map[string]interface{}{
+			"env_vars": []map[string]string{
+				{"key": "MY_VAR", "value": "hello-from-update"},
+				{"key": "ENV", "value": "test"},
+			},
+		}
+		resp := patchRequest(t, client, fmt.Sprintf("%s/functions/%s", testutil.TestBaseURL, fnID), token, updateReq)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var res struct {
+			Data domain.Function `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		require.Len(t, res.Data.EnvVars, 2)
+	})
+
+	// 4. Invoke and verify env vars are available
+	t.Run("InvokeWithEnvVars", func(t *testing.T) {
+		payload := map[string]string{}
+		b, _ := json.Marshal(payload)
+		req, _ := http.NewRequest("POST", fmt.Sprintf("%s/functions/%s/invoke", testutil.TestBaseURL, fnID), bytes.NewBuffer(b))
+		req.Header.Set(testutil.TestHeaderAPIKey, token)
+		applyTenantHeader(t, req, token)
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var invRes struct {
+			Data struct {
+				Logs string `json:"logs"`
+			} `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&invRes))
+		assert.Contains(t, invRes.Data.Logs, "hello-from-update")
+		assert.Contains(t, invRes.Data.Logs, "ENV=test")
+	})
+
+	// 5. Update invalid timeout
+	t.Run("UpdateInvalidTimeout", func(t *testing.T) {
+		updateReq := map[string]interface{}{"timeout": 0}
+		resp := patchRequest(t, client, fmt.Sprintf("%s/functions/%s", testutil.TestBaseURL, fnID), token, updateReq)
+		defer func() { _ = resp.Body.Close() }()
+		// Service returns 400 for validation error
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	// 6. Update invalid memory
+	t.Run("UpdateInvalidMemory", func(t *testing.T) {
+		updateReq := map[string]interface{}{"memory_mb": 10}
+		resp := patchRequest(t, client, fmt.Sprintf("%s/functions/%s", testutil.TestBaseURL, fnID), token, updateReq)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	// Cleanup
+	t.Run("Cleanup", func(t *testing.T) {
+		resp := deleteRequest(t, client, fmt.Sprintf("%s/functions/%s", testutil.TestBaseURL, fnID), token)
+		defer func() { _ = resp.Body.Close() }()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}
+
+// createFunction creates a real zip and registers a function, returning its ID.
+func createFunction(t *testing.T, client *http.Client, token, name, runtime, handler, jsCode string) string {
+	buf := new(bytes.Buffer)
+	zw := zip.NewWriter(buf)
+	f, err := zw.Create("index.js")
+	require.NoError(t, err)
+	_, err = f.Write([]byte(jsCode))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	_ = writer.WriteField("name", name)
+	_ = writer.WriteField("runtime", runtime)
+	_ = writer.WriteField("handler", handler)
+	part, err := writer.CreateFormFile("code", "code.zip")
+	require.NoError(t, err)
+	_, err = io.Copy(part, bytes.NewReader(buf.Bytes()))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req, _ := http.NewRequest("POST", testutil.TestBaseURL+"/functions", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set(testutil.TestHeaderAPIKey, token)
+	applyTenantHeader(t, req, token)
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var res struct {
+		Data domain.Function `json:"data"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+	return res.Data.ID.String()
 }

--- a/tests/functions_e2e_test.go
+++ b/tests/functions_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -205,7 +206,10 @@ func TestFunctionsUpdateE2E(t *testing.T) {
 func createFunction(t *testing.T, client *http.Client, token, name, runtime, handler, jsCode string) string {
 	buf := new(bytes.Buffer)
 	zw := zip.NewWriter(buf)
-	f, err := zw.Create("index.js")
+	// Handler is like "index.handler"; the zip file contains "index.js"
+	// so we strip ".handler" to get the actual filename inside the zip
+	zipName := strings.TrimSuffix(handler, ".handler") + ".js"
+	f, err := zw.Create(zipName)
 	require.NoError(t, err)
 	_, err = f.Write([]byte(jsCode))
 	require.NoError(t, err)

--- a/tests/helpers_test.go
+++ b/tests/helpers_test.go
@@ -212,6 +212,28 @@ func deleteRequest(t *testing.T, client *http.Client, url, token string) *http.R
 	return resp
 }
 
+func patchRequest(t *testing.T, client *http.Client, url, token string, payload interface{}) *http.Response {
+	t.Helper()
+	var body io.Reader
+	if payload != nil {
+		b, _ := json.Marshal(payload)
+		body = bytes.NewBuffer(b)
+	}
+	req, _ := http.NewRequest("PATCH", url, body)
+	req.Header.Set("Content-Type", testutil.TestContentTypeAppJSON)
+	req.Header.Set(testutil.TestHeaderAPIKey, token)
+	if requiresTenantHeader(url) {
+		tenantID := tenantIDForToken(token)
+		if tenantID == "" {
+			t.Fatal(errTenantNotSet)
+		}
+		req.Header.Set(headerTenantID, tenantID)
+	}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	return resp
+}
+
 func applyTenantHeader(t *testing.T, req *http.Request, token string) {
 	t.Helper()
 	if !requiresTenantHeader(req.URL.Path) {


### PR DESCRIPTION
## Summary
- Add `FunctionUpdate` and `EnvVar` domain types with dynamic partial SQL updates
- Add `PATCH /functions/:id` endpoint for updating timeout, memory, handler, status, and env vars
- Add `UpdateFunction` to SDK client and CLI with `--handler`, `--timeout`, `--memory`, `--status`, `--env` flags
- Add comprehensive unit and E2E tests for update and env var injection

## Test plan
- [x] Unit tests pass (`go test ./internal/core/services/... ./internal/handlers/...`)
- [x] Unit tests pass (`go test ./internal/core/services/... ./internal/handlers/...`)
- [x] Integration tests via GitHub Actions