### PR TITLE
feat(images): ImportImage — pull OS images directly from URLs

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -243,6 +243,75 @@ Get the VNC console URL for the instance.
 
 ---
 
+## Images
+
+**Headers Required:** `X-API-Key: <your-api-key>`
+
+### GET /images
+List all images available to the authenticated user (own + public).
+
+**Response:**
+```json
+[
+  {
+    "id": "uuid",
+    "name": "ubuntu-22.04",
+    "description": "Ubuntu 22.04 LTS",
+    "os": "linux",
+    "version": "22.04",
+    "format": "qcow2",
+    "size_gb": 2,
+    "is_public": false,
+    "status": "ACTIVE",
+    "created_at": "2026-04-21T10:00:00Z"
+  }
+]
+```
+
+### POST /images
+Register a new image (metadata only; upload the file separately via `POST /images/:id/upload`).
+
+**Request:**
+```json
+{
+  "name": "my-custom-image",
+  "description": "My custom OS image",
+  "os": "linux",
+  "version": "22.04",
+  "is_public": false
+}
+```
+
+### GET /images/:id
+Get details of a specific image.
+
+### DELETE /images/:id
+Delete an image and its associated file from storage.
+
+### POST /images/:id/upload
+Upload the qcow2/image file for a registered image (multipart/form-data).
+
+**Form field:** `file` — the image binary file.
+
+### POST /images/import
+Import an image from a remote URL. The file is downloaded and stored automatically.
+
+**Request:**
+```json
+{
+  "name": "ubuntu-22.04-cloud",
+  "url": "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img",
+  "description": "Ubuntu 22.04 LTS cloud image",
+  "os": "linux",
+  "version": "22.04",
+  "is_public": false
+}
+```
+
+**Response:** `202 Accepted` — image metadata is returned immediately. The image status transitions from `PENDING` to `ACTIVE` once the download completes.
+
+---
+
 ## Networks (VPC)
 
 **Headers Required:** `X-API-Key: <your-api-key>`

--- a/docs/services/cloud-images.md
+++ b/docs/services/cloud-images.md
@@ -1,0 +1,125 @@
+# Cloud Images
+
+Cloud Images provides a managed image registry for bootable OS templates (qcow2, img, raw, iso). Images can be registered and uploaded manually, or imported directly from remote URLs.
+
+---
+
+## Overview
+
+Cloud Images is a service for managing custom OS images that can be used to launch compute instances. Images go through a lifecycle: `PENDING` → `ACTIVE` (or `ERROR` on failure).
+
+---
+
+## Features
+
+- **Register + Upload**: Create image metadata first, then stream the binary file via multipart upload.
+- **Import from URL**: Pull an OS image directly from a remote URL (e.g., cloud-images.ubuntu.com). The image is downloaded and stored without intermediate buffering.
+- **Public Images**: Mark images as public to share them across all users in a tenant.
+- **Format Detection**: Format is auto-detected from URL extension (`.qcow2`, `.img`, `.raw`, `.iso`).
+- **Status Tracking**: Images transition through `PENDING` → `ACTIVE` or `ERROR` states.
+
+---
+
+## Internal Workings
+
+### Register + Upload Flow
+
+```
+1. POST /images          → Create image record (status=PENDING)
+2. POST /images/:id/upload → Stream file to FileStore (status=ACTIVE on success)
+```
+
+The two-step flow allows large files to be uploaded without blocking the API server, since the binary transfer happens in a separate request.
+
+### Import from URL Flow
+
+```
+POST /images/import
+  → Create image record (status=PENDING)
+  → HTTP GET remote URL (30-minute timeout)
+  → Stream response body directly to FileStore
+  → On success: status=ACTIVE
+  → On failure: status=ERROR
+```
+
+Import is synchronous and returns `202 Accepted` immediately after the image metadata is created. The download and storage happens in the foreground; for very large images (>1GB) this may take several minutes.
+
+---
+
+## Image Model
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Unique identifier |
+| `name` | string | Human-readable name |
+| `description` | string | Optional description |
+| `os` | string | OS family (e.g., `linux`, `windows`) |
+| `version` | string | OS version (e.g., `22.04`) |
+| `format` | string | Disk format: `qcow2`, `img`, `raw`, `iso` |
+| `size_gb` | int | Image size in GB (populated after upload/import) |
+| `file_path` | string | Path in object storage |
+| `source_url` | string | URL the image was imported from (if applicable) |
+| `is_public` | bool | Whether the image is visible to all users |
+| `status` | enum | `PENDING`, `ACTIVE`, `ERROR`, `DELETING` |
+| `user_id` | UUID | Owner |
+| `tenant_id` | UUID | Tenant scope |
+
+---
+
+## CLI Usage
+
+```bash
+# Register an image (metadata only)
+cloud image register my-ubuntu "Ubuntu 22.04 LTS" --os linux --version 22.04
+
+# Upload the qcow2 file
+cloud image upload <image-id> --file ./ubuntu-22.04.qcow2
+
+# Import directly from URL (e.g., Ubuntu cloud images)
+cloud image import my-ubuntu \
+  --url "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img" \
+  --os linux --version 22.04
+
+# List images
+cloud image list
+
+# Get image details
+cloud image get <image-id>
+
+# Delete image
+cloud image delete <image-id>
+```
+
+---
+
+## Common Import Sources
+
+| Source | URL Pattern |
+|--------|-------------|
+| Ubuntu Cloud Images | `https://cloud-images.ubuntu.com/releases/<version>/release/ubuntu-<version>-server-cloudimg-amd64.img` |
+| CentOS Cloud | `https://cloud.centos.org/centos/<version>/images/CentOS-<version>-GenericCloud.qcow2` |
+| Debian Cloud | `https://cloud.debian.org/images/cloud/<version>/latest/debian-<version>-nocloud-amd64.qcow2` |
+| Fedora Cloud | `https://download.fedoraproject.org/pub/fedora/linux/releases/<version>/Cloud/x86_64/images/Fedora-Cloud-Base-<version>.qcow2` |
+
+---
+
+## Error Handling
+
+| Scenario | Result |
+|----------|--------|
+| Remote URL returns non-200 | `ERROR` status; error message includes HTTP status code |
+| Remote URL unreachable / timeout | `ERROR` status; 30-minute timeout per request |
+| File store write fails | `ERROR` status; partial file may remain |
+| Invalid URL format | Returns `400 Bad Request` before image creation |
+
+---
+
+## Relationship to Compute
+
+Images are referenced by `LaunchInstance` via the `image` field. After an image is imported and active, it can be used as the `image` value when launching instances.
+
+---
+
+## Storage
+
+Image binaries are stored in the `images` bucket in the underlying `FileStore` (local filesystem by default). The storage path is `<image-id>.<format>` (e.g., `abc123.qcow2`).

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -175,6 +175,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/images/import": {
+            "post": {
+                "description": "Downloads an OS image from a remote URL and registers it",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Import image from URL",
+                "parameters": [
+                    {
+                        "description": "Import request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.importImageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Image"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/images/{id}": {
             "get": {
                 "description": "Get detailed information about a specific image",
@@ -7840,6 +7874,10 @@ const docTemplate = `{
                     "description": "Minimum disk size required",
                     "type": "integer"
                 },
+                "source_url": {
+                    "description": "URL image was imported from",
+                    "type": "string"
+                },
                 "status": {
                     "$ref": "#/definitions/domain.ImageStatus"
                 },
@@ -10196,6 +10234,35 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "volume_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.importImageRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "os",
+                "url",
+                "version"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "is_public": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "os": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -167,6 +167,40 @@
                 }
             }
         },
+        "/api/v1/images/import": {
+            "post": {
+                "description": "Downloads an OS image from a remote URL and registers it",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Images"
+                ],
+                "summary": "Import image from URL",
+                "parameters": [
+                    {
+                        "description": "Import request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.importImageRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Accepted",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Image"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/images/{id}": {
             "get": {
                 "description": "Get detailed information about a specific image",
@@ -7832,6 +7866,10 @@
                     "description": "Minimum disk size required",
                     "type": "integer"
                 },
+                "source_url": {
+                    "description": "URL image was imported from",
+                    "type": "string"
+                },
                 "status": {
                     "$ref": "#/definitions/domain.ImageStatus"
                 },
@@ -10188,6 +10226,35 @@
                     "type": "string"
                 },
                 "volume_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.importImageRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "os",
+                "url",
+                "version"
+            ],
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "is_public": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "os": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -551,6 +551,9 @@ definitions:
       size_gb:
         description: Minimum disk size required
         type: integer
+      source_url:
+        description: URL image was imported from
+        type: string
       status:
         $ref: '#/definitions/domain.ImageStatus'
       tenant_id:
@@ -2247,6 +2250,26 @@ definitions:
       volume_id:
         type: string
     type: object
+  httphandlers.importImageRequest:
+    properties:
+      description:
+        type: string
+      is_public:
+        type: boolean
+      name:
+        type: string
+      os:
+        type: string
+      url:
+        type: string
+      version:
+        type: string
+    required:
+    - name
+    - os
+    - url
+    - version
+    type: object
   httphandlers.registerImageRequest:
     properties:
       description:
@@ -2460,6 +2483,28 @@ paths:
               type: string
             type: object
       summary: Upload image file
+      tags:
+      - Images
+  /api/v1/images/import:
+    post:
+      consumes:
+      - application/json
+      description: Downloads an OS image from a remote URL and registers it
+      parameters:
+      - description: Import request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.importImageRequest'
+      produces:
+      - application/json
+      responses:
+        "202":
+          description: Accepted
+          schema:
+            $ref: '#/definitions/domain.Image'
+      summary: Import image from URL
       tags:
       - Images
   /audit:

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -302,6 +302,7 @@ func registerComputeRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		imageGroup.GET("/:id", httputil.Permission(svcs.RBAC, domain.PermissionImageRead), handlers.Image.GetImage)
 		imageGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionImageDelete), handlers.Image.DeleteImage)
 		imageGroup.POST("/:id/upload", httputil.Permission(svcs.RBAC, domain.PermissionImageCreate), handlers.Image.UploadImage)
+		imageGroup.POST("/import", httputil.Permission(svcs.RBAC, domain.PermissionImageCreate), handlers.Image.ImportImage)
 	}
 
 	clusterGroup := r.Group("/clusters")

--- a/internal/core/domain/image.go
+++ b/internal/core/domain/image.go
@@ -34,6 +34,7 @@ type Image struct {
 	IsPublic    bool        `json:"is_public"` // If true, available to all users
 	UserID      uuid.UUID   `json:"user_id"`   // Owner (nil for system images if handled)
 	TenantID    *uuid.UUID  `json:"tenant_id,omitempty"`
+	SourceURL   string      `json:"source_url,omitempty"` // URL image was imported from
 	Status      ImageStatus `json:"status"`
 	CreatedAt   time.Time   `json:"created_at"`
 	UpdatedAt   time.Time   `json:"updated_at"`

--- a/internal/core/ports/image.go
+++ b/internal/core/ports/image.go
@@ -15,6 +15,8 @@ type ImageService interface {
 	RegisterImage(ctx context.Context, name, description, os, version string, isPublic bool) (*domain.Image, error)
 	// UploadImage streams the binary image data to the underlying storage backend.
 	UploadImage(ctx context.Context, id uuid.UUID, reader io.Reader) error
+	// ImportImage downloads an image from a remote URL, stores it, and registers it.
+	ImportImage(ctx context.Context, name, url, description, os, version string, isPublic bool) (*domain.Image, error)
 	// GetImage retrieves details for a specific image by its UUID.
 	GetImage(ctx context.Context, id uuid.UUID) (*domain.Image, error)
 	// ListImages returns images available to the user, including private and optionally public ones.

--- a/internal/core/services/image.go
+++ b/internal/core/services/image.go
@@ -264,6 +264,14 @@ func formatFromURL(url string) string {
 }
 
 func (s *imageService) importFromURL(ctx context.Context, img *domain.Image, imageURL string) error {
+	parsedURL, err := url.Parse(imageURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return fmt.Errorf("invalid URL scheme: only http and https are allowed")
+	}
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)

--- a/internal/core/services/image.go
+++ b/internal/core/services/image.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net/http"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -189,4 +192,94 @@ func (s *imageService) DeleteImage(ctx context.Context, id uuid.UUID) error {
 	}
 
 	return s.repo.Delete(ctx, id)
+}
+
+func (s *imageService) ImportImage(ctx context.Context, name, url, description, os, version string, isPublic bool) (*domain.Image, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionImageCreate, "*"); err != nil {
+		return nil, err
+	}
+
+	img := &domain.Image{
+		ID:          uuid.New(),
+		Name:        name,
+		Description: description,
+		OS:          os,
+		Version:     version,
+		IsPublic:    isPublic,
+		UserID:      userID,
+		TenantID:    &tenantID,
+		Status:      domain.ImageStatusPending,
+		SourceURL:   url,
+		Format:      formatFromURL(url),
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+
+	if err := s.repo.Create(ctx, img); err != nil {
+		return nil, err
+	}
+
+	// Download and stream to storage
+	if err := s.importFromURL(ctx, img, url); err != nil {
+		img.Status = domain.ImageStatusError
+		_ = s.repo.Update(ctx, img)
+		return nil, err
+	}
+
+	img.Status = domain.ImageStatusActive
+	if err := s.repo.Update(ctx, img); err != nil {
+		return nil, err
+	}
+
+	return img, nil
+}
+
+func formatFromURL(url string) string {
+	ext := strings.ToLower(filepath.Ext(url))
+	switch ext {
+	case ".qcow2":
+		return "qcow2"
+	case ".img":
+		return "img"
+	case ".raw":
+		return "raw"
+	case ".iso":
+		return "iso"
+	default:
+		return "qcow2"
+	}
+}
+
+func (s *imageService) importFromURL(ctx context.Context, img *domain.Image, url string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to fetch image: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("remote returned status %d", resp.StatusCode)
+	}
+
+	key := fmt.Sprintf("%s.%s", img.ID.String(), img.Format)
+	size, err := s.fileStore.Write(ctx, s.bucketName, key, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to store image: %w", err)
+	}
+
+	img.SizeGB = int(size / (1024 * 1024 * 1024))
+	if img.SizeGB == 0 && size > 0 {
+		img.SizeGB = 1
+	}
+	img.FilePath = key
+	return nil
 }

--- a/internal/core/services/image.go
+++ b/internal/core/services/image.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -194,12 +195,21 @@ func (s *imageService) DeleteImage(ctx context.Context, id uuid.UUID) error {
 	return s.repo.Delete(ctx, id)
 }
 
-func (s *imageService) ImportImage(ctx context.Context, name, url, description, os, version string, isPublic bool) (*domain.Image, error) {
+func (s *imageService) ImportImage(ctx context.Context, name, imageURL, description, os, version string, isPublic bool) (*domain.Image, error) {
 	userID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)
 
 	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionImageCreate, "*"); err != nil {
 		return nil, err
+	}
+
+	// Validate URL before creating any record (CodeQL: go/request-forgery)
+	parsedURL, err := url.Parse(imageURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return nil, fmt.Errorf("invalid URL: %w", err)
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return nil, fmt.Errorf("invalid URL scheme: only http and https are allowed")
 	}
 
 	img := &domain.Image{
@@ -212,8 +222,8 @@ func (s *imageService) ImportImage(ctx context.Context, name, url, description, 
 		UserID:      userID,
 		TenantID:    &tenantID,
 		Status:      domain.ImageStatusPending,
-		SourceURL:   url,
-		Format:      formatFromURL(url),
+		SourceURL:   imageURL,
+		Format:      formatFromURL(imageURL),
 		CreatedAt:   time.Now(),
 		UpdatedAt:   time.Now(),
 	}
@@ -223,7 +233,7 @@ func (s *imageService) ImportImage(ctx context.Context, name, url, description, 
 	}
 
 	// Download and stream to storage
-	if err := s.importFromURL(ctx, img, url); err != nil {
+	if err := s.importFromURL(ctx, img, imageURL); err != nil {
 		img.Status = domain.ImageStatusError
 		_ = s.repo.Update(ctx, img)
 		return nil, err
@@ -253,8 +263,8 @@ func formatFromURL(url string) string {
 	}
 }
 
-func (s *imageService) importFromURL(ctx context.Context, img *domain.Image, url string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func (s *imageService) importFromURL(ctx context.Context, img *domain.Image, imageURL string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
 	if err != nil {
 		return fmt.Errorf("invalid URL: %w", err)
 	}

--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -228,6 +228,7 @@ func TestImageService_Unit_RBACErrors(t *testing.T) {
 }
 
 func testRegisterImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	t.Helper()
 	ctx := context.Background()
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageCreate, "*").
 		Return(errors.New(errors.Forbidden, "denied")).Once()
@@ -237,6 +238,7 @@ func testRegisterImageRBACDenied(t *testing.T, svc ports.ImageService, repo *Moc
 }
 
 func testUploadImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	t.Helper()
 	ctx := context.Background()
 	id := uuid.New()
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageCreate, id.String()).
@@ -247,6 +249,7 @@ func testUploadImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockI
 }
 
 func testGetImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	t.Helper()
 	ctx := context.Background()
 	id := uuid.New()
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageRead, id.String()).
@@ -257,6 +260,7 @@ func testGetImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImag
 }
 
 func testListImagesRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	t.Helper()
 	ctx := context.Background()
 	userID := uuid.New()
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageRead, "*").
@@ -267,6 +271,7 @@ func testListImagesRBACDenied(t *testing.T, svc ports.ImageService, repo *MockIm
 }
 
 func testDeleteImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	t.Helper()
 	ctx := context.Background()
 	id := uuid.New()
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageDelete, id.String()).
@@ -277,6 +282,7 @@ func testDeleteImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockI
 }
 
 func testImportImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	t.Helper()
 	ctx := context.Background()
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageCreate, "*").
 		Return(errors.New(errors.Forbidden, "denied")).Once()

--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -361,6 +361,13 @@ func TestImageService_Unit_ErrorPaths(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("ImportImage_InvalidScheme", func(t *testing.T) {
+		// url.Parse succeeds for ftp:// but scheme is not http/https
+		_, err := svc.ImportImage(ctx, "name", "ftp://example.com/img.qcow2", "desc", "linux", "1.0", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid URL scheme")
+	})
+
 	t.Run("UploadImage_UpdateFails", func(t *testing.T) {
 		imgID := uuid.New()
 		img := &domain.Image{ID: imgID, UserID: userID}

--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -5,12 +5,18 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -20,7 +26,7 @@ func TestImageService_Unit(t *testing.T) {
 	repo := new(MockImageRepo)
 	fileStore := new(MockFileStore)
 	rbacSvc := new(MockRBACService)
-	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	svc := services.NewImageService(services.ImageServiceParams{
 		Repo:      repo,
@@ -140,4 +146,376 @@ func TestImageService_Unit(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, res, 2)
 	})
+
+	t.Run("ImportImage_Success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(bytes.Repeat([]byte("x"), 1024*1024)) // 1MB response
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusActive
+		})).Return(nil).Once()
+
+		fileStore.On("Write", mock.Anything, "images", mock.Anything, mock.Anything).Return(int64(1024*1024), nil).Once()
+
+		img, err := svc.ImportImage(ctx, "my-image", server.URL, "desc", "linux", "22.04", false)
+		require.NoError(t, err)
+		assert.Equal(t, "my-image", img.Name)
+		assert.Equal(t, server.URL, img.SourceURL)
+		assert.Equal(t, domain.ImageStatusActive, img.Status)
+	})
+
+	t.Run("ImportImage_StoreError", func(t *testing.T) {
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		// importFromURL fails → first Update with Error status
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusError
+		})).Return(nil).Once()
+
+		fileStore.On("Write", mock.Anything, "images", mock.Anything, mock.Anything).Return(int64(0), fmt.Errorf("store error")).Once()
+
+		_, err := svc.ImportImage(ctx, "my-image", "https://example.com/image.qcow2", "desc", "linux", "22.04", false)
+		require.Error(t, err)
+	})
+
+	t.Run("ImportImage_ServerError", func(t *testing.T) {
+		// Non-200 response
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusError
+		})).Return(nil).Once()
+
+		_, err := svc.ImportImage(ctx, "fail-img", server.URL, "desc", "linux", "1.0", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+	})
+}
+
+func TestImageService_Unit_RBACErrors(t *testing.T) {
+	// Each test gets its own service with a mock that returns errors on Authorize
+	for _, tc := range []struct {
+		name string
+		test func(*testing.T, ports.ImageService, *MockImageRepo, *MockFileStore, *MockRBACService)
+	}{
+		{"RegisterImage_RBACDenied", testRegisterImageRBACDenied},
+		{"UploadImage_RBACDenied", testUploadImageRBACDenied},
+		{"GetImage_RBACDenied", testGetImageRBACDenied},
+		{"ListImages_RBACDenied", testListImagesRBACDenied},
+		{"DeleteImage_RBACDenied", testDeleteImageRBACDenied},
+		{"ImportImage_RBACDenied", testImportImageRBACDenied},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := new(MockImageRepo)
+			fileStore := new(MockFileStore)
+			rbacSvc := new(MockRBACService)
+			svc := services.NewImageService(services.ImageServiceParams{
+				Repo:      repo,
+				RBACSvc:   rbacSvc,
+				FileStore: fileStore,
+				Logger:    slog.Default(),
+			})
+			tc.test(t, svc, repo, fileStore, rbacSvc)
+		})
+	}
+}
+
+func testRegisterImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	ctx := context.Background()
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageCreate, "*").
+		Return(errors.New(errors.Forbidden, "denied")).Once()
+	_, err := svc.RegisterImage(ctx, "name", "desc", "linux", "22.04", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied")
+}
+
+func testUploadImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	ctx := context.Background()
+	id := uuid.New()
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageCreate, id.String()).
+		Return(errors.New(errors.Forbidden, "denied")).Once()
+	err := svc.UploadImage(ctx, id, bytes.NewReader(nil))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied")
+}
+
+func testGetImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	ctx := context.Background()
+	id := uuid.New()
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageRead, id.String()).
+		Return(errors.New(errors.Forbidden, "denied")).Once()
+	_, err := svc.GetImage(ctx, id)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied")
+}
+
+func testListImagesRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	ctx := context.Background()
+	userID := uuid.New()
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageRead, "*").
+		Return(errors.New(errors.Forbidden, "denied")).Once()
+	_, err := svc.ListImages(ctx, userID, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied")
+}
+
+func testDeleteImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	ctx := context.Background()
+	id := uuid.New()
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageDelete, id.String()).
+		Return(errors.New(errors.Forbidden, "denied")).Once()
+	err := svc.DeleteImage(ctx, id)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied")
+}
+
+func testImportImageRBACDenied(t *testing.T, svc ports.ImageService, repo *MockImageRepo, fs *MockFileStore, rbacSvc *MockRBACService) {
+	ctx := context.Background()
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageCreate, "*").
+		Return(errors.New(errors.Forbidden, "denied")).Once()
+	_, err := svc.ImportImage(ctx, "name", "https://example.com/img.qcow2", "desc", "linux", "1.0", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "denied")
+}
+
+func TestImageService_Unit_ErrorPaths(t *testing.T) {
+	repo := new(MockImageRepo)
+	fileStore := new(MockFileStore)
+	rbacSvc := new(MockRBACService)
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	svc := services.NewImageService(services.ImageServiceParams{
+		Repo:      repo,
+		RBACSvc:   rbacSvc,
+		FileStore: fileStore,
+		Logger:    slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+
+	t.Run("UploadImage_NotOwner", func(t *testing.T) {
+		imgID := uuid.New()
+		otherUser := uuid.New()
+		img := &domain.Image{ID: imgID, UserID: otherUser}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+		err := svc.UploadImage(ctx, imgID, bytes.NewReader(nil))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "someone else's")
+	})
+
+	t.Run("UploadImage_TenantMismatch", func(t *testing.T) {
+		imgID := uuid.New()
+		tenantID := uuid.New()
+		otherTenantID := uuid.New()
+		tenantCtx := appcontext.WithTenantID(ctx, tenantID)
+		img := &domain.Image{ID: imgID, UserID: userID, TenantID: &otherTenantID}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+		err := svc.UploadImage(tenantCtx, imgID, bytes.NewReader(nil))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("DeleteImage_NotOwner", func(t *testing.T) {
+		imgID := uuid.New()
+		otherUser := uuid.New()
+		img := &domain.Image{ID: imgID, UserID: otherUser}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+		err := svc.DeleteImage(ctx, imgID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "someone else's")
+	})
+
+	t.Run("DeleteImage_FileDeleteError", func(t *testing.T) {
+		imgID := uuid.New()
+		img := &domain.Image{ID: imgID, UserID: userID, FilePath: "some/path"}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+		fileStore.On("Delete", mock.Anything, "images", "some/path").Return(fmt.Errorf("delete failed")).Once()
+		err := svc.DeleteImage(ctx, imgID)
+		require.Error(t, err)
+	})
+
+	t.Run("ImportImage_CreateFails", func(t *testing.T) {
+		repo.On("Create", mock.Anything, mock.Anything).Return(fmt.Errorf("db error")).Maybe()
+		_, err := svc.ImportImage(ctx, "name", "https://example.com/img.qcow2", "desc", "linux", "1.0", false)
+		require.Error(t, err)
+	})
+
+	t.Run("ImportImage_InvalidURL", func(t *testing.T) {
+		// http.NewRequestWithContext returns error for an invalid URL
+		_, err := svc.ImportImage(ctx, "name", "not-a-valid-url", "desc", "linux", "1.0", false)
+		require.Error(t, err)
+	})
+
+	t.Run("UploadImage_UpdateFails", func(t *testing.T) {
+		imgID := uuid.New()
+		img := &domain.Image{ID: imgID, UserID: userID}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+		fileStore.On("Write", mock.Anything, "images", mock.Anything, mock.Anything).Return(int64(1024*1024*1024), nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusActive && i.SizeGB == 1
+		})).Return(fmt.Errorf("db error")).Once()
+
+		err := svc.UploadImage(ctx, imgID, bytes.NewReader([]byte("content")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("DeleteImage_EmptyFilePath", func(t *testing.T) {
+		imgID := uuid.New()
+		img := &domain.Image{ID: imgID, UserID: userID, FilePath: ""}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+		repo.On("Delete", mock.Anything, imgID).Return(nil).Once()
+
+		err := svc.DeleteImage(ctx, imgID)
+		require.NoError(t, err)
+	})
+
+	t.Run("DeleteImage_DeleteFails", func(t *testing.T) {
+		imgID := uuid.New()
+		img := &domain.Image{ID: imgID, UserID: userID, FilePath: "some/path"}
+		repo.On("GetByID", mock.Anything, imgID).Return(img, nil).Once()
+		fileStore.On("Delete", mock.Anything, "images", "some/path").Return(nil).Once()
+		repo.On("Delete", mock.Anything, imgID).Return(fmt.Errorf("db error")).Once()
+
+		err := svc.DeleteImage(ctx, imgID)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+}
+
+func TestImageService_Unit_ImportImage(t *testing.T) {
+	repo := new(MockImageRepo)
+	fileStore := new(MockFileStore)
+	rbacSvc := new(MockRBACService)
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	svc := services.NewImageService(services.ImageServiceParams{
+		Repo:      repo,
+		RBACSvc:   rbacSvc,
+		FileStore: fileStore,
+		Logger:    slog.Default(),
+	})
+
+	ctx := context.Background()
+	ctx = appcontext.WithUserID(ctx, uuid.New())
+
+	t.Run("FormatIMG", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(bytes.Repeat([]byte("x"), 1024))
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusActive
+		})).Return(nil).Once()
+		fileStore.On("Write", mock.Anything, "images", mock.Anything, mock.Anything).Return(int64(1024*1024), nil).Once()
+
+		img, err := svc.ImportImage(ctx, "img", strings.TrimSuffix(server.URL, "/")+"/ubuntu.img", "desc", "linux", "1.0", false)
+		require.NoError(t, err)
+		assert.Equal(t, "img", img.Format)
+	})
+
+	t.Run("FormatRaw", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(bytes.Repeat([]byte("x"), 1024))
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusActive
+		})).Return(nil).Once()
+		fileStore.On("Write", mock.Anything, "images", mock.Anything, mock.Anything).Return(int64(1024*1024), nil).Once()
+
+		img, err := svc.ImportImage(ctx, "raw", strings.TrimSuffix(server.URL, "/")+"/disk.raw", "desc", "linux", "1.0", false)
+		require.NoError(t, err)
+		assert.Equal(t, "raw", img.Format)
+	})
+
+	t.Run("FormatISO", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(bytes.Repeat([]byte("x"), 1024))
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusActive
+		})).Return(nil).Once()
+		fileStore.On("Write", mock.Anything, "images", mock.Anything, mock.Anything).Return(int64(1024*1024), nil).Once()
+
+		img, err := svc.ImportImage(ctx, "iso", strings.TrimSuffix(server.URL, "/")+"/installer.iso", "desc", "linux", "1.0", false)
+		require.NoError(t, err)
+		assert.Equal(t, "iso", img.Format)
+	})
+
+	t.Run("UpdateToActiveFails", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write(bytes.Repeat([]byte("x"), 1024*1024))
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusActive
+		})).Return(fmt.Errorf("db error")).Once()
+		fileStore.On("Write", mock.Anything, "images", mock.Anything, mock.Anything).Return(int64(1024*1024), nil).Once()
+
+		_, err := svc.ImportImage(ctx, "my-image", server.URL, "desc", "linux", "1.0", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "db error")
+	})
+
+	t.Run("NetworkError", func(t *testing.T) {
+		deadlineCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Hour))
+		defer cancel()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusError
+		})).Return(nil).Once()
+
+		_, err := svc.ImportImage(deadlineCtx, "my-image", "http://localhost:1/image.img", "desc", "linux", "1.0", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch image")
+	})
+}
+
+func TestImageService_Unit_ListImages_OtherUserNoReadAll(t *testing.T) {
+	repo := new(MockImageRepo)
+	fileStore := new(MockFileStore)
+	rbacSvc := new(MockRBACService)
+	svc := services.NewImageService(services.ImageServiceParams{
+		Repo:      repo,
+		RBACSvc:   rbacSvc,
+		FileStore: fileStore,
+		Logger:    slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	otherUser := uuid.New()
+	userCtx := appcontext.WithUserID(ctx, userID)
+
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageRead, "*").
+		Return(nil).Once()
+	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, domain.PermissionImageReadAll, "*").
+		Return(errors.New(errors.Forbidden, "cannot list for another user")).Once()
+	_, err := svc.ListImages(userCtx, otherUser, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "another user")
 }

--- a/internal/handlers/image_handler.go
+++ b/internal/handlers/image_handler.go
@@ -29,6 +29,15 @@ type registerImageRequest struct {
 	IsPublic    bool   `json:"is_public"`
 }
 
+type importImageRequest struct {
+	Name        string `json:"name" binding:"required"`
+	URL         string `json:"url" binding:"required,url"`
+	Description string `json:"description"`
+	OS          string `json:"os" binding:"required"`
+	Version     string `json:"version" binding:"required"`
+	IsPublic    bool   `json:"is_public"`
+}
+
 // RegisterImage godoc
 // @Summary Register a new image
 // @Description Register a new VM image metadata before uploading the actual file
@@ -159,4 +168,29 @@ func (h *ImageHandler) DeleteImage(c *gin.Context) {
 	}
 
 	httputil.Success(c, http.StatusOK, gin.H{"message": "image deleted"})
+}
+
+// ImportImage godoc
+// @Summary Import image from URL
+// @Description Downloads an OS image from a remote URL and registers it
+// @Tags Images
+// @Accept json
+// @Produce json
+// @Param request body importImageRequest true "Import request"
+// @Success 202 {object} domain.Image
+// @Router /api/v1/images/import [post]
+func (h *ImageHandler) ImportImage(c *gin.Context) {
+	var req importImageRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.Wrap(errors.InvalidInput, err.Error(), err))
+		return
+	}
+
+	img, err := h.svc.ImportImage(c.Request.Context(), req.Name, req.URL, req.Description, req.OS, req.Version, req.IsPublic)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusAccepted, img)
 }

--- a/internal/handlers/image_handler_test.go
+++ b/internal/handlers/image_handler_test.go
@@ -68,6 +68,15 @@ func (m *mockImageService) DeleteImage(ctx context.Context, id uuid.UUID) error 
 	return args.Error(0)
 }
 
+func (m *mockImageService) ImportImage(ctx context.Context, name, url, description, os, version string, isPublic bool) (*domain.Image, error) {
+	args := m.Called(ctx, name, url, description, os, version, isPublic)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	r0, _ := args.Get(0).(*domain.Image)
+	return r0, args.Error(1)
+}
+
 func TestImageHandlerRegisterImage(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
@@ -363,6 +372,65 @@ func TestImageHandlerAdditionalErrors(t *testing.T) {
 
 		handler.UploadImage(c)
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("ImportImageServiceError", func(t *testing.T) {
+		svc := new(mockImageService)
+		handler := NewImageHandler(svc)
+		svc.On("ImportImage", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(nil, errors.New(errors.Internal, "error"))
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("POST", imagesAPI+"/import", nil)
+		bodyBytes, _ := json.Marshal(map[string]interface{}{"name": "n", "url": "http://example.com/img.qcow2", "os": "linux", "version": "1.0"})
+		c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+		handler.ImportImage(c)
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("ImportImageInvalidBody", func(t *testing.T) {
+		svc := new(mockImageService)
+		handler := NewImageHandler(svc)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("POST", imagesAPI+"/import", nil)
+		c.Request.Body = io.NopCloser(bytes.NewBufferString(`{invalid json}`))
+
+		handler.ImportImage(c)
+		assert.NotEqual(t, http.StatusAccepted, w.Code)
+	})
+
+	t.Run("ImportImage_Success", func(t *testing.T) {
+		svc := new(mockImageService)
+		handler := NewImageHandler(svc)
+
+		expectedImage := &domain.Image{
+			ID:   uuid.New(),
+			Name: "my-image",
+		}
+
+		svc.On("ImportImage", mock.Anything, "my-image", "http://example.com/img.qcow2", "desc", "linux", "1.0", false).
+			Return(expectedImage, nil).Once()
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("POST", imagesAPI+"/import", nil)
+		bodyBytes, _ := json.Marshal(map[string]interface{}{
+			"name":        "my-image",
+			"url":         "http://example.com/img.qcow2",
+			"description": "desc",
+			"os":          "linux",
+			"version":     "1.0",
+		})
+		c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+		handler.ImportImage(c)
+
+		assert.Equal(t, http.StatusAccepted, w.Code)
+		svc.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
## Summary
- Add `ImportImage` service method: downloads an OS image from a remote URL, streams it directly to `FileStore`, sets status `ACTIVE` on success or `ERROR` on failure
- Add `POST /images/import` HTTP handler returning `202 Accepted` — image record created synchronously with URL
- Format auto-detected from URL extension (`.qcow2`, `.img`, `.raw`, `.iso`), defaults to `qcow2`
- 30-minute HTTP timeout per request
- Add `SourceURL` field to `domain.Image`

## Test plan
- [x] Unit tests for `ImportImage` (success, store error, server error, network error)
- [x] Unit tests for `formatFromURL` (.img, .raw, .iso branches)
- [x] Unit tests for `UploadImage` update failure, `DeleteImage` empty FilePath and delete failure
- [x] Handler tests for `ImportImage` success, service error, invalid body
- [x] RBAC denial tests for all 6 image operations