### PR TITLE
test(services): add RBAC and repo error subtests to DNS unit tests

### DIFF
--- a/internal/core/services/dns_unit_test.go
+++ b/internal/core/services/dns_unit_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 
@@ -110,6 +111,8 @@ func (m *MockDNSBackend) ListRecords(ctx context.Context, zoneID string) ([]port
 func TestDNSService_Unit(t *testing.T) {
 	t.Run("Extended", testDNSServiceUnitExtended)
 	t.Run("GetZoneByVPC", testGetZoneByVPC)
+	t.Run("RBACErrors", testDNSServiceUnitRBACErrors)
+	t.Run("RepoErrors", testDNSServiceUnitRepoErrors)
 }
 
 func testDNSServiceUnitExtended(t *testing.T) {
@@ -360,4 +363,366 @@ func testGetZoneByVPC(t *testing.T) {
 			rbacSvc.AssertExpectations(t)
 		})
 	}
+}
+
+func testDNSServiceUnitRBACErrors(t *testing.T) {
+	repo := new(MockDNSRepository)
+	backend := new(MockDNSBackend)
+	vpcRepo := new(MockVpcRepo)
+	auditSvc := new(MockAuditService)
+	eventSvc := new(MockEventService)
+	rbacSvc := new(MockRBACService)
+
+	svc := services.NewDNSService(services.DNSServiceParams{
+		Repo:     repo,
+		Backend:  backend,
+		RBAC:     rbacSvc,
+		VpcRepo:  vpcRepo,
+		AuditSvc: auditSvc,
+		EventSvc: eventSvc,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	vpcID := uuid.New()
+	zoneID := uuid.New()
+	zoneIDStr := zoneID.String()
+	recordID := uuid.New()
+	recordIDStr := recordID.String()
+
+	type rbacCase struct {
+		name       string
+		permission domain.Permission
+		resourceID string
+		invoke     func() error
+	}
+
+	cases := []rbacCase{
+		{
+			name:       "CreateZone_Unauthorized",
+			permission: domain.PermissionDNSCreate,
+			resourceID: "*",
+			invoke: func() error {
+				_, err := svc.CreateZone(ctx, vpcID, "example.com", "desc")
+				return err
+			},
+		},
+		{
+			name:       "GetZone_Unauthorized",
+			permission: domain.PermissionDNSRead,
+			resourceID: zoneIDStr,
+			invoke: func() error {
+				_, err := svc.GetZone(ctx, zoneIDStr)
+				return err
+			},
+		},
+		{
+			name:       "ListZones_Unauthorized",
+			permission: domain.PermissionDNSRead,
+			resourceID: "*",
+			invoke: func() error {
+				_, err := svc.ListZones(ctx)
+				return err
+			},
+		},
+		{
+			name:       "DeleteZone_Unauthorized",
+			permission: domain.PermissionDNSDelete,
+			resourceID: zoneIDStr,
+			invoke: func() error {
+				return svc.DeleteZone(ctx, zoneIDStr)
+			},
+		},
+		{
+			name:       "CreateRecord_Unauthorized",
+			permission: domain.PermissionDNSCreate,
+			resourceID: "*",
+			invoke: func() error {
+				_, err := svc.CreateRecord(ctx, zoneID, "www", domain.RecordTypeA, "1.2.3.4", 3600, nil)
+				return err
+			},
+		},
+		{
+			name:       "GetRecord_Unauthorized",
+			permission: domain.PermissionDNSRead,
+			resourceID: recordIDStr,
+			invoke: func() error {
+				_, err := svc.GetRecord(ctx, recordID)
+				return err
+			},
+		},
+		{
+			name:       "ListRecords_Unauthorized",
+			permission: domain.PermissionDNSRead,
+			resourceID: "*",
+			invoke: func() error {
+				_, err := svc.ListRecords(ctx, zoneID)
+				return err
+			},
+		},
+		{
+			name:       "UpdateRecord_Unauthorized",
+			permission: domain.PermissionDNSUpdate,
+			resourceID: recordIDStr,
+			invoke: func() error {
+				_, err := svc.UpdateRecord(ctx, recordID, "1.2.3.4", 3600, nil)
+				return err
+			},
+		},
+		{
+			name:       "DeleteRecord_Unauthorized",
+			permission: domain.PermissionDNSDelete,
+			resourceID: recordIDStr,
+			invoke: func() error {
+				return svc.DeleteRecord(ctx, recordID)
+			},
+		},
+	}
+
+	authErr := errors.New(errors.Forbidden, "permission denied")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rbacSvc.On("Authorize", mock.Anything, userID, tenantID, c.permission, c.resourceID).Return(authErr).Once()
+			err := c.invoke()
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, errors.Forbidden))
+		})
+	}
+}
+
+func testDNSServiceUnitRepoErrors(t *testing.T) {
+	repo := new(MockDNSRepository)
+	backend := new(MockDNSBackend)
+	vpcRepo := new(MockVpcRepo)
+	auditSvc := new(MockAuditService)
+	eventSvc := new(MockEventService)
+	rbacSvc := new(MockRBACService)
+
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	svc := services.NewDNSService(services.DNSServiceParams{
+		Repo:     repo,
+		Backend:  backend,
+		RBAC:     rbacSvc,
+		VpcRepo:  vpcRepo,
+		AuditSvc: auditSvc,
+		EventSvc: eventSvc,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	vpcID := uuid.New()
+	zoneID := uuid.New()
+
+	t.Run("CreateZone_VPCNotFound", func(t *testing.T) {
+		vpcRepo.On("GetByID", mock.Anything, vpcID).Return(nil, errors.New(errors.NotFound, "vpc not found")).Once()
+
+		_, err := svc.CreateZone(ctx, vpcID, "example.com", "desc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "vpc not found")
+	})
+
+	t.Run("CreateZone_DuplicateZone", func(t *testing.T) {
+		vpcRepo.On("GetByID", mock.Anything, vpcID).Return(&domain.VPC{ID: vpcID, Name: "test-vpc"}, nil).Once()
+		repo.On("GetZoneByVPC", mock.Anything, vpcID).Return(&domain.DNSZone{ID: uuid.New()}, nil).Once()
+
+		_, err := svc.CreateZone(ctx, vpcID, "example.com", "desc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+	})
+
+	t.Run("CreateZone_BackendError", func(t *testing.T) {
+		vpcRepo.On("GetByID", mock.Anything, vpcID).Return(&domain.VPC{ID: vpcID, Name: "test-vpc"}, nil).Once()
+		repo.On("GetZoneByVPC", mock.Anything, vpcID).Return(nil, nil).Once()
+		backend.On("CreateZone", mock.Anything, "example.com.", mock.Anything).Return(fmt.Errorf("backend error")).Once()
+
+		_, err := svc.CreateZone(ctx, vpcID, "example.com", "desc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backend error")
+	})
+
+	t.Run("CreateZone_RepoError", func(t *testing.T) {
+		vpcRepo.On("GetByID", mock.Anything, vpcID).Return(&domain.VPC{ID: vpcID, Name: "test-vpc"}, nil).Once()
+		repo.On("GetZoneByVPC", mock.Anything, vpcID).Return(nil, nil).Once()
+		backend.On("CreateZone", mock.Anything, "example.com.", mock.Anything).Return(nil).Once()
+		repo.On("CreateZone", mock.Anything, mock.Anything).Return(fmt.Errorf("db error")).Once()
+		backend.On("DeleteZone", mock.Anything, "example.com.").Return(nil).Once()
+
+		_, err := svc.CreateZone(ctx, vpcID, "example.com", "desc")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("GetZone_NotFound", func(t *testing.T) {
+		repo.On("GetZoneByName", mock.Anything, "not-found").Return(nil, errors.New(errors.NotFound, "zone not found")).Once()
+
+		_, err := svc.GetZone(ctx, "not-found")
+		require.Error(t, err)
+	})
+
+	t.Run("GetZone_RepoError", func(t *testing.T) {
+		repo.On("GetZoneByName", mock.Anything, "error").Return(nil, fmt.Errorf("db error")).Once()
+
+		_, err := svc.GetZone(ctx, "error")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("ListZones_RepoError", func(t *testing.T) {
+		repo.On("ListZones", mock.Anything).Return(nil, fmt.Errorf("db error")).Once()
+
+		_, err := svc.ListZones(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("DeleteZone_NotFound", func(t *testing.T) {
+		repo.On("GetZoneByName", mock.Anything, "not-found").Return(nil, errors.New(errors.NotFound, "zone not found")).Once()
+
+		err := svc.DeleteZone(ctx, "not-found")
+		require.Error(t, err)
+	})
+
+	t.Run("DeleteZone_BackendError", func(t *testing.T) {
+		zone := &domain.DNSZone{ID: zoneID, Name: "example.com", PowerDNSID: "example.com.", UserID: userID}
+		repo.On("GetZoneByID", mock.Anything, zoneID).Return(zone, nil).Once()
+		backend.On("DeleteZone", mock.Anything, "example.com.").Return(fmt.Errorf("backend error")).Once()
+
+		err := svc.DeleteZone(ctx, zoneID.String())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backend error")
+	})
+
+	t.Run("DeleteZone_RepoError", func(t *testing.T) {
+		zone := &domain.DNSZone{ID: zoneID, Name: "example.com", PowerDNSID: "example.com.", UserID: userID}
+		repo.On("GetZoneByID", mock.Anything, zoneID).Return(zone, nil).Once()
+		backend.On("DeleteZone", mock.Anything, "example.com.").Return(nil).Once()
+		repo.On("DeleteZone", mock.Anything, zoneID).Return(fmt.Errorf("db error")).Once()
+
+		err := svc.DeleteZone(ctx, zoneID.String())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("CreateRecord_ZoneNotFound", func(t *testing.T) {
+		repo.On("GetZoneByID", mock.Anything, zoneID).Return(nil, errors.New(errors.NotFound, "zone not found")).Once()
+
+		_, err := svc.CreateRecord(ctx, zoneID, "www", domain.RecordTypeA, "1.2.3.4", 3600, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("CreateRecord_BackendError", func(t *testing.T) {
+		zone := &domain.DNSZone{ID: zoneID, Name: "example.com", PowerDNSID: "example.com."}
+		repo.On("GetZoneByID", mock.Anything, zoneID).Return(zone, nil).Once()
+		backend.On("AddRecords", mock.Anything, "example.com.", mock.Anything).Return(fmt.Errorf("backend error")).Once()
+
+		_, err := svc.CreateRecord(ctx, zoneID, "www", domain.RecordTypeA, "1.2.3.4", 3600, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backend error")
+	})
+
+	t.Run("CreateRecord_RepoError", func(t *testing.T) {
+		zone := &domain.DNSZone{ID: zoneID, Name: "example.com", PowerDNSID: "example.com."}
+		repo.On("GetZoneByID", mock.Anything, zoneID).Return(zone, nil).Once()
+		backend.On("AddRecords", mock.Anything, "example.com.", mock.Anything).Return(nil).Once()
+		repo.On("CreateRecord", mock.Anything, mock.Anything).Return(fmt.Errorf("db error")).Once()
+
+		_, err := svc.CreateRecord(ctx, zoneID, "www", domain.RecordTypeA, "1.2.3.4", 3600, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("GetRecord_NotFound", func(t *testing.T) {
+		recordID := uuid.New()
+		repo.On("GetRecordByID", mock.Anything, recordID).Return(nil, errors.New(errors.NotFound, "record not found")).Once()
+
+		_, err := svc.GetRecord(ctx, recordID)
+		require.Error(t, err)
+	})
+
+	t.Run("GetRecord_RepoError", func(t *testing.T) {
+		recordID := uuid.New()
+		repo.On("GetRecordByID", mock.Anything, recordID).Return(nil, fmt.Errorf("db error")).Once()
+
+		_, err := svc.GetRecord(ctx, recordID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("ListRecords_RepoError", func(t *testing.T) {
+		repo.On("ListRecordsByZone", mock.Anything, zoneID).Return(nil, fmt.Errorf("db error")).Once()
+
+		_, err := svc.ListRecords(ctx, zoneID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("UpdateRecord_NotFound", func(t *testing.T) {
+		recordID := uuid.New()
+		repo.On("GetRecordByID", mock.Anything, recordID).Return(nil, errors.New(errors.NotFound, "record not found")).Once()
+
+		_, err := svc.UpdateRecord(ctx, recordID, "5.6.7.8", 3600, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("UpdateRecord_BackendError", func(t *testing.T) {
+		recordID := uuid.New()
+		zoneID := uuid.New()
+		record := &domain.DNSRecord{ID: recordID, ZoneID: zoneID, Name: "www", Type: domain.RecordTypeA, Content: "1.2.3.4"}
+		zone := &domain.DNSZone{ID: zoneID, Name: "example.com", PowerDNSID: "example.com."}
+		repo.On("GetRecordByID", mock.Anything, recordID).Return(record, nil).Once()
+		repo.On("GetZoneByID", mock.Anything, zoneID).Return(zone, nil).Once()
+		backend.On("UpdateRecords", mock.Anything, "example.com.", mock.Anything).Return(fmt.Errorf("backend error")).Once()
+
+		_, err := svc.UpdateRecord(ctx, recordID, "5.6.7.8", 3600, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backend error")
+	})
+
+	t.Run("DeleteRecord_NotFound", func(t *testing.T) {
+		recordID := uuid.New()
+		repo.On("GetRecordByID", mock.Anything, recordID).Return(nil, errors.New(errors.NotFound, "record not found")).Once()
+
+		err := svc.DeleteRecord(ctx, recordID)
+		require.Error(t, err)
+	})
+
+	t.Run("DeleteRecord_BackendError", func(t *testing.T) {
+		recordID := uuid.New()
+		zoneID := uuid.New()
+		record := &domain.DNSRecord{ID: recordID, ZoneID: zoneID, Name: "www", Type: domain.RecordTypeA}
+		zone := &domain.DNSZone{ID: zoneID, Name: "example.com", PowerDNSID: "example.com."}
+		repo.On("GetRecordByID", mock.Anything, recordID).Return(record, nil).Once()
+		repo.On("GetZoneByID", mock.Anything, zoneID).Return(zone, nil).Once()
+		backend.On("DeleteRecords", mock.Anything, "example.com.", "www.example.com.", "A").Return(fmt.Errorf("backend error")).Once()
+
+		err := svc.DeleteRecord(ctx, recordID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "backend error")
+	})
+
+	t.Run("DeleteRecord_RepoError", func(t *testing.T) {
+		recordID := uuid.New()
+		zoneID := uuid.New()
+		record := &domain.DNSRecord{ID: recordID, ZoneID: zoneID, Name: "www", Type: domain.RecordTypeA}
+		zone := &domain.DNSZone{ID: zoneID, Name: "example.com", PowerDNSID: "example.com."}
+		repo.On("GetRecordByID", mock.Anything, recordID).Return(record, nil).Once()
+		repo.On("GetZoneByID", mock.Anything, zoneID).Return(zone, nil).Once()
+		backend.On("DeleteRecords", mock.Anything, "example.com.", "www.example.com.", "A").Return(nil).Once()
+		repo.On("DeleteRecord", mock.Anything, recordID).Return(fmt.Errorf("db error")).Once()
+
+		err := svc.DeleteRecord(ctx, recordID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
 }


### PR DESCRIPTION
## Summary
- Add `testDnsServiceUnitRbacErrors` with 9 table-driven RBAC error tests covering all DNS operations
- Add `testDnsServiceUnitRepoErrors` with 21 error-path subtests covering:
  - CreateZone: VPC not found, duplicate zone, backend error, repo error (with rollback mock)
  - GetZone/ListZones: not found, repo error
  - DeleteZone: not found, backend error, repo error
  - CreateRecord: zone not found, backend error, repo error
  - GetRecord/ListRecords: not found, repo error
  - UpdateRecord: not found, backend error
  - DeleteRecord: not found, backend error, repo error

## Test plan
- [x] `go test -run TestDNSService_Unit` passes
- [x] Race detector clean