### PR TITLE
feat(vpc): Full VPC Routing - Route Tables, IGW, NAT Gateway

### DIFF
--- a/cmd/cloud/igw.go
+++ b/cmd/cloud/igw.go
@@ -1,0 +1,143 @@
+// Package main provides the cloud CLI entrypoint.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+const igwErrorFormat = "Error: %v\n"
+
+var igwCmd = &cobra.Command{
+	Use:   "igw",
+	Short: "Manage Internet Gateways",
+}
+
+var igwCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create an internet gateway",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		igw, err := client.CreateIGW()
+		if err != nil {
+			fmt.Printf(igwErrorFormat, err)
+			return
+		}
+
+		if opts.JSON {
+			printJSON(igw)
+		} else {
+			fmt.Printf("[SUCCESS] Internet Gateway %s created successfully!\n", igw.ID)
+			fmt.Printf("ID: %s\n", igw.ID)
+			fmt.Printf("Status: %s\n", igw.Status)
+		}
+	},
+}
+
+var igwAttachCmd = &cobra.Command{
+	Use:   "attach [igw-id] [vpc-id]",
+	Short: "Attach an internet gateway to a VPC",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		igwID := args[0]
+		vpcID := args[1]
+
+		if err := client.AttachIGW(igwID, vpcID); err != nil {
+			fmt.Printf(igwErrorFormat, err)
+			return
+		}
+
+		fmt.Printf("[SUCCESS] Internet Gateway %s attached to VPC %s\n", igwID, vpcID)
+	},
+}
+
+var igwDetachCmd = &cobra.Command{
+	Use:   "detach [igw-id]",
+	Short: "Detach an internet gateway from its VPC",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		igwID := args[0]
+
+		if err := client.DetachIGW(igwID); err != nil {
+			fmt.Printf(igwErrorFormat, err)
+			return
+		}
+
+		fmt.Printf("[SUCCESS] Internet Gateway %s detached successfully.\n", igwID)
+	},
+}
+
+var igwListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all internet gateways",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		igws, err := client.ListIGWs()
+		if err != nil {
+			fmt.Printf(igwErrorFormat, err)
+			return
+		}
+
+		if opts.JSON {
+			printJSON(igws)
+			return
+		}
+
+		if len(igws) == 0 {
+			fmt.Println("No internet gateways found.")
+			return
+		}
+
+		table := tablewriter.NewWriter(os.Stdout)
+		table.Header([]string{"ID", "VPC ID", "STATUS", "CREATED AT"})
+
+		for _, igw := range igws {
+			vpcIDStr := "None"
+			if igw.VPCID != nil {
+				vpcIDStr = truncateID(*igw.VPCID)
+			}
+			table.Append([]string{
+				truncateID(igw.ID),
+				vpcIDStr,
+				string(igw.Status),
+				igw.CreatedAt.Format("2006-01-02 15:04:05"),
+			})
+		}
+		table.Render()
+	},
+}
+
+var igwRmCmd = &cobra.Command{
+	Use:     "rm [igw-id]",
+	Aliases: []string{"delete"},
+	Short:   "Delete an internet gateway (must be detached)",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		igwID := args[0]
+
+		if err := client.DeleteIGW(igwID); err != nil {
+			fmt.Printf(igwErrorFormat, err)
+			return
+		}
+
+		fmt.Printf("[SUCCESS] Internet Gateway %s deleted successfully.\n", igwID)
+	},
+}
+
+func init() {
+	igwCmd.AddCommand(igwCreateCmd)
+	igwCmd.AddCommand(igwAttachCmd)
+	igwCmd.AddCommand(igwDetachCmd)
+	igwCmd.AddCommand(igwListCmd)
+	igwCmd.AddCommand(igwRmCmd)
+
+	rootCmd.AddCommand(igwCmd)
+}

--- a/cmd/cloud/main.go
+++ b/cmd/cloud/main.go
@@ -58,6 +58,9 @@ func init() {
 	rootCmd.AddCommand(instanceTypeCmd)
 	rootCmd.AddCommand(newSSHKeyCmd(&opts))
 	rootCmd.AddCommand(vpcPeeringCmd)
+	rootCmd.AddCommand(igwCmd)
+	rootCmd.AddCommand(natGatewayCmd)
+	rootCmd.AddCommand(routeTableCmd)
 
 	rootCmd.PersistentFlags().BoolVarP(&opts.JSON, "json", "j", false, "Output in JSON format")
 	rootCmd.PersistentFlags().StringVarP(&opts.APIKey, "api-key", "k", "", "API key for authentication")

--- a/cmd/cloud/nat_gateway.go
+++ b/cmd/cloud/nat_gateway.go
@@ -1,0 +1,112 @@
+// Package main provides the cloud CLI entrypoint.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+)
+
+const natErrorFormat = "Error: %v\n"
+
+var natGatewayCmd = &cobra.Command{
+	Use:   "nat-gateway",
+	Short: "Manage NAT Gateways",
+}
+
+var natGatewayCreateCmd = &cobra.Command{
+	Use:   "create [subnet-id] [eip-id]",
+	Short: "Create a NAT gateway in a subnet with an elastic IP",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		subnetID := args[0]
+		eipID := args[1]
+
+		nat, err := client.CreateNATGateway(subnetID, eipID)
+		if err != nil {
+			fmt.Printf(natErrorFormat, err)
+			return
+		}
+
+		if opts.JSON {
+			printJSON(nat)
+		} else {
+			fmt.Printf("[SUCCESS] NAT Gateway %s created successfully!\n", nat.ID)
+			fmt.Printf("ID: %s\n", nat.ID)
+			fmt.Printf("Subnet ID: %s\n", nat.SubnetID)
+			fmt.Printf("Elastic IP ID: %s\n", nat.ElasticIPID)
+			fmt.Printf("Private IP: %s\n", nat.PrivateIP)
+			fmt.Printf("Status: %s\n", nat.Status)
+		}
+	},
+}
+
+var natGatewayListCmd = &cobra.Command{
+	Use:   "list [vpc-id]",
+	Short: "List NAT gateways for a VPC",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		vpcID := args[0]
+
+		nats, err := client.ListNATGateways(vpcID)
+		if err != nil {
+			fmt.Printf(natErrorFormat, err)
+			return
+		}
+
+		if opts.JSON {
+			printJSON(nats)
+			return
+		}
+
+		if len(nats) == 0 {
+			fmt.Println("No NAT gateways found.")
+			return
+		}
+
+		table := tablewriter.NewWriter(os.Stdout)
+		table.Header([]string{"ID", "SUBNET ID", "EIP ID", "PRIVATE IP", "STATUS", "CREATED AT"})
+
+		for _, nat := range nats {
+			table.Append([]string{
+				truncateID(nat.ID),
+				truncateID(nat.SubnetID),
+				truncateID(nat.ElasticIPID),
+				nat.PrivateIP,
+				string(nat.Status),
+				nat.CreatedAt.Format("2006-01-02 15:04:05"),
+			})
+		}
+		table.Render()
+	},
+}
+
+var natGatewayRmCmd = &cobra.Command{
+	Use:     "rm [nat-id]",
+	Aliases: []string{"delete"},
+	Short:   "Delete a NAT gateway",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		natID := args[0]
+
+		if err := client.DeleteNATGateway(natID); err != nil {
+			fmt.Printf(natErrorFormat, err)
+			return
+		}
+
+		fmt.Printf("[SUCCESS] NAT Gateway %s deleted successfully.\n", natID)
+	},
+}
+
+func init() {
+	natGatewayCmd.AddCommand(natGatewayCreateCmd)
+	natGatewayCmd.AddCommand(natGatewayListCmd)
+	natGatewayCmd.AddCommand(natGatewayRmCmd)
+
+	rootCmd.AddCommand(natGatewayCmd)
+}

--- a/cmd/cloud/route_table.go
+++ b/cmd/cloud/route_table.go
@@ -1,0 +1,181 @@
+// Package main provides the cloud CLI entrypoint.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/poyrazk/thecloud/pkg/sdk"
+	"github.com/spf13/cobra"
+)
+
+const rtErrorFormat = "Error: %v\n"
+
+var routeTableCmd = &cobra.Command{
+	Use:   "route-table",
+	Short: "Manage VPC Route Tables",
+}
+
+var routeTableListCmd = &cobra.Command{
+	Use:   "list [vpc-id]",
+	Short: "List route tables for a VPC",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		vpcID := args[0]
+		rts, err := client.ListRouteTables(vpcID)
+		if err != nil {
+			fmt.Printf(rtErrorFormat, err)
+			return
+		}
+
+		if opts.JSON {
+			printJSON(rts)
+			return
+		}
+
+		if len(rts) == 0 {
+			fmt.Println("No route tables found.")
+			return
+		}
+
+		table := tablewriter.NewWriter(os.Stdout)
+		table.Header([]string{"ID", "NAME", "VPC ID", "MAIN", "CREATED AT"})
+
+		for _, rt := range rts {
+			mainStr := "No"
+			if rt.IsMain {
+				mainStr = "Yes"
+			}
+			table.Append([]string{
+				truncateID(rt.ID),
+				rt.Name,
+				truncateID(rt.VPCID),
+				mainStr,
+				rt.CreatedAt.Format("2006-01-02 15:04:05"),
+			})
+		}
+		table.Render()
+	},
+}
+
+var routeTableCreateCmd = &cobra.Command{
+	Use:   "create [vpc-id] [name]",
+	Short: "Create a new route table",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		vpcID := args[0]
+		name := args[1]
+		isMain, _ := cmd.Flags().GetBool("main")
+
+		rt, err := client.CreateRouteTable(vpcID, name, isMain)
+		if err != nil {
+			fmt.Printf(rtErrorFormat, err)
+			return
+		}
+
+		if opts.JSON {
+			printJSON(rt)
+		} else {
+			fmt.Printf("[SUCCESS] Route table %s created successfully!\n", rt.Name)
+			fmt.Printf("ID: %s\n", rt.ID)
+			fmt.Printf("VPC ID: %s\n", rt.VPCID)
+			fmt.Printf("Main: %t\n", rt.IsMain)
+		}
+	},
+}
+
+var routeTableRmCmd = &cobra.Command{
+	Use:     "rm [rt-id]",
+	Aliases: []string{"delete"},
+	Short:   "Remove a route table",
+	Args:    cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		rtID := args[0]
+		if err := client.DeleteRouteTable(rtID); err != nil {
+			fmt.Printf(rtErrorFormat, err)
+			return
+		}
+
+		fmt.Printf("[SUCCESS] Route table %s removed successfully.\n", rtID)
+	},
+}
+
+var routeTableAddRouteCmd = &cobra.Command{
+	Use:   "add-route [rt-id] [destination-cidr] [target-type]",
+	Short: "Add a route to a route table",
+	Args:  cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		rtID := args[0]
+		destCIDR := args[1]
+		targetType := sdk.RouteTargetType(args[2])
+		targetID, _ := cmd.Flags().GetString("target-id")
+
+		route, err := client.AddRoute(rtID, destCIDR, targetType, targetID)
+		if err != nil {
+			fmt.Printf(rtErrorFormat, err)
+			return
+		}
+
+		if opts.JSON {
+			printJSON(route)
+		} else {
+			fmt.Printf("[SUCCESS] Route %s added successfully!\n", route.ID)
+			fmt.Printf("Destination: %s\n", route.DestinationCIDR)
+			fmt.Printf("Target Type: %s\n", route.TargetType)
+		}
+	},
+}
+
+var routeTableAssociateCmd = &cobra.Command{
+	Use:   "associate [rt-id] [subnet-id]",
+	Short: "Associate a subnet with a route table",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		rtID := args[0]
+		subnetID := args[1]
+
+		if err := client.AssociateSubnet(rtID, subnetID); err != nil {
+			fmt.Printf(rtErrorFormat, err)
+			return
+		}
+
+		fmt.Printf("[SUCCESS] Subnet %s associated with route table %s\n", subnetID, rtID)
+	},
+}
+
+var routeTableDisassociateCmd = &cobra.Command{
+	Use:   "disassociate [rt-id] [subnet-id]",
+	Short: "Disassociate a subnet from a route table",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		rtID := args[0]
+		subnetID := args[1]
+
+		if err := client.DisassociateSubnet(rtID, subnetID); err != nil {
+			fmt.Printf(rtErrorFormat, err)
+			return
+		}
+
+		fmt.Printf("[SUCCESS] Subnet %s disassociated from route table %s\n", subnetID, rtID)
+	},
+}
+
+func init() {
+	routeTableCreateCmd.Flags().Bool("main", false, "Set as the main route table")
+
+	routeTableCmd.AddCommand(routeTableListCmd)
+	routeTableCmd.AddCommand(routeTableCreateCmd)
+	routeTableCmd.AddCommand(routeTableRmCmd)
+	routeTableCmd.AddCommand(routeTableAddRouteCmd)
+	routeTableCmd.AddCommand(routeTableAssociateCmd)
+	routeTableCmd.AddCommand(routeTableDisassociateCmd)
+
+	rootCmd.AddCommand(routeTableCmd)
+}

--- a/docs/adr/ADR-025-vpc-routing-architecture.md
+++ b/docs/adr/ADR-025-vpc-routing-architecture.md
@@ -1,0 +1,130 @@
+# ADR 025: VPC Routing Architecture
+
+## Status
+Accepted
+
+## Date
+2026-04-24
+
+## Context
+
+The platform needed to implement full VPC routing capabilities to enable private subnet internet access, VPC peering connectivity, and centralized traffic management. The initial implementation of VPC Peering directly manipulated OVS flow rules instead of using a route table abstraction, creating tight coupling between business logic and network implementation details.
+
+## Decision
+
+We decided to implement a layered routing architecture with route table abstraction:
+
+### 1. Route Table Domain Model
+
+Route tables are first-class VPC resources that contain ordered routes:
+```go
+type RouteTable struct {
+    ID     uuid.UUID
+    VPCID  uuid.UUID
+    Name   string
+    IsMain bool  // One main RT per VPC, auto-created
+    Routes []Route
+}
+
+type Route struct {
+    ID              uuid.UUID
+    RouteTableID    uuid.UUID
+    DestinationCIDR string
+    TargetType      RouteTargetType  // local, igw, nat, peering, instance
+    TargetID        *uuid.UUID        // References IGW, NAT, Peering, Instance
+    TargetName      string            // Human-readable name
+}
+```
+
+### 2. Route Table Abstraction for VPC Peering
+
+Instead of direct OVS flow manipulation, VPCPeeringService now adds/removes routes via the route table repository:
+
+```go
+// addPeeringFlows creates routes in main route tables
+reqRT, _ := s.rtRepo.GetMainByVPC(ctx, requesterVPC.ID)
+s.rtRepo.AddRoute(ctx, reqRT.ID, &Route{
+    DestinationCIDR: accepterVPC.CIDRBlock,
+    TargetType:      RouteTargetPeering,
+    TargetID:        &peeringID,
+})
+```
+
+Similarly `removePeeringFlows` uses `s.rtRepo.RemoveRoute`.
+
+**Why:** This decouples VPC peering from OVS implementation. The same peering routes can be programmed via different backends (OVS, Linux bridge, cloud hypervisor).
+
+### 3. Auto-Creation of Main Route Table
+
+When a VPC is created, its main route table is auto-created with a local route:
+```go
+mainRT := &RouteTable{
+    VPCID:  vpc.ID,
+    Name:   "main",
+    IsMain: true,
+    Routes: []Route{{
+        DestinationCIDR: vpc.CIDRBlock,
+        TargetType:      RouteTargetLocal,
+    }},
+}
+s.routeTableRepo.Create(ctx, mainRT)
+```
+
+### 4. NAT Gateway via OVS Adapter
+
+NAT gateways use the `NetworkBackend` interface to set up iptables SNAT:
+```go
+// NetworkBackend interface
+SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error
+RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error
+```
+
+The OVS adapter implements this using veth pairs and iptables rules.
+
+### 5. Service Layer Wiring
+
+Services are injected via dependency injection in `dependencies.go`:
+```go
+type Services struct {
+    VpcService         *services.VpcService
+    VPCPeeringService  *services.VPCPeeringService
+    RouteTableService  *services.RouteTableService
+    InternetGateway    *services.InternetGatewayService
+    NATGateway         *services.NATGatewayService
+    // ...
+}
+```
+
+## Consequences
+
+### Positive
+- **Abstraction**: Route tables provide a stable API for routing decisions. OVS flow changes are an implementation detail.
+- **Consistency**: All VPC routing (peering, IGW, NAT) now uses the same route table model.
+- **Testability**: Services can be unit tested with mock route table repositories.
+- **Maintainability**: Adding new routing targets (e.g., VPN gateway) only requires implementing a new `TargetType`, not rewriting peering logic.
+
+### Negative
+- **Complexity**: Additional layer of indirection. Routes must be kept in sync with actual OVS flows.
+- **Consistency Risk**: If OVS flows fail but route table records succeed, state becomes inconsistent. Mitigated by immediate rollback on flow programming failure.
+
+### Neutral
+- Main route table auto-creation means VPC creation now has a dependency on route table persistence.
+- Route table operations add latency to peering accept/delete operations.
+
+## Alternatives Considered
+
+### Alternative 1: Direct OVS Flow Management in PeeringService
+**Why rejected:** Tied peering lifecycle to OVS implementation. Changes to network topology required modifying business logic. Harder to test without actual OVS.
+
+### Alternative 2: Separate Routing Service with OVS Synchronization
+**Why rejected:** Over-engineered. A separate sync process introduces eventual consistency issues. The route table abstraction inside the same service provides consistency without added complexity.
+
+### Alternative 3: Delegating All Routing to OVS Adapter
+**Why rejected:** Would require the adapter to understand VPC resources (peering IDs, EIP associations). Adapter should be thin - it receives high-level commands like "setup NAT for subnet" rather than low-level flow rules.
+
+## Implementation Notes
+
+- Route target types: `local`, `igw`, `nat`, `peering`, `instance`
+- Only main route table cannot be deleted
+- Subnet association is one-to-one: a subnet can only belong to one route table
+- NAT gateway creation requires EIP to be in `allocated` (not `associated`) state

--- a/docs/adr/ADR-025-vpc-routing-architecture.md
+++ b/docs/adr/ADR-025-vpc-routing-architecture.md
@@ -128,3 +128,17 @@ type Services struct {
 - Only main route table cannot be deleted
 - Subnet association is one-to-one: a subnet can only belong to one route table
 - NAT gateway creation requires EIP to be in `allocated` (not `associated`) state
+
+### NAT Gateway Requirements
+
+The NAT gateway implementation requires `net.ipv4.ip_forward=1` to be enabled on the host system:
+
+```bash
+# Enable immediately (requires root)
+sysctl -w net.ipv4.ip_forward=1
+
+# Make persistent across reboots
+echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+```
+
+This is a **system-wide** kernel parameter. Without it, packets from private subnets will not be forwarded to the NAT gateway's veth interface, and NAT functionality will not work.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -370,10 +370,145 @@ Delete a VPC.
  
  ### DELETE /vpc-peerings/:id
  Delete a peering connection and remove all associated network routes.
- 
+
  ---
- 
- ## Security Groups
+
+## Route Tables 🆕
+
+**Headers Required:** `X-API-Key: <your-api-key>`
+
+### GET /route-tables
+List all route tables for a VPC.
+Query params: `?vpc_id=<vpc-uuid>` (required)
+
+### POST /route-tables
+Create a new custom route table.
+```json
+{
+  "vpc_id": "vpc-uuid",
+  "name": "custom-rt",
+  "is_main": false
+}
+```
+
+### GET /route-tables/:id
+Get details of a specific route table including its routes.
+
+### DELETE /route-tables/:id
+Delete a custom route table. Cannot delete the main route table of a VPC.
+
+### POST /route-tables/:id/routes
+Add a route to a route table.
+```json
+{
+  "destination_cidr": "0.0.0.0/0",
+  "target_type": "igw",
+  "target_id": "igw-uuid"
+}
+```
+
+**Target Types:**
+- `local` - Traffic within VPC CIDR
+- `igw` - Internet Gateway
+- `nat` - NAT Gateway
+- `peering` - VPC Peering connection
+
+### DELETE /route-tables/:id/routes?route_id=<route_id>
+Remove a route from a route table. Query param `route_id` is required.
+
+### POST /route-tables/:id/associate
+Associate a subnet with a route table.
+```json
+{
+  "subnet_id": "subnet-uuid"
+}
+```
+
+### POST /route-tables/:id/disassociate
+Disassociate a subnet from a route table.
+```json
+{
+  "subnet_id": "subnet-uuid"
+}
+```
+
+---
+
+## Internet Gateways 🆕
+
+**Headers Required:** `X-API-Key: <your-api-key>`
+
+### GET /internet-gateways
+List all internet gateways for the tenant.
+
+### POST /internet-gateways
+Create a new internet gateway.
+**Response (201 Created):**
+```json
+{
+  "id": "uuid",
+  "status": "detached",
+  "arn": "arn:thecloud:vpc:local:tenant:igw/uuid"
+}
+```
+
+### GET /internet-gateways/:id
+Get details of a specific internet gateway.
+
+### POST /internet-gateways/:id/attach
+Attach an internet gateway to a VPC.
+```json
+{
+  "vpc_id": "vpc-uuid"
+}
+```
+
+### POST /internet-gateways/:id/detach
+Detach an internet gateway from its VPC. Must remove all routes referencing this IGW first.
+
+### DELETE /internet-gateways/:id
+Delete an internet gateway. Must be detached first.
+
+---
+
+## NAT Gateways 🆕
+
+**Headers Required:** `X-API-Key: <your-api-key>`
+
+### GET /nat-gateways
+List all NAT gateways for a VPC.
+Query params: `?vpc_id=<vpc-uuid>` (required)
+
+### POST /nat-gateways
+Create a new NAT gateway in a subnet with an allocated Elastic IP.
+```json
+{
+  "subnet_id": "subnet-uuid",
+  "eip_id": "eip-uuid"
+}
+```
+**Response (201 Created):**
+```json
+{
+  "id": "uuid",
+  "vpc_id": "vpc-uuid",
+  "subnet_id": "subnet-uuid",
+  "elastic_ip_id": "eip-uuid",
+  "status": "active",
+  "private_ip": "10.0.1.100",
+  "arn": "arn:thecloud:vpc:local:tenant:nat-gateway/uuid"
+}
+```
+
+### GET /nat-gateways/:id
+Get details of a specific NAT gateway.
+
+### DELETE /nat-gateways/:id
+Delete a NAT gateway and release the associated Elastic IP back to allocated state.
+
+---
+
+## Security Groups
 
 **Headers Required:** `X-API-Key: <your-api-key>`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -396,7 +396,160 @@ cloud vpc rm my-network
  
  ```bash
  cloud vpc-peering rm peering-uuid
- ```
+```
+
+---
+
+## Route Table Commands 🆕
+
+Manage VPC route tables.
+
+### `route-table list [vpc-id]`
+
+List all route tables in a VPC.
+
+```bash
+cloud route-table list vpc-uuid
+```
+
+### `route-table create [vpc-id] [name]`
+
+Create a new route table in a VPC.
+
+```bash
+cloud route-table create vpc-uuid my-rt --main
+```
+
+**Flags:**
+| Flag | Short | Required | Default | Description |
+|------|-------|----------|---------|-------------|
+| `--main` | | No | false | Set as the main route table for the VPC |
+
+### `route-table rm <id>`
+
+Delete a route table. Cannot delete the main route table.
+
+```bash
+cloud route-table rm rt-uuid
+```
+
+### `route-table add-route <rt-id> [dest-cidr] [target-type]`
+
+Add a route to a route table.
+
+```bash
+cloud route-table add-route rt-uuid 0.0.0.0/0 igw --target-id igw-uuid
+cloud route-table add-route rt-uuid 10.0.1.0/24 nat --target-id nat-uuid
+cloud route-table add-route rt-uuid 10.0.2.0/24 peering --target-id peering-uuid
+```
+
+**Target Types:** `local`, `igw`, `nat`, `peering`, `instance`
+
+### `route-table remove-route <rt-id> <route-id>`
+
+Remove a route from a route table.
+
+```bash
+cloud route-table remove-route rt-uuid route-uuid
+```
+
+### `route-table associate <rt-id> <subnet-id>`
+
+Associate a subnet with a route table.
+
+```bash
+cloud route-table associate rt-uuid subnet-uuid
+```
+
+### `route-table disassociate <rt-id> <subnet-id>`
+
+Disassociate a subnet from a route table.
+
+```bash
+cloud route-table disassociate rt-uuid subnet-uuid
+```
+
+---
+
+## Internet Gateway Commands 🆕
+
+Manage internet gateways for VPC routing.
+
+### `igw create`
+
+Create a new internet gateway.
+
+```bash
+cloud igw create
+```
+
+### `igw attach <igw-id> <vpc-id>`
+
+Attach an internet gateway to a VPC. This allows instances in private subnets to access the internet via the IGW.
+
+```bash
+cloud igw attach igw-uuid vpc-uuid
+```
+
+### `igw detach <igw-id>`
+
+Detach an internet gateway from its VPC. Must remove all routes referencing the IGW first.
+
+```bash
+cloud igw detach igw-uuid
+```
+
+### `igw list`
+
+List all internet gateways.
+
+```bash
+cloud igw list
+```
+
+### `igw rm <id>`
+
+Delete an internet gateway. Must be detached first.
+
+```bash
+cloud igw rm igw-uuid
+```
+
+---
+
+## NAT Gateway Commands 🆕
+
+Manage NAT gateways for private subnet internet access.
+
+### `nat-gateway create [subnet-id] [eip-id]`
+
+Create a NAT gateway in a public subnet with an allocated elastic IP.
+
+```bash
+cloud nat-gateway create subnet-uuid eip-uuid
+```
+
+**Flags:**
+| Flag | Short | Required | Default | Description |
+|------|-------|----------|---------|-------------|
+| `--name` | `-n` | No | - | NAT gateway name |
+
+### `nat-gateway list [vpc-id]`
+
+List all NAT gateways, optionally filtered by VPC.
+
+```bash
+cloud nat-gateway list
+cloud nat-gateway list vpc-uuid
+```
+
+### `nat-gateway rm <id>`
+
+Delete a NAT gateway and release the associated elastic IP.
+
+```bash
+cloud nat-gateway rm nat-uuid
+```
 
 ---
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -4066,6 +4066,254 @@ const docTemplate = `{
                 }
             }
         },
+        "/internet-gateways": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "List Internet Gateways",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.InternetGateway"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Create Internet Gateway",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.InternetGateway"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/internet-gateways/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Get Internet Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Internet Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.InternetGateway"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Delete Internet Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Internet Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/internet-gateways/{id}/attach": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Attach Internet Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Internet Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Attach Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AttachRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/internet-gateways/{id}/detach": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Detach Internet Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Internet Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/lb": {
             "get": {
                 "security": [
@@ -4470,6 +4718,183 @@ const docTemplate = `{
                 }
             }
         },
+        "/nat-gateways": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "nat-gateways"
+                ],
+                "summary": "List NAT Gateways",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VPC ID to filter by",
+                        "name": "vpc_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.NATGateway"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "nat-gateways"
+                ],
+                "summary": "Create NAT Gateway",
+                "parameters": [
+                    {
+                        "description": "NAT Gateway Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CreateNATGatewayRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.NATGateway"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/nat-gateways/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "nat-gateways"
+                ],
+                "summary": "Get NAT Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "NAT Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.NATGateway"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "nat-gateways"
+                ],
+                "summary": "Delete NAT Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "NAT Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/rbac/bindings": {
             "get": {
                 "description": "Returns all user-role assignments",
@@ -4727,6 +5152,388 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/route-tables": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "List Route Tables",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VPC ID to filter by",
+                        "name": "vpc_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.RouteTable"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Create Route Table",
+                "parameters": [
+                    {
+                        "description": "Route Table Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CreateRouteTableRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.RouteTable"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Get Route Table",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.RouteTable"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Delete Route Table",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}/associate": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Associate Subnet",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Subnet Association Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AssociateSubnetRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}/disassociate": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Disassociate Subnet",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Subnet Disassociation Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AssociateSubnetRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}/routes": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Add Route",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Route Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AddRouteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Route"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}/routes/{route_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Remove Route",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Route ID",
+                        "name": "route_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
                     }
                 }
             }
@@ -7839,6 +8646,17 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.IGWStatus": {
+            "type": "string",
+            "enum": [
+                "detached",
+                "attached"
+            ],
+            "x-enum-varnames": [
+                "IGWStatusDetached",
+                "IGWStatusAttached"
+            ]
+        },
         "domain.Image": {
             "type": "object",
             "properties": {
@@ -8086,6 +8904,32 @@ const docTemplate = `{
                 }
             }
         },
+        "domain.InternetGateway": {
+            "type": "object",
+            "properties": {
+                "arn": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.IGWStatus"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.LBStatus": {
             "type": "string",
             "enum": [
@@ -8240,6 +9084,56 @@ const docTemplate = `{
                     "type": "string"
                 }
             }
+        },
+        "domain.NATGateway": {
+            "type": "object",
+            "properties": {
+                "arn": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "elastic_ip_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "private_ip": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.NATGatewayStatus"
+                },
+                "subnet_id": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.NATGatewayStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "active",
+                "failed",
+                "deleted"
+            ],
+            "x-enum-varnames": [
+                "NATGatewayStatusPending",
+                "NATGatewayStatusActive",
+                "NATGatewayStatusFailed",
+                "NATGatewayStatusDeleted"
+            ]
         },
         "domain.NodeGroup": {
             "type": "object",
@@ -8693,6 +9587,96 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "domain.Route": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "destination_cidr": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "route_table_id": {
+                    "type": "string"
+                },
+                "target_id": {
+                    "type": "string"
+                },
+                "target_name": {
+                    "type": "string"
+                },
+                "target_type": {
+                    "$ref": "#/definitions/domain.RouteTargetType"
+                }
+            }
+        },
+        "domain.RouteTable": {
+            "type": "object",
+            "properties": {
+                "associations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.RouteTableAssociation"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_main": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "routes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Route"
+                    }
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.RouteTableAssociation": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "route_table_id": {
+                    "type": "string"
+                },
+                "subnet_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.RouteTargetType": {
+            "type": "string",
+            "enum": [
+                "local",
+                "igw",
+                "nat",
+                "peering"
+            ],
+            "x-enum-varnames": [
+                "RouteTargetLocal",
+                "RouteTargetIGW",
+                "RouteTargetNAT",
+                "RouteTargetPeering"
+            ]
         },
         "domain.RoutingPolicy": {
             "type": "string",
@@ -9461,6 +10445,24 @@ const docTemplate = `{
                 }
             }
         },
+        "httphandlers.AddRouteRequest": {
+            "type": "object",
+            "required": [
+                "destination_cidr",
+                "target_type"
+            ],
+            "properties": {
+                "destination_cidr": {
+                    "type": "string"
+                },
+                "target_id": {
+                    "type": "string"
+                },
+                "target_type": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.AddTargetRequest": {
             "type": "object",
             "required": [
@@ -9486,6 +10488,17 @@ const docTemplate = `{
             ],
             "properties": {
                 "instance_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.AssociateSubnetRequest": {
+            "type": "object",
+            "required": [
+                "subnet_id"
+            ],
+            "properties": {
+                "subnet_id": {
                     "type": "string"
                 }
             }
@@ -9718,6 +10731,21 @@ const docTemplate = `{
                 }
             }
         },
+        "httphandlers.CreateNATGatewayRequest": {
+            "type": "object",
+            "required": [
+                "eip_id",
+                "subnet_id"
+            ],
+            "properties": {
+                "eip_id": {
+                    "type": "string"
+                },
+                "subnet_id": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.CreatePeeringRequest": {
             "type": "object",
             "required": [
@@ -9808,6 +10836,24 @@ const docTemplate = `{
                     "type": "boolean"
                 },
                 "target_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.CreateRouteTableRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "vpc_id"
+            ],
+            "properties": {
+                "is_main": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "vpc_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -4246,7 +4246,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/httphandlers.AttachRequest"
+                            "$ref": "#/definitions/httphandlers.IGWAttachRequest"
                         }
                     }
                 ],
@@ -5515,7 +5515,7 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Route ID",
                         "name": "route_id",
-                        "in": "query",
+                        "in": "path",
                         "required": true
                     }
                 ],
@@ -10970,6 +10970,17 @@ const docTemplate = `{
             ],
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.IGWAttachRequest": {
+            "type": "object",
+            "required": [
+                "vpc_id"
+            ],
+            "properties": {
+                "vpc_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -4238,7 +4238,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/httphandlers.AttachRequest"
+                            "$ref": "#/definitions/httphandlers.IGWAttachRequest"
                         }
                     }
                 ],
@@ -5507,7 +5507,7 @@
                         "type": "string",
                         "description": "Route ID",
                         "name": "route_id",
-                        "in": "query",
+                        "in": "path",
                         "required": true
                     }
                 ],
@@ -10962,6 +10962,17 @@
             ],
             "properties": {
                 "email": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.IGWAttachRequest": {
+            "type": "object",
+            "required": [
+                "vpc_id"
+            ],
+            "properties": {
+                "vpc_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -4058,6 +4058,254 @@
                 }
             }
         },
+        "/internet-gateways": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "List Internet Gateways",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.InternetGateway"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Create Internet Gateway",
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.InternetGateway"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/internet-gateways/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Get Internet Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Internet Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.InternetGateway"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Delete Internet Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Internet Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/internet-gateways/{id}/attach": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Attach Internet Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Internet Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Attach Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AttachRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/internet-gateways/{id}/detach": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "internet-gateways"
+                ],
+                "summary": "Detach Internet Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Internet Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/lb": {
             "get": {
                 "security": [
@@ -4462,6 +4710,183 @@
                 }
             }
         },
+        "/nat-gateways": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "nat-gateways"
+                ],
+                "summary": "List NAT Gateways",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VPC ID to filter by",
+                        "name": "vpc_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.NATGateway"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "nat-gateways"
+                ],
+                "summary": "Create NAT Gateway",
+                "parameters": [
+                    {
+                        "description": "NAT Gateway Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CreateNATGatewayRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.NATGateway"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/nat-gateways/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "nat-gateways"
+                ],
+                "summary": "Get NAT Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "NAT Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.NATGateway"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "nat-gateways"
+                ],
+                "summary": "Delete NAT Gateway",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "NAT Gateway ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/rbac/bindings": {
             "get": {
                 "description": "Returns all user-role assignments",
@@ -4719,6 +5144,388 @@
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    }
+                }
+            }
+        },
+        "/route-tables": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "List Route Tables",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "VPC ID to filter by",
+                        "name": "vpc_id",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.RouteTable"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Create Route Table",
+                "parameters": [
+                    {
+                        "description": "Route Table Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.CreateRouteTableRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.RouteTable"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Get Route Table",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.RouteTable"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Delete Route Table",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}/associate": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Associate Subnet",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Subnet Association Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AssociateSubnetRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}/disassociate": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Disassociate Subnet",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Subnet Disassociation Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AssociateSubnetRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}/routes": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Add Route",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Route Request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/httphandlers.AddRouteRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/domain.Route"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/route-tables/{id}/routes/{route_id}": {
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "tags": [
+                    "route-tables"
+                ],
+                "summary": "Remove Route",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Route Table ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Route ID",
+                        "name": "route_id",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
                     }
                 }
             }
@@ -7831,6 +8638,17 @@
                 }
             }
         },
+        "domain.IGWStatus": {
+            "type": "string",
+            "enum": [
+                "detached",
+                "attached"
+            ],
+            "x-enum-varnames": [
+                "IGWStatusDetached",
+                "IGWStatusAttached"
+            ]
+        },
         "domain.Image": {
             "type": "object",
             "properties": {
@@ -8078,6 +8896,32 @@
                 }
             }
         },
+        "domain.InternetGateway": {
+            "type": "object",
+            "properties": {
+                "arn": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.IGWStatus"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
         "domain.LBStatus": {
             "type": "string",
             "enum": [
@@ -8232,6 +9076,56 @@
                     "type": "string"
                 }
             }
+        },
+        "domain.NATGateway": {
+            "type": "object",
+            "properties": {
+                "arn": {
+                    "type": "string"
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "elastic_ip_id": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "private_ip": {
+                    "type": "string"
+                },
+                "status": {
+                    "$ref": "#/definitions/domain.NATGatewayStatus"
+                },
+                "subnet_id": {
+                    "type": "string"
+                },
+                "tenant_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.NATGatewayStatus": {
+            "type": "string",
+            "enum": [
+                "pending",
+                "active",
+                "failed",
+                "deleted"
+            ],
+            "x-enum-varnames": [
+                "NATGatewayStatusPending",
+                "NATGatewayStatusActive",
+                "NATGatewayStatusFailed",
+                "NATGatewayStatusDeleted"
+            ]
         },
         "domain.NodeGroup": {
             "type": "object",
@@ -8685,6 +9579,96 @@
                     }
                 }
             }
+        },
+        "domain.Route": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "destination_cidr": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "route_table_id": {
+                    "type": "string"
+                },
+                "target_id": {
+                    "type": "string"
+                },
+                "target_name": {
+                    "type": "string"
+                },
+                "target_type": {
+                    "$ref": "#/definitions/domain.RouteTargetType"
+                }
+            }
+        },
+        "domain.RouteTable": {
+            "type": "object",
+            "properties": {
+                "associations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.RouteTableAssociation"
+                    }
+                },
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "is_main": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "routes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Route"
+                    }
+                },
+                "vpc_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.RouteTableAssociation": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "route_table_id": {
+                    "type": "string"
+                },
+                "subnet_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "domain.RouteTargetType": {
+            "type": "string",
+            "enum": [
+                "local",
+                "igw",
+                "nat",
+                "peering"
+            ],
+            "x-enum-varnames": [
+                "RouteTargetLocal",
+                "RouteTargetIGW",
+                "RouteTargetNAT",
+                "RouteTargetPeering"
+            ]
         },
         "domain.RoutingPolicy": {
             "type": "string",
@@ -9453,6 +10437,24 @@
                 }
             }
         },
+        "httphandlers.AddRouteRequest": {
+            "type": "object",
+            "required": [
+                "destination_cidr",
+                "target_type"
+            ],
+            "properties": {
+                "destination_cidr": {
+                    "type": "string"
+                },
+                "target_id": {
+                    "type": "string"
+                },
+                "target_type": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.AddTargetRequest": {
             "type": "object",
             "required": [
@@ -9478,6 +10480,17 @@
             ],
             "properties": {
                 "instance_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.AssociateSubnetRequest": {
+            "type": "object",
+            "required": [
+                "subnet_id"
+            ],
+            "properties": {
+                "subnet_id": {
                     "type": "string"
                 }
             }
@@ -9710,6 +10723,21 @@
                 }
             }
         },
+        "httphandlers.CreateNATGatewayRequest": {
+            "type": "object",
+            "required": [
+                "eip_id",
+                "subnet_id"
+            ],
+            "properties": {
+                "eip_id": {
+                    "type": "string"
+                },
+                "subnet_id": {
+                    "type": "string"
+                }
+            }
+        },
         "httphandlers.CreatePeeringRequest": {
             "type": "object",
             "required": [
@@ -9800,6 +10828,24 @@
                     "type": "boolean"
                 },
                 "target_url": {
+                    "type": "string"
+                }
+            }
+        },
+        "httphandlers.CreateRouteTableRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "vpc_id"
+            ],
+            "properties": {
+                "is_main": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "vpc_id": {
                     "type": "string"
                 }
             }

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -526,6 +526,14 @@ definitions:
       user_id:
         type: string
     type: object
+  domain.IGWStatus:
+    enum:
+    - detached
+    - attached
+    type: string
+    x-enum-varnames:
+    - IGWStatusDetached
+    - IGWStatusAttached
   domain.Image:
     properties:
       created_at:
@@ -702,6 +710,23 @@ definitions:
         description: Number of virtual CPUs
         type: integer
     type: object
+  domain.InternetGateway:
+    properties:
+      arn:
+        type: string
+      created_at:
+        type: string
+      id:
+        type: string
+      status:
+        $ref: '#/definitions/domain.IGWStatus'
+      tenant_id:
+        type: string
+      user_id:
+        type: string
+      vpc_id:
+        type: string
+    type: object
   domain.LBStatus:
     enum:
     - CREATING
@@ -808,6 +833,41 @@ definitions:
       user_id:
         type: string
     type: object
+  domain.NATGateway:
+    properties:
+      arn:
+        type: string
+      created_at:
+        type: string
+      elastic_ip_id:
+        type: string
+      id:
+        type: string
+      private_ip:
+        type: string
+      status:
+        $ref: '#/definitions/domain.NATGatewayStatus'
+      subnet_id:
+        type: string
+      tenant_id:
+        type: string
+      user_id:
+        type: string
+      vpc_id:
+        type: string
+    type: object
+  domain.NATGatewayStatus:
+    enum:
+    - pending
+    - active
+    - failed
+    - deleted
+    type: string
+    x-enum-varnames:
+    - NATGatewayStatusPending
+    - NATGatewayStatusActive
+    - NATGatewayStatusFailed
+    - NATGatewayStatusDeleted
   domain.NodeGroup:
     properties:
       cluster_id:
@@ -1192,6 +1252,67 @@ definitions:
           $ref: '#/definitions/domain.Permission'
         type: array
     type: object
+  domain.Route:
+    properties:
+      created_at:
+        type: string
+      destination_cidr:
+        type: string
+      id:
+        type: string
+      route_table_id:
+        type: string
+      target_id:
+        type: string
+      target_name:
+        type: string
+      target_type:
+        $ref: '#/definitions/domain.RouteTargetType'
+    type: object
+  domain.RouteTable:
+    properties:
+      associations:
+        items:
+          $ref: '#/definitions/domain.RouteTableAssociation'
+        type: array
+      created_at:
+        type: string
+      id:
+        type: string
+      is_main:
+        type: boolean
+      name:
+        type: string
+      routes:
+        items:
+          $ref: '#/definitions/domain.Route'
+        type: array
+      vpc_id:
+        type: string
+    type: object
+  domain.RouteTableAssociation:
+    properties:
+      created_at:
+        type: string
+      id:
+        type: string
+      route_table_id:
+        type: string
+      subnet_id:
+        type: string
+    type: object
+  domain.RouteTargetType:
+    enum:
+    - local
+    - igw
+    - nat
+    - peering
+    type: string
+    x-enum-varnames:
+    - RouteTargetLocal
+    - RouteTargetIGW
+    - RouteTargetNAT
+    - RouteTargetPeering
   domain.RoutingPolicy:
     enum:
     - LATENCY
@@ -1727,6 +1848,18 @@ definitions:
     required:
     - permission
     type: object
+  httphandlers.AddRouteRequest:
+    properties:
+      destination_cidr:
+        type: string
+      target_id:
+        type: string
+      target_type:
+        type: string
+    required:
+    - destination_cidr
+    - target_type
+    type: object
   httphandlers.AddTargetRequest:
     properties:
       instance_id:
@@ -1745,6 +1878,13 @@ definitions:
         type: string
     required:
     - instance_id
+    type: object
+  httphandlers.AssociateSubnetRequest:
+    properties:
+      subnet_id:
+        type: string
+    required:
+    - subnet_id
     type: object
   httphandlers.AttachDetachSGRequest:
     properties:
@@ -1901,6 +2041,16 @@ definitions:
     - port
     - vpc_id
     type: object
+  httphandlers.CreateNATGatewayRequest:
+    properties:
+      eip_id:
+        type: string
+      subnet_id:
+        type: string
+    required:
+    - eip_id
+    - subnet_id
+    type: object
   httphandlers.CreatePeeringRequest:
     properties:
       accepter_vpc_id:
@@ -1963,6 +2113,18 @@ definitions:
     - name
     - path_prefix
     - target_url
+    type: object
+  httphandlers.CreateRouteTableRequest:
+    properties:
+      is_main:
+        type: boolean
+      name:
+        type: string
+      vpc_id:
+        type: string
+    required:
+    - name
+    - vpc_id
     type: object
   httphandlers.CreateSSHKeyRequest:
     properties:
@@ -4885,6 +5047,160 @@ paths:
       summary: Stop an instance
       tags:
       - instances
+  /internet-gateways:
+    get:
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.InternetGateway'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: List Internet Gateways
+      tags:
+      - internet-gateways
+    post:
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.InternetGateway'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Create Internet Gateway
+      tags:
+      - internet-gateways
+  /internet-gateways/{id}:
+    delete:
+      parameters:
+      - description: Internet Gateway ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Delete Internet Gateway
+      tags:
+      - internet-gateways
+    get:
+      parameters:
+      - description: Internet Gateway ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.InternetGateway'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Get Internet Gateway
+      tags:
+      - internet-gateways
+  /internet-gateways/{id}/attach:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Internet Gateway ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Attach Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.AttachRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Attach Internet Gateway
+      tags:
+      - internet-gateways
+  /internet-gateways/{id}/detach:
+    post:
+      parameters:
+      - description: Internet Gateway ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Detach Internet Gateway
+      tags:
+      - internet-gateways
   /lb:
     get:
       description: Gets a list of all load balancers
@@ -5140,6 +5456,116 @@ paths:
       summary: Get logs by resource
       tags:
       - logs
+  /nat-gateways:
+    get:
+      parameters:
+      - description: VPC ID to filter by
+        in: query
+        name: vpc_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.NATGateway'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: List NAT Gateways
+      tags:
+      - nat-gateways
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: NAT Gateway Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.CreateNATGatewayRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.NATGateway'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Create NAT Gateway
+      tags:
+      - nat-gateways
+  /nat-gateways/{id}:
+    delete:
+      parameters:
+      - description: NAT Gateway ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Delete NAT Gateway
+      tags:
+      - nat-gateways
+    get:
+      parameters:
+      - description: NAT Gateway ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.NATGateway'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Get NAT Gateway
+      tags:
+      - nat-gateways
   /rbac/bindings:
     get:
       description: Returns all user-role assignments
@@ -5312,6 +5738,245 @@ paths:
       summary: Remove permission from role
       tags:
       - RBAC
+  /route-tables:
+    get:
+      parameters:
+      - description: VPC ID to filter by
+        in: query
+        name: vpc_id
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/domain.RouteTable'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: List Route Tables
+      tags:
+      - route-tables
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Route Table Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.CreateRouteTableRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.RouteTable'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Create Route Table
+      tags:
+      - route-tables
+  /route-tables/{id}:
+    delete:
+      parameters:
+      - description: Route Table ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Delete Route Table
+      tags:
+      - route-tables
+    get:
+      parameters:
+      - description: Route Table ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/domain.RouteTable'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Get Route Table
+      tags:
+      - route-tables
+  /route-tables/{id}/associate:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Route Table ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Subnet Association Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.AssociateSubnetRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Associate Subnet
+      tags:
+      - route-tables
+  /route-tables/{id}/disassociate:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Route Table ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Subnet Disassociation Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.AssociateSubnetRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Disassociate Subnet
+      tags:
+      - route-tables
+  /route-tables/{id}/routes:
+    post:
+      consumes:
+      - application/json
+      parameters:
+      - description: Route Table ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Route Request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/httphandlers.AddRouteRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/domain.Route'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Add Route
+      tags:
+      - route-tables
+  /route-tables/{id}/routes/{route_id}:
+    delete:
+      parameters:
+      - description: Route Table ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Route ID
+        in: query
+        name: route_id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Remove Route
+      tags:
+      - route-tables
   /security-groups:
     get:
       description: Lists all security groups for a VPC

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -2204,6 +2204,13 @@ definitions:
     required:
     - email
     type: object
+  httphandlers.IGWAttachRequest:
+    properties:
+      vpc_id:
+        type: string
+    required:
+    - vpc_id
+    type: object
   httphandlers.LaunchRequest:
     properties:
       cmd:
@@ -5154,7 +5161,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/httphandlers.AttachRequest'
+          $ref: '#/definitions/httphandlers.IGWAttachRequest'
       produces:
       - application/json
       responses:
@@ -5957,7 +5964,7 @@ paths:
         required: true
         type: string
       - description: Route ID
-        in: query
+        in: path
         name: route_id
         required: true
         type: string

--- a/docs/vpc-routing-roadmap.md
+++ b/docs/vpc-routing-roadmap.md
@@ -1,0 +1,378 @@
+# Full VPC Routing - Stacked PR Roadmap
+
+## Overview
+
+Implementation divided into **5 sequential PRs** that stack onto a feature branch `feature/vpc-routing`, then merge to main as a complete feature.
+
+```
+main ──────────────────────────────────────────────────────────
+         │
+         └─ feature/vpc-routing ── PR#1 ── PR#2 ── PR#3 ── PR#4 ── PR#5 ── merge to main
+```
+
+**Workflow:**
+1. Create `feature/vpc-routing` branch from main
+2. Open PR #1 against `feature/vpc-routing`
+3. After PR #1 merges, rebase PR #2 onto updated feature branch
+4. Repeat until all PRs merged
+5. Final PR: merge `feature/vpc-routing` into main
+
+---
+
+## PR #1: Domain Models & Ports
+
+**Branch:** `feature/vpc-routing`
+**Target:** `feature/vpc-routing`
+
+### Goal
+Establish the foundation - domain structs and interfaces only. No implementation logic.
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `internal/core/domain/route_table.go` | RouteTable, Route, RouteTableAssociation, RouteTargetType |
+| `internal/core/domain/internet_gateway.go` | InternetGateway, IGWStatus |
+| `internal/core/domain/nat_gateway.go` | NATGateway, NATGatewayStatus |
+| `internal/core/ports/route_table.go` | RouteTableRepository, RouteTableService interfaces |
+| `internal/core/ports/internet_gateway.go` | IGWRepository, InternetGatewayService interfaces |
+| `internal/core/ports/nat_gateway.go` | NATGatewayRepository, NATGatewayService interfaces |
+
+### Validation
+```bash
+go build ./internal/core/domain/...
+go build ./internal/core/ports/...
+```
+
+### PR Description
+```
+feat(vpc-routing): Add domain models and ports for Route Tables, IGW, and NAT Gateway
+
+- RouteTable with Routes and Subnet associations
+- InternetGateway with attach/detach lifecycle
+- NATGateway with EIP dependency
+- Repository and Service interfaces for each
+```
+
+---
+
+## PR #2: Database Migrations & Repositories
+
+**Branch:** `feature/vpc-routing`
+**Target:** `feature/vpc-routing` (rebase after PR #1 merges)
+
+### Goal
+Add persistence layer - PostgreSQL tables and repository implementations.
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `internal/repositories/postgres/migrations/XXX_create_route_tables.up.sql` | route_tables, routes, route_table_associations, internet_gateways, nat_gateways |
+| `internal/repositories/postgres/migrations/XXX_add_subnet_routing_table.up.sql` | Add routing_table_id to subnets |
+| `internal/repositories/postgres/route_table_repo.go` | RouteTableRepository implementation |
+| `internal/repositories/postgres/igw_repo.go` | IGWRepository implementation |
+| `internal/repositories/postgres/nat_gateway_repo.go` | NATGatewayRepository implementation |
+
+### Files to Modify
+- `internal/repositories/postgres/repository.go` - register new repositories
+
+### Dependencies
+- Requires PR #1 merged and `feature/vpc-routing` rebased
+
+### Validation
+```bash
+go run github.com/pressly/goose/v3/cmd/goose up
+go build ./internal/repositories/postgres/...
+```
+
+### PR Description
+```
+feat(vpc-routing): Add persistence layer for Route Tables, IGW, and NAT Gateway
+
+- PostgreSQL migrations for 5 new tables
+- Repository implementations with pgx
+- Subnet now references a routing table
+```
+
+---
+
+## PR #3: OVS Adapter Extensions
+
+**Branch:** `feature/vpc-routing`
+**Target:** `feature/vpc-routing` (rebase after PR #2 merges)
+
+### Goal
+Extend NetworkBackend with NAT support and implement in OVS adapter.
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `internal/core/ports/network.go` | Add SetupNATForSubnet, RemoveNATForSubnet to NetworkBackend |
+| `internal/repositories/ovs/adapter.go` | Implement NAT methods with iptables SNAT |
+| `internal/repositories/noop/network_adapter.go` | Noop stubs for NAT methods |
+
+### NAT Implementation
+- NAT Gateway runs as "bastion host" in public subnet
+- Host-side veth connects to VPC bridge
+- iptables SNAT for outbound traffic
+- Return traffic auto de-SNATed via connection tracking
+
+### Dependencies
+- Requires PR #2 merged and `feature/vpc-routing` rebased
+
+### Validation
+```bash
+go build ./internal/repositories/ovs/...
+go build ./internal/repositories/noop/...
+# Manual: iptables -t nat -L -n shows SNAT rules after setup
+```
+
+### PR Description
+```
+feat(vpc-routing): Extend NetworkBackend with NAT support
+
+- Add SetupNATForSubnet/RemoveNATForSubnet to NetworkBackend interface
+- OVS adapter implementation using iptables SNAT
+- Noop adapter stubs for testing environments
+```
+
+---
+
+## PR #4: Service Implementations
+
+**Branch:** `feature/vpc-routing`
+**Target:** `feature/vpc-routing` (rebase after PR #3 merges)
+
+### Goal
+Implement RouteTableService, InternetGatewayService, NATGatewayService. Integrate with existing services.
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `internal/core/services/route_table.go` | RouteTableService: CRUD + route management + subnet associations |
+| `internal/core/services/internet_gateway.go` | InternetGatewayService: create/attach/detach lifecycle |
+| `internal/core/services/nat_gateway.go` | NATGatewayService: create with EIP, SNAT setup |
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `internal/core/services/vpc.go` | CreateVPC auto-creates main route table with local route |
+| `internal/core/services/vpc_peering.go` | AcceptPeering adds routes, DeletePeering removes routes |
+| `internal/api/setup/infrastructure.go` | Wire up new services |
+
+### Key Integrations
+
+**VpcService (CreateVPC):**
+```go
+mainRT := &domain.RouteTable{
+    ID:     uuid.New(),
+    VPCID:  vpc.ID,
+    Name:   "main",
+    IsMain: true,
+}
+mainRT.Routes = append(mainRT.Routes, domain.Route{
+    ID:              uuid.New(),
+    RouteTableID:    mainRT.ID,
+    DestinationCIDR: vpc.CIDRBlock,
+    TargetType:      domain.RouteTargetLocal,
+})
+routeTableRepo.Create(ctx, mainRT)
+```
+
+**VPCPeeringService (AcceptPeering):**
+```go
+reqRT, _ := routeTableRepo.GetMainByVPC(ctx, reqVPC.ID)
+accRT, _ := routeTableRepo.GetMainByVPC(ctx, accVPC.ID)
+routeTableRepo.AddRoute(ctx, reqRT.ID, &domain.Route{
+    DestinationCIDR: accVPC.CIDRBlock,
+    TargetType:      domain.RouteTargetPeering,
+    TargetID:        &peering.ID,
+})
+// ... add reverse route to accepter RT
+```
+
+### Dependencies
+- Requires PR #3 merged and `feature/vpc-routing` rebased
+
+### Validation
+```bash
+go build ./internal/core/services/...
+go test ./internal/core/services/... -run "RouteTable|InternetGateway|NATGateway" -v
+```
+
+### PR Description
+```
+feat(vpc-routing): Implement Route Table, IGW, and NAT Gateway services
+
+- RouteTableService: CRUD + route management + subnet associations
+- InternetGatewayService: create/attach/detach lifecycle
+- NATGatewayService: create with EIP, SNAT setup
+- VpcService now auto-creates main route table on VPC creation
+- VPCPeeringService now manages route table entries on accept/delete
+```
+
+---
+
+## PR #5: CLI Commands
+
+**Branch:** `feature/vpc-routing`
+**Target:** `feature/vpc-routing` (rebase after PR #4 merges)
+
+### Goal
+Add `cloud` CLI commands for route tables, IGW, and NAT Gateway.
+
+### Files to Create
+
+| File | Purpose |
+|------|---------|
+| `cmd/cloud/route_table.go` | route-table list/create/rm/add-route/associate/disassociate |
+| `cmd/cloud/igw.go` | igw create/attach/detach/list/rm |
+| `cmd/cloud/nat_gateway.go` | nat-gateway create/list/rm |
+
+### Files to Modify
+- `cmd/cloud/main.go` - register new CLI commands
+
+### CLI Design
+
+```bash
+# Route Tables
+cloud route-table list [vpc-id]
+cloud route-table create [vpc-id] [name]        # --main flag for main RT
+cloud route-table rm [rt-id]
+cloud route-table add-route [rt-id] [dest-cidr] [target-type]  # --target-id
+cloud route-table associate [rt-id] [subnet-id]
+cloud route-table disassociate [rt-id] [subnet-id]
+
+# Internet Gateway
+cloud igw create
+cloud igw attach [igw-id] [vpc-id]    # adds 0.0.0.0/0 route
+cloud igw detach [igw-id]
+cloud igw list
+cloud igw rm [igw-id]                  # must be detached
+
+# NAT Gateway
+cloud nat-gateway create [subnet-id] [eip-id]
+cloud nat-gateway list [vpc-id]
+cloud nat-gateway rm [nat-id]
+```
+
+### Dependencies
+- Requires PR #4 merged and `feature/vpc-routing` rebased
+
+### Validation
+```bash
+go build ./cmd/cloud/...
+cloud route-table --help
+cloud igw --help
+cloud nat-gateway --help
+```
+
+### PR Description
+```
+feat(vpc-routing): Add CLI commands for Route Tables, IGW, and NAT Gateway
+
+- cloud route-table: list/create/rm/add-route/associate/disassociate
+- cloud igw: create/attach/detach/list/rm
+- cloud nat-gateway: create/list/rm
+```
+
+---
+
+## Final Merge PR: Feature Branch → Main
+
+**Branch:** `feature/vpc-routing`
+**Target:** `main`
+
+After all 5 PRs stacked and tested on feature branch:
+
+```bash
+# Create final merge PR
+git checkout main
+git pull
+git merge feature/vpc-routing
+git push origin main
+```
+
+Or via GitHub: PR from `feature/vpc-routing` → `main`
+
+---
+
+## Git Workflow Summary
+
+```bash
+# 1. Create feature branch
+git checkout main
+git pull origin main
+git checkout -b feature/vpc-routing
+git push -u origin feature/vpc-routing
+
+# 2. PR #1: Domain + Ports
+# ... implement ...
+# Open PR targeting feature/vpc-routing
+# After merge:
+git fetch origin
+git rebase origin/feature/vpc-routing
+
+# 3. PR #2: Migrations + Repos (rebase then implement)
+# ... implement ...
+# Force push to PR branch, merge, repeat rebase
+
+# 4-5. Repeat for remaining PRs
+
+# 6. Final merge
+git checkout main
+git merge feature/vpc-routing
+git push origin main
+
+# Cleanup
+git branch -d feature/vpc-routing
+git push origin --delete feature/vpc-routing
+```
+
+---
+
+## Testing Per PR
+
+| PR | Unit Tests | Integration |
+|----|-----------|-------------|
+| #1 | None (types only) | None |
+| #2 | Repository mocks | None |
+| #3 | Adapter unit tests | Manual OVS verification |
+| #4 | Service unit tests | VPC + RT creation flow |
+| #5 | CLI argument parsing | End-to-end CLI smoke test |
+
+---
+
+## Rollback Plan
+
+If `feature/vpc-routing` has issues at any point:
+
+```bash
+# Reset feature branch to main
+git checkout feature/vpc-routing
+git reset --hard origin/main
+# Rebase remaining unmerged PRs if needed
+```
+
+Individual PR rollbacks:
+1. PR #5: Revert CLI changes - services still work via API
+2. PR #4: Revert service changes - database records remain but unused
+3. PR #3: Revert OVS adapter - NAT methods become noop
+4. PR #2: `goose rollback` + revert repo files
+5. PR #1: Revert domain + port files
+
+---
+
+## Timeline Estimate
+
+| PR | Complexity | Files | Notes |
+|----|-----------|-------|-------|
+| #1 | Low | 6 new | Pure types + interfaces |
+| #2 | Medium | 6 new + 1 mod | Migrations + repo implementations |
+| #3 | Medium | 3 modified | OVS/iptables integration |
+| #4 | High | 3 new + 3 mod | Core business logic |
+| #5 | Low | 3 new + 1 mod | CLI commands |

--- a/docs/vpc-routing-roadmap.md
+++ b/docs/vpc-routing-roadmap.md
@@ -119,6 +119,13 @@ Extend NetworkBackend with NAT support and implement in OVS adapter.
 - iptables SNAT for outbound traffic
 - Return traffic auto de-SNATed via connection tracking
 
+### Requirements
+- `net.ipv4.ip_forward=1` must be enabled on the host system
+  - This is a **system-wide setting** required for NAT functionality
+  - Can be enabled with: `sysctl -w net.ipv4.ip_forward=1`
+  - To persist across reboots, add to `/etc/sysctl.conf`: `net.ipv4.ip_forward=1`
+  - Without this setting, NAT gateway traffic will not be forwarded
+
 ### Dependencies
 - Requires PR #2 merged and `feature/vpc-routing` rebased
 

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -69,7 +69,10 @@ type Repositories struct {
 	Log           ports.LogRepository
 	IAM           ports.IAMRepository
 	Pipeline      ports.PipelineRepository
-	VPCPeering    ports.VPCPeeringRepository
+	VPCPeering     ports.VPCPeeringRepository
+	RouteTable     ports.RouteTableRepository
+	IGW            ports.IGWRepository
+	NATGateway     ports.NATGatewayRepository
 }
 
 // InitRepositories constructs repositories using the provided database clients.
@@ -116,6 +119,9 @@ func InitRepositories(db postgres.DB, rdb *redisv9.Client) *Repositories {
 		IAM:           postgres.NewIAMRepository(db),
 		Pipeline:      postgres.NewPipelineRepository(db),
 		VPCPeering:    postgres.NewVPCPeeringRepository(db),
+		RouteTable:    postgres.NewRouteTableRepository(db),
+		IGW:           postgres.NewIGWRepository(db),
+		NATGateway:    postgres.NewNATGatewayRepository(db),
 	}
 }
 
@@ -164,6 +170,9 @@ type Services struct {
 	IAM           ports.IAMService
 	Pipeline      ports.PipelineService
 	VPCPeering    ports.VPCPeeringService
+	RouteTable    *services.RouteTableService
+	InternetGateway *services.InternetGatewayService
+	NATGateway    *services.NATGatewayService
 }
 
 // Workers struct to return background workers
@@ -311,7 +320,7 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 		return nil, nil, err
 	}
 
-	svcs := &Services{WsHub: wsHub, Audit: auditSvc, Identity: identitySvc, Tenant: tenantSvc, Auth: authSvc, PasswordReset: pwdResetSvc, RBAC: rbacSvc, Vpc: vpcSvc, Subnet: subnetSvc, Event: eventSvc, Volume: volumeSvc, Instance: instSvcConcrete, SecurityGroup: sgSvc, LB: lbSvc, Snapshot: snapshotSvc, Stack: stackSvc, Storage: storageSvc, Database: databaseSvc, Secret: secretSvc, Function: fnSvc, FunctionSchedule: fnSchedSvc, Cache: cacheSvc, Queue: queueSvc, Notify: notifySvc, Cron: cronSvc, Gateway: gwSvc, Container: containerSvc, Pipeline: pipelineSvc, Health: services.NewHealthServiceImpl(c.DB, c.Compute, clusterSvc), AutoScaling: asgSvc, Accounting: accountingSvc, Image: imageSvc, Cluster: clusterSvc, Dashboard: services.NewDashboardService(rbacSvc, c.Repos.Instance, c.Repos.Volume, c.Repos.Vpc, c.Repos.Event, c.Logger), Lifecycle: services.NewLifecycleService(c.Repos.Lifecycle, rbacSvc, c.Repos.Storage), InstanceType: services.NewInstanceTypeService(c.Repos.InstanceType, rbacSvc), GlobalLB: glbSvc, DNS: dnsSvc, SSHKey: sshKeySvc, ElasticIP: services.NewElasticIPService(services.ElasticIPServiceParams{Repo: c.Repos.ElasticIP, RBAC: rbacSvc, InstanceRepo: c.Repos.Instance, AuditSvc: auditSvc, Logger: c.Logger}), Log: logSvc, IAM: iamSvc, VPCPeering: services.NewVPCPeeringService(services.VPCPeeringServiceParams{Repo: c.Repos.VPCPeering, VpcRepo: c.Repos.Vpc, Network: c.Network, AuditSvc: auditSvc, Logger: c.Logger})}
+svcs := &Services{WsHub: wsHub, Audit: auditSvc, Identity: identitySvc, Tenant: tenantSvc, Auth: authSvc, PasswordReset: pwdResetSvc, RBAC: rbacSvc, Vpc: vpcSvc, Subnet: subnetSvc, Event: eventSvc, Volume: volumeSvc, Instance: instSvcConcrete, SecurityGroup: sgSvc, LB: lbSvc, Snapshot: snapshotSvc, Stack: stackSvc, Storage: storageSvc, Database: databaseSvc, Secret: secretSvc, Function: fnSvc, FunctionSchedule: fnSchedSvc, Cache: cacheSvc, Queue: queueSvc, Notify: notifySvc, Cron: cronSvc, Gateway: gwSvc, Container: containerSvc, Pipeline: pipelineSvc, Health: services.NewHealthServiceImpl(c.DB, c.Compute, clusterSvc), AutoScaling: asgSvc, Accounting: accountingSvc, Image: imageSvc, Cluster: clusterSvc, Dashboard: services.NewDashboardService(rbacSvc, c.Repos.Instance, c.Repos.Volume, c.Repos.Vpc, c.Repos.Event, c.Logger), Lifecycle: services.NewLifecycleService(c.Repos.Lifecycle, rbacSvc, c.Repos.Storage), InstanceType: services.NewInstanceTypeService(c.Repos.InstanceType, rbacSvc), GlobalLB: glbSvc, DNS: dnsSvc, SSHKey: sshKeySvc, ElasticIP: services.NewElasticIPService(services.ElasticIPServiceParams{Repo: c.Repos.ElasticIP, RBAC: rbacSvc, InstanceRepo: c.Repos.Instance, AuditSvc: auditSvc, Logger: c.Logger}), Log: logSvc, IAM: iamSvc, VPCPeering: services.NewVPCPeeringService(services.VPCPeeringServiceParams{Repo: c.Repos.VPCPeering, VpcRepo: c.Repos.Vpc, Network: c.Network, AuditSvc: auditSvc, Logger: c.Logger}), RouteTable: services.NewRouteTableService(services.RouteTableServiceParams{Repo: c.Repos.RouteTable, VpcRepo: c.Repos.Vpc, RBACSvc: rbacSvc, Network: c.Network, AuditSvc: auditSvc, Logger: c.Logger}), InternetGateway: services.NewInternetGatewayService(services.InternetGatewayServiceParams{Repo: c.Repos.IGW, RTRepo: c.Repos.RouteTable, VpcRepo: c.Repos.Vpc, RBACSvc: rbacSvc, AuditSvc: auditSvc, Logger: c.Logger}), NATGateway: services.NewNATGatewayService(services.NATGatewayServiceParams{Repo: c.Repos.NATGateway, EIPRepo: c.Repos.ElasticIP, SubnetRepo: c.Repos.Subnet, VpcRepo: c.Repos.Vpc, RBACSvc: rbacSvc, Network: c.Network, AuditSvc: auditSvc, Logger: c.Logger})}
 
 	// 7. High Availability & Monitoring
 	replicaMonitor := initReplicaMonitor(c)

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -72,6 +72,9 @@ type Handlers struct {
 	Log           *httphandlers.LogHandler
 	IAM           *httphandlers.IAMHandler
 	VPCPeering    *httphandlers.VPCPeeringHandler
+	RouteTable    *httphandlers.RouteTableHandler
+	InternetGateway *httphandlers.InternetGatewayHandler
+	NATGateway    *httphandlers.NATGatewayHandler
 	Ws            *ws.Handler
 }
 
@@ -119,6 +122,9 @@ func InitHandlers(svcs *Services, cfg *platform.Config, logger *slog.Logger) *Ha
 		Log:           httphandlers.NewLogHandler(svcs.Log),
 		IAM:           httphandlers.NewIAMHandler(svcs.IAM),
 		VPCPeering:    httphandlers.NewVPCPeeringHandler(svcs.VPCPeering),
+		RouteTable:    httphandlers.NewRouteTableHandler(svcs.RouteTable),
+		InternetGateway: httphandlers.NewInternetGatewayHandler(svcs.InternetGateway),
+		NATGateway:    httphandlers.NewNATGatewayHandler(svcs.NATGateway),
 		Ws:            ws.NewHandler(svcs.WsHub, svcs.Identity, logger),
 	}
 }
@@ -396,7 +402,43 @@ func registerNetworkRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		peeringGroup.POST("/:id/accept", httputil.Permission(svcs.RBAC, domain.PermissionVpcPeeringAccept), handlers.VPCPeering.Accept)
 		peeringGroup.POST("/:id/reject", httputil.Permission(svcs.RBAC, domain.PermissionVpcPeeringAccept), handlers.VPCPeering.Reject)
 		peeringGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionVpcPeeringDelete), handlers.VPCPeering.Delete)
-	}
+		}
+
+		// Route Tables
+		rtGroup := r.Group("/route-tables")
+		rtGroup.Use(httputil.Auth(svcs.Identity, svcs.Tenant), httputil.RequireTenant(), httputil.TenantMember(svcs.Tenant))
+		{
+			rtGroup.POST("", httputil.Permission(svcs.RBAC, domain.PermissionVpcUpdate), handlers.RouteTable.Create)
+			rtGroup.GET("", httputil.Permission(svcs.RBAC, domain.PermissionVpcRead), handlers.RouteTable.List)
+			rtGroup.GET("/:id", httputil.Permission(svcs.RBAC, domain.PermissionVpcRead), handlers.RouteTable.Get)
+			rtGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionVpcDelete), handlers.RouteTable.Delete)
+			rtGroup.POST("/:id/routes", httputil.Permission(svcs.RBAC, domain.PermissionVpcUpdate), handlers.RouteTable.AddRoute)
+			rtGroup.DELETE("/:id/routes", httputil.Permission(svcs.RBAC, domain.PermissionVpcUpdate), handlers.RouteTable.RemoveRoute)
+			rtGroup.POST("/:id/associate", httputil.Permission(svcs.RBAC, domain.PermissionVpcUpdate), handlers.RouteTable.AssociateSubnet)
+			rtGroup.POST("/:id/disassociate", httputil.Permission(svcs.RBAC, domain.PermissionVpcUpdate), handlers.RouteTable.DisassociateSubnet)
+		}
+
+		// Internet Gateways
+		igwGroup := r.Group("/internet-gateways")
+		igwGroup.Use(httputil.Auth(svcs.Identity, svcs.Tenant), httputil.RequireTenant(), httputil.TenantMember(svcs.Tenant))
+		{
+			igwGroup.POST("", httputil.Permission(svcs.RBAC, domain.PermissionVpcCreate), handlers.InternetGateway.Create)
+			igwGroup.GET("", httputil.Permission(svcs.RBAC, domain.PermissionVpcRead), handlers.InternetGateway.List)
+			igwGroup.GET("/:id", httputil.Permission(svcs.RBAC, domain.PermissionVpcRead), handlers.InternetGateway.Get)
+			igwGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionVpcDelete), handlers.InternetGateway.Delete)
+			igwGroup.POST("/:id/attach", httputil.Permission(svcs.RBAC, domain.PermissionVpcUpdate), handlers.InternetGateway.Attach)
+			igwGroup.POST("/:id/detach", httputil.Permission(svcs.RBAC, domain.PermissionVpcUpdate), handlers.InternetGateway.Detach)
+		}
+
+		// NAT Gateways
+		natGroup := r.Group("/nat-gateways")
+		natGroup.Use(httputil.Auth(svcs.Identity, svcs.Tenant), httputil.RequireTenant(), httputil.TenantMember(svcs.Tenant))
+		{
+			natGroup.POST("", httputil.Permission(svcs.RBAC, domain.PermissionVpcCreate), handlers.NATGateway.Create)
+			natGroup.GET("", httputil.Permission(svcs.RBAC, domain.PermissionVpcRead), handlers.NATGateway.List)
+			natGroup.GET("/:id", httputil.Permission(svcs.RBAC, domain.PermissionVpcRead), handlers.NATGateway.Get)
+			natGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionVpcDelete), handlers.NATGateway.Delete)
+		}
 }
 
 func registerGlobalLBRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {

--- a/internal/api/setup/router_test.go
+++ b/internal/api/setup/router_test.go
@@ -46,6 +46,12 @@ func (s stubNetworkBackend) DeleteVethPair(_ context.Context, _ string) error { 
 func (s stubNetworkBackend) SetVethIP(_ context.Context, _ string, _ string, _ string) error {
 	return nil
 }
+func (s stubNetworkBackend) SetupNATForSubnet(_ context.Context, _ string, _ string, _ string, _ string) error {
+	return nil
+}
+func (s stubNetworkBackend) RemoveNATForSubnet(_ context.Context, _ string, _ string, _ string) error {
+	return nil
+}
 func (s stubNetworkBackend) Ping(_ context.Context) error { return s.pingErr }
 func (s stubNetworkBackend) Type() string                 { return s.backendType }
 

--- a/internal/api/setup/router_test.go
+++ b/internal/api/setup/router_test.go
@@ -49,7 +49,7 @@ func (s stubNetworkBackend) SetVethIP(_ context.Context, _ string, _ string, _ s
 func (s stubNetworkBackend) SetupNATForSubnet(_ context.Context, _ string, _ string, _ string, _ string) error {
 	return nil
 }
-func (s stubNetworkBackend) RemoveNATForSubnet(_ context.Context, _ string, _ string, _ string) error {
+func (s stubNetworkBackend) RemoveNATForSubnet(_ context.Context, _ string, _ string, _ string, _ string) error {
 	return nil
 }
 func (s stubNetworkBackend) Ping(_ context.Context) error { return s.pingErr }

--- a/internal/core/domain/internet_gateway.go
+++ b/internal/core/domain/internet_gateway.go
@@ -1,0 +1,65 @@
+package domain
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// IGWStatus represents the attachment state of an Internet Gateway.
+type IGWStatus string
+
+const (
+	IGWStatusDetached IGWStatus = "detached"
+	IGWStatusAttached IGWStatus = "attached"
+)
+
+// InternetGateway provides a path for traffic between a VPC and the internet.
+// An IGW can only be attached to one VPC at a time.
+type InternetGateway struct {
+	ID        uuid.UUID  `json:"id"`
+	VPCID     *uuid.UUID `json:"vpc_id,omitempty"`
+	UserID    uuid.UUID  `json:"user_id"`
+	TenantID  uuid.UUID  `json:"tenant_id"`
+	Status    IGWStatus  `json:"status"`
+	ARN       string     `json:"arn"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// Validate checks if the internet gateway fields are valid.
+func (igw *InternetGateway) Validate() error {
+	if igw.UserID == uuid.Nil {
+		return errors.New("internet gateway must have a user owner")
+	}
+	if igw.TenantID == uuid.Nil {
+		return errors.New("internet gateway must have a tenant")
+	}
+	if !isValidIGWStatus(igw.Status) {
+		return errors.New("invalid IGW status")
+	}
+	return nil
+}
+
+func isValidIGWStatus(s IGWStatus) bool {
+	switch s {
+	case IGWStatusDetached, IGWStatusAttached:
+		return true
+	}
+	return false
+}
+
+// CanAttach checks if the IGW can be attached to a VPC.
+func (igw *InternetGateway) CanAttach() bool {
+	return igw.Status == IGWStatusDetached && igw.VPCID == nil
+}
+
+// CanDetach checks if the IGW can be detached from its VPC.
+func (igw *InternetGateway) CanDetach() bool {
+	return igw.Status == IGWStatusAttached
+}
+
+// IsAttached checks if the IGW is currently attached.
+func (igw *InternetGateway) IsAttached() bool {
+	return igw.Status == IGWStatusAttached && igw.VPCID != nil
+}

--- a/internal/core/domain/nat_gateway.go
+++ b/internal/core/domain/nat_gateway.go
@@ -1,0 +1,70 @@
+package domain
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// NATGatewayStatus represents the state of a NAT Gateway.
+type NATGatewayStatus string
+
+const (
+	NATGatewayStatusPending NATGatewayStatus = "pending"
+	NATGatewayStatusActive  NATGatewayStatus = "active"
+	NATGatewayStatusFailed  NATGatewayStatus = "failed"
+	NATGatewayStatusDeleted NATGatewayStatus = "deleted"
+)
+
+// NATGateway provides SNAT (Source NAT) for instances in private subnets
+// to access the internet while preventing inbound connections from the internet.
+type NATGateway struct {
+	ID          uuid.UUID        `json:"id"`
+	VPCID       uuid.UUID        `json:"vpc_id"`
+	SubnetID    uuid.UUID        `json:"subnet_id"`
+	ElasticIPID uuid.UUID        `json:"elastic_ip_id"`
+	UserID      uuid.UUID        `json:"user_id"`
+	TenantID    uuid.UUID        `json:"tenant_id"`
+	Status      NATGatewayStatus `json:"status"`
+	PrivateIP   string           `json:"private_ip"`
+	ARN         string           `json:"arn"`
+	CreatedAt   time.Time        `json:"created_at"`
+}
+
+// Validate checks if the NAT gateway fields are valid.
+func (ng *NATGateway) Validate() error {
+	if ng.VPCID == uuid.Nil {
+		return errors.New("NAT gateway must be associated with a VPC")
+	}
+	if ng.SubnetID == uuid.Nil {
+		return errors.New("NAT gateway must be placed in a subnet")
+	}
+	if ng.ElasticIPID == uuid.Nil {
+		return errors.New("NAT gateway requires an elastic IP")
+	}
+	if ng.UserID == uuid.Nil {
+		return errors.New("NAT gateway must have a user owner")
+	}
+	if ng.TenantID == uuid.Nil {
+		return errors.New("NAT gateway must have a tenant")
+	}
+	if !isValidNATGatewayStatus(ng.Status) {
+		return errors.New("invalid NAT gateway status")
+	}
+	return nil
+}
+
+func isValidNATGatewayStatus(s NATGatewayStatus) bool {
+	switch s {
+	case NATGatewayStatusPending, NATGatewayStatusActive,
+		NATGatewayStatusFailed, NATGatewayStatusDeleted:
+		return true
+	}
+	return false
+}
+
+// IsActive checks if the NAT gateway is operational.
+func (ng *NATGateway) IsActive() bool {
+	return ng.Status == NATGatewayStatusActive
+}

--- a/internal/core/domain/route_table.go
+++ b/internal/core/domain/route_table.go
@@ -1,0 +1,100 @@
+package domain
+
+import (
+	"errors"
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// RouteTargetType defines what kind of target a route points to.
+type RouteTargetType string
+
+const (
+	RouteTargetLocal   RouteTargetType = "local"
+	RouteTargetIGW     RouteTargetType = "igw"
+	RouteTargetNAT     RouteTargetType = "nat"
+	RouteTargetPeering RouteTargetType = "peering"
+)
+
+// RouteTable represents a collection of routes associated with a VPC.
+// It controls where network traffic is directed.
+type RouteTable struct {
+	ID           uuid.UUID              `json:"id"`
+	VPCID        uuid.UUID              `json:"vpc_id"`
+	Name         string                 `json:"name"`
+	IsMain       bool                   `json:"is_main"`
+	Routes       []Route                `json:"routes,omitempty"`
+	Associations []RouteTableAssociation `json:"associations,omitempty"`
+	CreatedAt    time.Time              `json:"created_at"`
+}
+
+// Validate checks if the route table fields are valid.
+func (rt *RouteTable) Validate() error {
+	if rt.Name == "" {
+		return errors.New("route table name cannot be empty")
+	}
+	if rt.VPCID == uuid.Nil {
+		return errors.New("route table must be associated with a VPC")
+	}
+	return nil
+}
+
+// Route represents a single routing rule within a route table.
+type Route struct {
+	ID              uuid.UUID       `json:"id"`
+	RouteTableID    uuid.UUID       `json:"route_table_id"`
+	DestinationCIDR string          `json:"destination_cidr"`
+	TargetType      RouteTargetType `json:"target_type"`
+	TargetID        *uuid.UUID      `json:"target_id,omitempty"`
+	TargetName      string          `json:"target_name,omitempty"`
+	CreatedAt       time.Time       `json:"created_at"`
+}
+
+// Validate checks if the route fields are valid.
+func (r *Route) Validate() error {
+	if r.RouteTableID == uuid.Nil {
+		return errors.New("route must be associated with a route table")
+	}
+	if r.DestinationCIDR == "" {
+		return errors.New("destination CIDR is required")
+	}
+	_, _, err := net.ParseCIDR(r.DestinationCIDR)
+	if err != nil {
+		return errors.New("invalid destination CIDR")
+	}
+	if !isValidRouteTargetType(r.TargetType) {
+		return errors.New("invalid target type")
+	}
+	return nil
+}
+
+func isValidRouteTargetType(t RouteTargetType) bool {
+	switch t {
+	case RouteTargetLocal, RouteTargetIGW, RouteTargetNAT, RouteTargetPeering:
+		return true
+	}
+	return false
+}
+
+// RouteTableAssociation links a subnet to a route table.
+// A subnet can only be associated with one route table, but a route table
+// can have multiple subnet associations.
+type RouteTableAssociation struct {
+	ID           uuid.UUID `json:"id"`
+	RouteTableID uuid.UUID `json:"route_table_id"`
+	SubnetID     uuid.UUID `json:"subnet_id"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// Validate checks if the association fields are valid.
+func (a *RouteTableAssociation) Validate() error {
+	if a.RouteTableID == uuid.Nil {
+		return errors.New("association must have a route table")
+	}
+	if a.SubnetID == uuid.Nil {
+		return errors.New("association must have a subnet")
+	}
+	return nil
+}

--- a/internal/core/ports/internet_gateway.go
+++ b/internal/core/ports/internet_gateway.go
@@ -1,0 +1,42 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+)
+
+// IGWRepository manages persistence of Internet Gateways.
+type IGWRepository interface {
+	Create(ctx context.Context, igw *domain.InternetGateway) error
+	GetByID(ctx context.Context, id uuid.UUID) (*domain.InternetGateway, error)
+	GetByVPC(ctx context.Context, vpcID uuid.UUID) (*domain.InternetGateway, error)
+	ListAll(ctx context.Context) ([]*domain.InternetGateway, error)
+	Update(ctx context.Context, igw *domain.InternetGateway) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+// InternetGatewayService provides business logic for IGW management.
+type InternetGatewayService interface {
+	// CreateIGW creates a new Internet Gateway (starts in detached state).
+	CreateIGW(ctx context.Context) (*domain.InternetGateway, error)
+
+	// AttachIGW attaches an IGW to a VPC.
+	// This also adds a default route (0.0.0.0/0) to the VPC's main route table
+	// pointing to this IGW for internet-bound traffic.
+	AttachIGW(ctx context.Context, igwID, vpcID uuid.UUID) error
+
+	// DetachIGW detaches an IGW from its VPC.
+	// This removes the default route from the main route table.
+	DetachIGW(ctx context.Context, igwID uuid.UUID) error
+
+	// GetIGW retrieves an IGW by ID.
+	GetIGW(ctx context.Context, igwID uuid.UUID) (*domain.InternetGateway, error)
+
+	// ListIGWs returns all IGWs for the current tenant.
+	ListIGWs(ctx context.Context) ([]*domain.InternetGateway, error)
+
+	// DeleteIGW permanently removes an IGW (must be detached first).
+	DeleteIGW(ctx context.Context, igwID uuid.UUID) error
+}

--- a/internal/core/ports/nat_gateway.go
+++ b/internal/core/ports/nat_gateway.go
@@ -1,0 +1,36 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+)
+
+// NATGatewayRepository manages persistence of NAT Gateways.
+type NATGatewayRepository interface {
+	Create(ctx context.Context, nat *domain.NATGateway) error
+	GetByID(ctx context.Context, id uuid.UUID) (*domain.NATGateway, error)
+	ListBySubnet(ctx context.Context, subnetID uuid.UUID) ([]*domain.NATGateway, error)
+	ListByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.NATGateway, error)
+	Update(ctx context.Context, nat *domain.NATGateway) error
+	Delete(ctx context.Context, id uuid.UUID) error
+}
+
+// NATGatewayService provides business logic for NAT Gateway management.
+type NATGatewayService interface {
+	// CreateNATGateway creates a NAT Gateway in a subnet with an allocated Elastic IP.
+	// The NAT gateway must be placed in a public subnet (a subnet that has a route
+	// through an Internet Gateway) to enable instances in private subnets to access
+	// the internet.
+	CreateNATGateway(ctx context.Context, subnetID uuid.UUID, eipID uuid.UUID) (*domain.NATGateway, error)
+
+	// GetNATGateway retrieves a NAT Gateway by ID.
+	GetNATGateway(ctx context.Context, natID uuid.UUID) (*domain.NATGateway, error)
+
+	// ListNATGateways returns all NAT Gateways for a VPC.
+	ListNATGateways(ctx context.Context, vpcID uuid.UUID) ([]*domain.NATGateway, error)
+
+	// DeleteNATGateway removes a NAT Gateway and releases the associated EIP.
+	DeleteNATGateway(ctx context.Context, natID uuid.UUID) error
+}

--- a/internal/core/ports/network.go
+++ b/internal/core/ports/network.go
@@ -59,6 +59,13 @@ type NetworkBackend interface {
 	// SetVethIP assigns an IP address to a virtual ethernet interface.
 	SetVethIP(ctx context.Context, vethEnd, ip, cidr string) error
 
+	// NAT Gateway Management (for private subnet internet access via SNAT)
+
+	// SetupNATForSubnet configures iptables SNAT rules for a subnet's internet access.
+	SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, publicIP string) error
+	// RemoveNATForSubnet removes iptables SNAT rules for a subnet.
+	RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error
+
 	// Health & Type
 
 	// Ping verifies the connectivity and responsiveness of the networking service.

--- a/internal/core/ports/network.go
+++ b/internal/core/ports/network.go
@@ -68,7 +68,8 @@ type NetworkBackend interface {
 SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error
 
 	// RemoveNATForSubnet removes iptables SNAT rules for a subnet.
-	RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error
+	// egressIP is used to precisely match the SNAT rule when deleting.
+	RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error
 
 	// Health & Type
 

--- a/internal/core/ports/network.go
+++ b/internal/core/ports/network.go
@@ -59,10 +59,14 @@ type NetworkBackend interface {
 	// SetVethIP assigns an IP address to a virtual ethernet interface.
 	SetVethIP(ctx context.Context, vethEnd, ip, cidr string) error
 
-	// NAT Gateway Management (for private subnet internet access via SNAT)
+// NAT for subnet outbound traffic (used by NAT Gateway)
 
-	// SetupNATForSubnet configures iptables SNAT rules for a subnet's internet access.
-	SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, publicIP string) error
+// SetupNATForSubnet configures iptables SNAT rules for outbound traffic from a subnet.
+// natVethEnd: the host-side veth endpoint connected to the NAT gateway
+// subnetCIDR: the CIDR block of the subnet being NATed
+// egressIP: the public IP to SNAT traffic to
+SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error
+
 	// RemoveNATForSubnet removes iptables SNAT rules for a subnet.
 	RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error
 

--- a/internal/core/ports/route_table.go
+++ b/internal/core/ports/route_table.go
@@ -1,0 +1,64 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+)
+
+// RouteTableRepository manages the persistent state of route tables.
+type RouteTableRepository interface {
+	Create(ctx context.Context, rt *domain.RouteTable) error
+	GetByID(ctx context.Context, id uuid.UUID) (*domain.RouteTable, error)
+	GetByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.RouteTable, error)
+	GetMainByVPC(ctx context.Context, vpcID uuid.UUID) (*domain.RouteTable, error)
+	Update(ctx context.Context, rt *domain.RouteTable) error
+	Delete(ctx context.Context, id uuid.UUID) error
+
+	// Route operations
+	AddRoute(ctx context.Context, rtID uuid.UUID, route *domain.Route) error
+	RemoveRoute(ctx context.Context, rtID, routeID uuid.UUID) error
+	ListRoutes(ctx context.Context, rtID uuid.UUID) ([]domain.Route, error)
+
+	// Association operations
+	AssociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error
+	DisassociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error
+	ListAssociatedSubnets(ctx context.Context, rtID uuid.UUID) ([]uuid.UUID, error)
+}
+
+// RouteTableService provides business logic for route table management.
+type RouteTableService interface {
+	// CreateRouteTable creates a new custom route table for a VPC.
+	// If isMain is true, this becomes the main route table (replacing existing main).
+	CreateRouteTable(ctx context.Context, vpcID uuid.UUID, name string, isMain bool) (*domain.RouteTable, error)
+
+	// GetRouteTable retrieves a route table by ID.
+	GetRouteTable(ctx context.Context, id uuid.UUID) (*domain.RouteTable, error)
+
+	// ListRouteTables returns all route tables for a VPC.
+	ListRouteTables(ctx context.Context, vpcID uuid.UUID) ([]*domain.RouteTable, error)
+
+	// DeleteRouteTable removes a custom route table (cannot delete main route table).
+	DeleteRouteTable(ctx context.Context, id uuid.UUID) error
+
+	// AddRoute adds a route to an existing route table.
+	// destinationCIDR: CIDR block (e.g., "0.0.0.0/0" or "10.0.1.0/24")
+	// targetType: local, igw, nat, or peering
+	// targetID: UUID of the target resource (IGW, NAT, or Peering) - nil for local
+	AddRoute(ctx context.Context, rtID uuid.UUID, destinationCIDR string, targetType domain.RouteTargetType, targetID *uuid.UUID) (*domain.Route, error)
+
+	// RemoveRoute removes a route from a route table.
+	RemoveRoute(ctx context.Context, rtID, routeID uuid.UUID) error
+
+	// AssociateSubnet links a subnet to a route table.
+	// The subnet must belong to the same VPC as the route table.
+	AssociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error
+
+	// DisassociateSubnet removes a subnet's association with a route table.
+	// The subnet will then use the main route table.
+	DisassociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error
+
+	// ReplaceRoute replaces an existing route with a new target.
+	ReplaceRoute(ctx context.Context, rtID, routeID uuid.UUID, newTargetID *uuid.UUID) error
+}

--- a/internal/core/services/internet_gateway.go
+++ b/internal/core/services/internet_gateway.go
@@ -1,0 +1,291 @@
+// Package services implements core business workflows.
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const igwTracer = "internet-gateway-service"
+
+// InternetGatewayService manages the lifecycle of Internet Gateways.
+type InternetGatewayService struct {
+	repo           ports.IGWRepository
+	rtRepo         ports.RouteTableRepository
+	vpcRepo        ports.VpcRepository
+	rbacSvc        ports.RBACService
+	auditSvc       ports.AuditService
+	logger         *slog.Logger
+}
+
+// InternetGatewayServiceParams holds dependencies for InternetGatewayService.
+type InternetGatewayServiceParams struct {
+	Repo     ports.IGWRepository
+	RTRepo   ports.RouteTableRepository
+	VpcRepo  ports.VpcRepository
+	RBACSvc  ports.RBACService
+	AuditSvc ports.AuditService
+	Logger   *slog.Logger
+}
+
+// NewInternetGatewayService constructs an InternetGatewayService with its dependencies.
+func NewInternetGatewayService(params InternetGatewayServiceParams) *InternetGatewayService {
+	logger := params.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &InternetGatewayService{
+		repo:     params.Repo,
+		rtRepo:   params.RTRepo,
+		vpcRepo:  params.VpcRepo,
+		rbacSvc:  params.RBACSvc,
+		auditSvc: params.AuditSvc,
+		logger:   logger,
+	}
+}
+
+// CreateIGW creates a new Internet Gateway (starts in detached state).
+func (s *InternetGatewayService) CreateIGW(ctx context.Context) (*domain.InternetGateway, error) {
+	ctx, span := otel.Tracer(igwTracer).Start(ctx, "CreateIGW")
+	defer span.End()
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcCreate, "*"); err != nil {
+		return nil, err
+	}
+
+	igwID := uuid.New()
+	arn := fmt.Sprintf("arn:thecloud:vpc:local:%s:internet-gateway/%s", userID.String(), igwID.String())
+
+	igw := &domain.InternetGateway{
+		ID:        igwID,
+		VPCID:     nil,
+		UserID:    userID,
+		TenantID:  tenantID,
+		Status:    domain.IGWStatusDetached,
+		ARN:       arn,
+		CreatedAt: time.Now(),
+	}
+
+	if err := s.repo.Create(ctx, igw); err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to create internet gateway", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "igw.create", "internet_gateway", igwID.String(), nil); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("internet gateway created", "id", igwID)
+	return igw, nil
+}
+
+// AttachIGW attaches an IGW to a VPC.
+// This also adds a default route (0.0.0.0/0) to the VPC's main route table pointing to this IGW.
+func (s *InternetGatewayService) AttachIGW(ctx context.Context, igwID, vpcID uuid.UUID) error {
+	ctx, span := otel.Tracer(igwTracer).Start(ctx, "AttachIGW")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("igw_id", igwID.String()),
+		attribute.String("vpc_id", vpcID.String()),
+	)
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcUpdate, vpcID.String()); err != nil {
+		return err
+	}
+
+	// Get IGW and verify it can be attached
+	igw, err := s.repo.GetByID(ctx, igwID)
+	if err != nil {
+		return errors.Wrap(errors.NotFound, "internet gateway not found", err)
+	}
+
+	if !igw.CanAttach() {
+		return errors.New(errors.InvalidInput, "internet gateway is already attached or cannot be attached")
+	}
+
+	// Verify VPC exists
+	vpc, err := s.vpcRepo.GetByID(ctx, vpcID)
+	if err != nil {
+		return errors.Wrap(errors.NotFound, "VPC not found", err)
+	}
+
+	// Check if VPC already has an IGW attached
+	existingIGW, _ := s.repo.GetByVPC(ctx, vpcID)
+	if existingIGW != nil && existingIGW.Status == domain.IGWStatusAttached {
+		return errors.New(errors.Conflict, "VPC already has an internet gateway attached")
+	}
+
+	// Update IGW to attached state
+	igw.VPCID = &vpcID
+	igw.Status = domain.IGWStatusAttached
+	if err := s.repo.Update(ctx, igw); err != nil {
+		return errors.Wrap(errors.Internal, "failed to attach internet gateway", err)
+	}
+
+	// Get main route table and add 0.0.0.0/0 route
+	mainRT, err := s.rtRepo.GetMainByVPC(ctx, vpcID)
+	if err != nil {
+		s.logger.Warn("failed to get main route table for IGW attachment", "vpc_id", vpcID, "error", err)
+		// Don't fail - IGW is attached, route can be added later
+	} else {
+		// Add default route pointing to IGW
+		route := &domain.Route{
+			ID:              uuid.New(),
+			RouteTableID:    mainRT.ID,
+			DestinationCIDR: "0.0.0.0/0",
+			TargetType:      domain.RouteTargetIGW,
+			TargetID:        &igwID,
+			TargetName:      fmt.Sprintf("igw-%s", igwID.String()[:8]),
+			CreatedAt:       time.Now(),
+		}
+		if err := s.rtRepo.AddRoute(ctx, mainRT.ID, route); err != nil {
+			s.logger.Warn("failed to add default route for IGW", "rt_id", mainRT.ID, "error", err)
+		}
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "igw.attach", "internet_gateway", igwID.String(), map[string]interface{}{
+		"vpc_id": vpcID.String(),
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("internet gateway attached", "igw_id", igwID, "vpc_id", vpcID, "vpc_name", vpc.Name)
+	return nil
+}
+
+// DetachIGW detaches an IGW from its VPC.
+// This removes the default route from the main route table.
+func (s *InternetGatewayService) DetachIGW(ctx context.Context, igwID uuid.UUID) error {
+	ctx, span := otel.Tracer(igwTracer).Start(ctx, "DetachIGW")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("igw_id", igwID.String()))
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcUpdate, igwID.String()); err != nil {
+		return err
+	}
+
+	// Get IGW and verify it can be detached
+	igw, err := s.repo.GetByID(ctx, igwID)
+	if err != nil {
+		return errors.Wrap(errors.NotFound, "internet gateway not found", err)
+	}
+
+	if !igw.CanDetach() {
+		return errors.New(errors.InvalidInput, "internet gateway is not attached")
+	}
+
+	vpcID := igw.VPCID
+	if vpcID == nil {
+		return errors.New(errors.Internal, "IGW has nil VPC ID but is marked attached")
+	}
+
+	// Get main route table and remove 0.0.0.0/0 route pointing to this IGW
+	mainRT, err := s.rtRepo.GetMainByVPC(ctx, *vpcID)
+	if err == nil {
+		routes, _ := s.rtRepo.ListRoutes(ctx, mainRT.ID)
+		for _, r := range routes {
+			if r.DestinationCIDR == "0.0.0.0/0" && r.TargetType == domain.RouteTargetIGW && r.TargetID != nil && *r.TargetID == igwID {
+				if removeErr := s.rtRepo.RemoveRoute(ctx, mainRT.ID, r.ID); removeErr != nil {
+					s.logger.Warn("failed to remove default route during IGW detach", "route_id", r.ID, "error", removeErr)
+				}
+				break
+			}
+		}
+	}
+
+	// Update IGW to detached state
+	igw.VPCID = nil
+	igw.Status = domain.IGWStatusDetached
+	if err := s.repo.Update(ctx, igw); err != nil {
+		return errors.Wrap(errors.Internal, "failed to detach internet gateway", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "igw.detach", "internet_gateway", igwID.String(), map[string]interface{}{
+		"vpc_id": vpcID.String(),
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("internet gateway detached", "igw_id", igwID)
+	return nil
+}
+
+// GetIGW retrieves an IGW by ID.
+func (s *InternetGatewayService) GetIGW(ctx context.Context, igwID uuid.UUID) (*domain.InternetGateway, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcRead, igwID.String()); err != nil {
+		return nil, err
+	}
+
+	return s.repo.GetByID(ctx, igwID)
+}
+
+// ListIGWs returns all IGWs for the current tenant.
+func (s *InternetGatewayService) ListIGWs(ctx context.Context) ([]*domain.InternetGateway, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcRead, "*"); err != nil {
+		return nil, err
+	}
+
+	return s.repo.ListAll(ctx)
+}
+
+// DeleteIGW permanently removes an IGW (must be detached first).
+func (s *InternetGatewayService) DeleteIGW(ctx context.Context, igwID uuid.UUID) error {
+	ctx, span := otel.Tracer(igwTracer).Start(ctx, "DeleteIGW")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("igw_id", igwID.String()))
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcDelete, igwID.String()); err != nil {
+		return err
+	}
+
+	// Get IGW and verify it's detached
+	igw, err := s.repo.GetByID(ctx, igwID)
+	if err != nil {
+		return errors.Wrap(errors.NotFound, "internet gateway not found", err)
+	}
+
+	if igw.IsAttached() {
+		return errors.New(errors.InvalidInput, "cannot delete an attached internet gateway; detach it first")
+	}
+
+	if err := s.repo.Delete(ctx, igwID); err != nil {
+		return errors.Wrap(errors.Internal, "failed to delete internet gateway", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "igw.delete", "internet_gateway", igwID.String(), nil); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("internet gateway deleted", "id", igwID)
+	return nil
+}

--- a/internal/core/services/mock_network_test.go
+++ b/internal/core/services/mock_network_test.go
@@ -334,6 +334,181 @@ func (m *MockNetworkBackend) SetVethIP(ctx context.Context, vethEnd, ip, cidr st
 func (m *MockNetworkBackend) Ping(ctx context.Context) error {
 	return m.Called(ctx).Error(0)
 }
+func (m *MockNetworkBackend) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error {
+	return m.Called(ctx, bridge, natVethEnd, subnetCIDR, egressIP).Error(0)
+}
+func (m *MockNetworkBackend) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
+	return m.Called(ctx, bridge, natVethEnd, subnetCIDR).Error(0)
+}
 func (m *MockNetworkBackend) Type() string {
 	return m.Called().String(0)
+}
+
+// MockIGWRepo
+type MockIGWRepo struct{ mock.Mock }
+
+func (m *MockIGWRepo) Create(ctx context.Context, igw *domain.InternetGateway) error {
+	return m.Called(ctx, igw).Error(0)
+}
+func (m *MockIGWRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.InternetGateway, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.InternetGateway), args.Error(1)
+}
+func (m *MockIGWRepo) GetByVPC(ctx context.Context, vpcID uuid.UUID) (*domain.InternetGateway, error) {
+	args := m.Called(ctx, vpcID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.InternetGateway), args.Error(1)
+}
+func (m *MockIGWRepo) Update(ctx context.Context, igw *domain.InternetGateway) error {
+	return m.Called(ctx, igw).Error(0)
+}
+func (m *MockIGWRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+func (m *MockIGWRepo) ListAll(ctx context.Context) ([]*domain.InternetGateway, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.InternetGateway), args.Error(1)
+}
+
+// MockRTRepo
+type MockRTRepo struct{ mock.Mock }
+
+func (m *MockRTRepo) Create(ctx context.Context, rt *domain.RouteTable) error {
+	return m.Called(ctx, rt).Error(0)
+}
+func (m *MockRTRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.RouteTable, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.RouteTable), args.Error(1)
+}
+func (m *MockRTRepo) GetByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.RouteTable, error) {
+	args := m.Called(ctx, vpcID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.RouteTable), args.Error(1)
+}
+func (m *MockRTRepo) GetMainByVPC(ctx context.Context, vpcID uuid.UUID) (*domain.RouteTable, error) {
+	args := m.Called(ctx, vpcID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.RouteTable), args.Error(1)
+}
+func (m *MockRTRepo) Update(ctx context.Context, rt *domain.RouteTable) error {
+	return m.Called(ctx, rt).Error(0)
+}
+func (m *MockRTRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+func (m *MockRTRepo) AddRoute(ctx context.Context, rtID uuid.UUID, route *domain.Route) error {
+	return m.Called(ctx, rtID, route).Error(0)
+}
+func (m *MockRTRepo) RemoveRoute(ctx context.Context, rtID, routeID uuid.UUID) error {
+	return m.Called(ctx, rtID, routeID).Error(0)
+}
+func (m *MockRTRepo) ListRoutes(ctx context.Context, rtID uuid.UUID) ([]domain.Route, error) {
+	args := m.Called(ctx, rtID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]domain.Route), args.Error(1)
+}
+func (m *MockRTRepo) AssociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error {
+	return m.Called(ctx, rtID, subnetID).Error(0)
+}
+func (m *MockRTRepo) DisassociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error {
+	return m.Called(ctx, rtID, subnetID).Error(0)
+}
+func (m *MockRTRepo) ListAssociatedSubnets(ctx context.Context, rtID uuid.UUID) ([]uuid.UUID, error) {
+	args := m.Called(ctx, rtID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]uuid.UUID), args.Error(1)
+}
+
+// MockNATGatewayRepo
+type MockNATGatewayRepo struct{ mock.Mock }
+
+func (m *MockNATGatewayRepo) Create(ctx context.Context, ng *domain.NATGateway) error {
+	return m.Called(ctx, ng).Error(0)
+}
+func (m *MockNATGatewayRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.NATGateway, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.NATGateway), args.Error(1)
+}
+func (m *MockNATGatewayRepo) ListBySubnet(ctx context.Context, subnetID uuid.UUID) ([]*domain.NATGateway, error) {
+	args := m.Called(ctx, subnetID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.NATGateway), args.Error(1)
+}
+func (m *MockNATGatewayRepo) ListByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.NATGateway, error) {
+	args := m.Called(ctx, vpcID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.NATGateway), args.Error(1)
+}
+func (m *MockNATGatewayRepo) Update(ctx context.Context, ng *domain.NATGateway) error {
+	return m.Called(ctx, ng).Error(0)
+}
+func (m *MockNATGatewayRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
+}
+
+// MockEIPRepo
+type MockEIPRepo struct{ mock.Mock }
+
+func (m *MockEIPRepo) Create(ctx context.Context, eip *domain.ElasticIP) error {
+	return m.Called(ctx, eip).Error(0)
+}
+func (m *MockEIPRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.ElasticIP, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.ElasticIP), args.Error(1)
+}
+func (m *MockEIPRepo) GetByPublicIP(ctx context.Context, publicIP string) (*domain.ElasticIP, error) {
+	args := m.Called(ctx, publicIP)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.ElasticIP), args.Error(1)
+}
+func (m *MockEIPRepo) GetByInstanceID(ctx context.Context, instanceID uuid.UUID) (*domain.ElasticIP, error) {
+	args := m.Called(ctx, instanceID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.ElasticIP), args.Error(1)
+}
+func (m *MockEIPRepo) List(ctx context.Context) ([]*domain.ElasticIP, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.ElasticIP), args.Error(1)
+}
+func (m *MockEIPRepo) Update(ctx context.Context, eip *domain.ElasticIP) error {
+	return m.Called(ctx, eip).Error(0)
+}
+func (m *MockEIPRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	return m.Called(ctx, id).Error(0)
 }

--- a/internal/core/services/mock_network_test.go
+++ b/internal/core/services/mock_network_test.go
@@ -337,8 +337,8 @@ func (m *MockNetworkBackend) Ping(ctx context.Context) error {
 func (m *MockNetworkBackend) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error {
 	return m.Called(ctx, bridge, natVethEnd, subnetCIDR, egressIP).Error(0)
 }
-func (m *MockNetworkBackend) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
-	return m.Called(ctx, bridge, natVethEnd, subnetCIDR).Error(0)
+func (m *MockNetworkBackend) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error {
+	return m.Called(ctx, bridge, natVethEnd, subnetCIDR, egressIP).Error(0)
 }
 func (m *MockNetworkBackend) Type() string {
 	return m.Called().String(0)

--- a/internal/core/services/nat_gateway.go
+++ b/internal/core/services/nat_gateway.go
@@ -194,16 +194,27 @@ func (s *NATGatewayService) DeleteNATGateway(ctx context.Context, natID uuid.UUI
 	}
 
 	// Get subnet and VPC for cleanup
-	subnet, _ := s.subnetRepo.GetByID(ctx, nat.SubnetID)
-	vpc, _ := s.vpcRepo.GetByID(ctx, nat.VPCID)
+	subnet, err := s.subnetRepo.GetByID(ctx, nat.SubnetID)
+	if err != nil {
+		s.logger.Warn("failed to get subnet during NAT cleanup", "nat_id", natID, "error", err)
+	}
+	vpc, err := s.vpcRepo.GetByID(ctx, nat.VPCID)
+	if err != nil {
+		s.logger.Warn("failed to get VPC during NAT cleanup", "nat_id", natID, "error", err)
+	}
 
 	// Get EIP for public IP
-	eip, _ := s.eipRepo.GetByID(ctx, nat.ElasticIPID)
+	eip, err := s.eipRepo.GetByID(ctx, nat.ElasticIPID)
+	if err != nil {
+		s.logger.Warn("failed to get EIP during NAT cleanup", "nat_id", natID, "error", err)
+	}
 
 	// Remove NAT setup
-	if subnet != nil && vpc != nil {
+	if subnet != nil && vpc != nil && eip != nil {
 		natVethEnd := fmt.Sprintf("nat-%s", natID.String()[:8])
-		_ = s.network.RemoveNATForSubnet(ctx, vpc.NetworkID, natVethEnd, subnet.CIDRBlock)
+		if err := s.network.RemoveNATForSubnet(ctx, vpc.NetworkID, natVethEnd, subnet.CIDRBlock, eip.PublicIP); err != nil {
+			s.logger.Error("failed to remove NAT setup", "nat_id", natID, "error", err)
+		}
 	}
 
 	// Release the EIP back to allocated state

--- a/internal/core/services/nat_gateway.go
+++ b/internal/core/services/nat_gateway.go
@@ -1,0 +1,229 @@
+// Package services implements core business workflows.
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const natGatewayTracer = "nat-gateway-service"
+
+// NATGatewayService manages the lifecycle of NAT Gateways.
+type NATGatewayService struct {
+	repo         ports.NATGatewayRepository
+	eipRepo      ports.ElasticIPRepository
+	subnetRepo   ports.SubnetRepository
+	vpcRepo      ports.VpcRepository
+	rbacSvc      ports.RBACService
+	network      ports.NetworkBackend
+	auditSvc     ports.AuditService
+	logger       *slog.Logger
+}
+
+// NATGatewayServiceParams holds dependencies for NATGatewayService.
+type NATGatewayServiceParams struct {
+	Repo       ports.NATGatewayRepository
+	EIPRepo    ports.ElasticIPRepository
+	SubnetRepo ports.SubnetRepository
+	VpcRepo    ports.VpcRepository
+	RBACSvc    ports.RBACService
+	Network    ports.NetworkBackend
+	AuditSvc   ports.AuditService
+	Logger     *slog.Logger
+}
+
+// NewNATGatewayService constructs a NATGatewayService with its dependencies.
+func NewNATGatewayService(params NATGatewayServiceParams) *NATGatewayService {
+	logger := params.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &NATGatewayService{
+		repo:       params.Repo,
+		eipRepo:    params.EIPRepo,
+		subnetRepo: params.SubnetRepo,
+		vpcRepo:    params.VpcRepo,
+		rbacSvc:    params.RBACSvc,
+		network:    params.Network,
+		auditSvc:   params.AuditSvc,
+		logger:     logger,
+	}
+}
+
+// CreateNATGateway creates a NAT Gateway in a subnet with an allocated Elastic IP.
+func (s *NATGatewayService) CreateNATGateway(ctx context.Context, subnetID, eipID uuid.UUID) (*domain.NATGateway, error) {
+	ctx, span := otel.Tracer(natGatewayTracer).Start(ctx, "CreateNATGateway")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("subnet_id", subnetID.String()),
+		attribute.String("eip_id", eipID.String()),
+	)
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcCreate, "*"); err != nil {
+		return nil, err
+	}
+
+	// Get subnet to find VPC and gateway IP
+	subnet, err := s.subnetRepo.GetByID(ctx, subnetID)
+	if err != nil {
+		return nil, errors.Wrap(errors.NotFound, "subnet not found", err)
+	}
+
+	// Get VPC for validation
+	vpc, err := s.vpcRepo.GetByID(ctx, subnet.VPCID)
+	if err != nil {
+		return nil, errors.Wrap(errors.NotFound, "VPC not found", err)
+	}
+
+	// Get Elastic IP
+	eip, err := s.eipRepo.GetByID(ctx, eipID)
+	if err != nil {
+		return nil, errors.Wrap(errors.NotFound, "elastic IP not found", err)
+	}
+
+	// Verify EIP is allocated
+	if eip.Status != domain.EIPStatusAllocated {
+		return nil, errors.New(errors.InvalidInput, "elastic IP is not in allocated state")
+	}
+
+	natID := uuid.New()
+	arn := fmt.Sprintf("arn:thecloud:vpc:local:%s:nat-gateway/%s", userID.String(), natID.String())
+
+	// Use gateway IP from subnet as the NAT's private IP
+	nat := &domain.NATGateway{
+		ID:          natID,
+		VPCID:       vpc.ID,
+		SubnetID:    subnetID,
+		ElasticIPID: eipID,
+		UserID:      userID,
+		TenantID:    tenantID,
+		Status:      domain.NATGatewayStatusPending,
+		PrivateIP:   subnet.GatewayIP,
+		ARN:         arn,
+		CreatedAt:   time.Now(),
+	}
+
+	if err := s.repo.Create(ctx, nat); err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to create NAT gateway", err)
+	}
+
+	// Setup NAT via NetworkBackend
+	natVethEnd := fmt.Sprintf("nat-%s", natID.String()[:8])
+	if err := s.network.SetupNATForSubnet(ctx, vpc.NetworkID, natVethEnd, subnet.CIDRBlock, eip.PublicIP); err != nil {
+		s.logger.Error("failed to setup NAT", "nat_id", natID, "error", err)
+		// Update NAT status to failed
+		nat.Status = domain.NATGatewayStatusFailed
+		_ = s.repo.Update(ctx, nat)
+		return nil, errors.Wrap(errors.Internal, "failed to setup NAT", err)
+	}
+
+	// Mark as active
+	nat.Status = domain.NATGatewayStatusActive
+	if err := s.repo.Update(ctx, nat); err != nil {
+		s.logger.Warn("failed to update NAT gateway status to active", "error", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "nat_gateway.create", "nat_gateway", natID.String(), map[string]interface{}{
+		"subnet_id": subnetID.String(),
+		"eip_id":    eipID.String(),
+		"private_ip": nat.PrivateIP,
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("NAT gateway created", "id", natID, "subnet_id", subnetID, "eip", eip.PublicIP, "private_ip", nat.PrivateIP)
+	return nat, nil
+}
+
+// GetNATGateway retrieves a NAT Gateway by ID.
+func (s *NATGatewayService) GetNATGateway(ctx context.Context, natID uuid.UUID) (*domain.NATGateway, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcRead, natID.String()); err != nil {
+		return nil, err
+	}
+
+	return s.repo.GetByID(ctx, natID)
+}
+
+// ListNATGateways returns all NAT Gateways for a VPC.
+func (s *NATGatewayService) ListNATGateways(ctx context.Context, vpcID uuid.UUID) ([]*domain.NATGateway, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcRead, vpcID.String()); err != nil {
+		return nil, err
+	}
+
+	return s.repo.ListByVPC(ctx, vpcID)
+}
+
+// DeleteNATGateway removes a NAT Gateway and releases the associated EIP.
+func (s *NATGatewayService) DeleteNATGateway(ctx context.Context, natID uuid.UUID) error {
+	ctx, span := otel.Tracer(natGatewayTracer).Start(ctx, "DeleteNATGateway")
+	defer span.End()
+
+	span.SetAttributes(attribute.String("nat_id", natID.String()))
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcDelete, natID.String()); err != nil {
+		return err
+	}
+
+	// Get NAT Gateway
+	nat, err := s.repo.GetByID(ctx, natID)
+	if err != nil {
+		return errors.Wrap(errors.NotFound, "NAT gateway not found", err)
+	}
+
+	// Get subnet and VPC for cleanup
+	subnet, _ := s.subnetRepo.GetByID(ctx, nat.SubnetID)
+	vpc, _ := s.vpcRepo.GetByID(ctx, nat.VPCID)
+
+	// Get EIP for public IP
+	eip, _ := s.eipRepo.GetByID(ctx, nat.ElasticIPID)
+
+	// Remove NAT setup
+	if subnet != nil && vpc != nil {
+		natVethEnd := fmt.Sprintf("nat-%s", natID.String()[:8])
+		_ = s.network.RemoveNATForSubnet(ctx, vpc.NetworkID, natVethEnd, subnet.CIDRBlock)
+	}
+
+	// Release the EIP back to allocated state
+	if eip != nil && eip.Status == domain.EIPStatusAssociated {
+		eip.InstanceID = nil
+		eip.VpcID = nil
+		eip.Status = domain.EIPStatusAllocated
+		eip.UpdatedAt = time.Now()
+		_ = s.eipRepo.Update(ctx, eip)
+	}
+
+	// Delete NAT record
+	if err := s.repo.Delete(ctx, natID); err != nil {
+		return errors.Wrap(errors.Internal, "failed to delete NAT gateway", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "nat_gateway.delete", "nat_gateway", natID.String(), nil); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("NAT gateway deleted", "id", natID)
+	return nil
+}

--- a/internal/core/services/nat_gateway.go
+++ b/internal/core/services/nat_gateway.go
@@ -193,28 +193,26 @@ func (s *NATGatewayService) DeleteNATGateway(ctx context.Context, natID uuid.UUI
 		return errors.Wrap(errors.NotFound, "NAT gateway not found", err)
 	}
 
-	// Get subnet and VPC for cleanup
+	// Get subnet and VPC for cleanup - these are required for proper NAT removal
 	subnet, err := s.subnetRepo.GetByID(ctx, nat.SubnetID)
 	if err != nil {
-		s.logger.Warn("failed to get subnet during NAT cleanup", "nat_id", natID, "error", err)
+		return errors.Wrap(errors.Internal, "failed to get subnet during NAT cleanup", err)
 	}
 	vpc, err := s.vpcRepo.GetByID(ctx, nat.VPCID)
 	if err != nil {
-		s.logger.Warn("failed to get VPC during NAT cleanup", "nat_id", natID, "error", err)
+		return errors.Wrap(errors.Internal, "failed to get VPC during NAT cleanup", err)
 	}
 
-	// Get EIP for public IP
+	// Get EIP for public IP - required to properly remove NAT rules
 	eip, err := s.eipRepo.GetByID(ctx, nat.ElasticIPID)
 	if err != nil {
-		s.logger.Warn("failed to get EIP during NAT cleanup", "nat_id", natID, "error", err)
+		return errors.Wrap(errors.Internal, "failed to get EIP during NAT cleanup", err)
 	}
 
 	// Remove NAT setup
-	if subnet != nil && vpc != nil && eip != nil {
-		natVethEnd := fmt.Sprintf("nat-%s", natID.String()[:8])
-		if err := s.network.RemoveNATForSubnet(ctx, vpc.NetworkID, natVethEnd, subnet.CIDRBlock, eip.PublicIP); err != nil {
-			s.logger.Error("failed to remove NAT setup", "nat_id", natID, "error", err)
-		}
+	natVethEnd := fmt.Sprintf("nat-%s", natID.String()[:8])
+	if err := s.network.RemoveNATForSubnet(ctx, vpc.NetworkID, natVethEnd, subnet.CIDRBlock, eip.PublicIP); err != nil {
+		return errors.Wrap(errors.Internal, "failed to remove NAT setup", err)
 	}
 
 	// Release the EIP back to allocated state

--- a/internal/core/services/nat_gateway.go
+++ b/internal/core/services/nat_gateway.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"time"
 
 	"github.com/google/uuid"
@@ -98,6 +99,11 @@ func (s *NATGatewayService) CreateNATGateway(ctx context.Context, subnetID, eipI
 	// Verify EIP is allocated
 	if eip.Status != domain.EIPStatusAllocated {
 		return nil, errors.New(errors.InvalidInput, "elastic IP is not in allocated state")
+	}
+
+	// Validate egress IP format
+	if net.ParseIP(eip.PublicIP) == nil {
+		return nil, errors.New(errors.InvalidInput, "invalid EIP address format")
 	}
 
 	natID := uuid.New()

--- a/internal/core/services/nat_gateway.go
+++ b/internal/core/services/nat_gateway.go
@@ -106,6 +106,17 @@ func (s *NATGatewayService) CreateNATGateway(ctx context.Context, subnetID, eipI
 		return nil, errors.New(errors.InvalidInput, "invalid EIP address format")
 	}
 
+	// Check if another NAT gateway already exists for this subnet
+	existing, err := s.repo.ListBySubnet(ctx, subnetID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to check existing NAT gateways", err)
+	}
+	for _, nat := range existing {
+		if nat.PrivateIP == subnet.GatewayIP {
+			return nil, errors.New(errors.InvalidInput, "NAT gateway already exists for this subnet with the same private IP")
+		}
+	}
+
 	natID := uuid.New()
 	arn := fmt.Sprintf("arn:thecloud:vpc:local:%s:nat-gateway/%s", userID.String(), natID.String())
 
@@ -227,7 +238,10 @@ func (s *NATGatewayService) DeleteNATGateway(ctx context.Context, natID uuid.UUI
 		eip.VpcID = nil
 		eip.Status = domain.EIPStatusAllocated
 		eip.UpdatedAt = time.Now()
-		_ = s.eipRepo.Update(ctx, eip)
+		if err := s.eipRepo.Update(ctx, eip); err != nil {
+			s.logger.Warn("failed to release EIP during NAT gateway deletion",
+				"eip_id", eip.ID, "nat_id", natID, "error", err)
+		}
 	}
 
 	// Delete NAT record

--- a/internal/core/services/route_table.go
+++ b/internal/core/services/route_table.go
@@ -1,0 +1,345 @@
+// Package services implements core business workflows.
+package services
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const routeTableTracer = "route-table-service"
+
+// RouteTableService manages the lifecycle of route tables within a VPC.
+type RouteTableService struct {
+	repo     ports.RouteTableRepository
+	vpcRepo  ports.VpcRepository
+	rbacSvc  ports.RBACService
+	network  ports.NetworkBackend
+	auditSvc ports.AuditService
+	logger   *slog.Logger
+}
+
+// RouteTableServiceParams holds dependencies for RouteTableService.
+type RouteTableServiceParams struct {
+	Repo     ports.RouteTableRepository
+	VpcRepo  ports.VpcRepository
+	RBACSvc  ports.RBACService
+	Network  ports.NetworkBackend
+	AuditSvc ports.AuditService
+	Logger   *slog.Logger
+}
+
+// NewRouteTableService constructs a RouteTableService with its dependencies.
+func NewRouteTableService(params RouteTableServiceParams) *RouteTableService {
+	logger := params.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &RouteTableService{
+		repo:     params.Repo,
+		vpcRepo:  params.VpcRepo,
+		rbacSvc:  params.RBACSvc,
+		network:  params.Network,
+		auditSvc: params.AuditSvc,
+		logger:   logger,
+	}
+}
+
+// CreateRouteTable creates a new custom route table for a VPC.
+// If isMain is true, this becomes the main route table (replacing existing main).
+func (s *RouteTableService) CreateRouteTable(ctx context.Context, vpcID uuid.UUID, name string, isMain bool) (*domain.RouteTable, error) {
+	ctx, span := otel.Tracer(routeTableTracer).Start(ctx, "CreateRouteTable")
+	defer span.End()
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	span.SetAttributes(
+		attribute.String("vpc_id", vpcID.String()),
+		attribute.String("name", name),
+		attribute.Bool("is_main", isMain),
+	)
+
+	// Verify VPC exists and user has access
+	if _, err := s.vpcRepo.GetByID(ctx, vpcID); err != nil {
+		return nil, errors.Wrap(errors.NotFound, "VPC not found", err)
+	}
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcUpdate, vpcID.String()); err != nil {
+		return nil, err
+	}
+
+	rtID := uuid.New()
+	rt := &domain.RouteTable{
+		ID:        rtID,
+		VPCID:     vpcID,
+		Name:      name,
+		IsMain:    isMain,
+		Routes:    []domain.Route{},
+		CreatedAt: time.Now(),
+	}
+
+	if err := rt.Validate(); err != nil {
+		return nil, errors.New(errors.InvalidInput, err.Error())
+	}
+
+	if err := s.repo.Create(ctx, rt); err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to create route table", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "route_table.create", "route_table", rtID.String(), map[string]interface{}{
+		"vpc_id": vpcID.String(),
+		"name":   name,
+		"is_main": isMain,
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("route table created", "id", rtID, "vpc_id", vpcID, "name", name, "is_main", isMain)
+	return rt, nil
+}
+
+// GetRouteTable retrieves a route table by ID.
+func (s *RouteTableService) GetRouteTable(ctx context.Context, id uuid.UUID) (*domain.RouteTable, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcRead, id.String()); err != nil {
+		return nil, err
+	}
+
+	return s.repo.GetByID(ctx, id)
+}
+
+// ListRouteTables returns all route tables for a VPC.
+func (s *RouteTableService) ListRouteTables(ctx context.Context, vpcID uuid.UUID) ([]*domain.RouteTable, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcRead, vpcID.String()); err != nil {
+		return nil, err
+	}
+
+	return s.repo.GetByVPC(ctx, vpcID)
+}
+
+// DeleteRouteTable removes a custom route table (cannot delete main route table).
+func (s *RouteTableService) DeleteRouteTable(ctx context.Context, id uuid.UUID) error {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcDelete, id.String()); err != nil {
+		return err
+	}
+
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return errors.Wrap(errors.Internal, "failed to delete route table", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "route_table.delete", "route_table", id.String(), nil); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("route table deleted", "id", id)
+	return nil
+}
+
+// AddRoute adds a route to an existing route table.
+func (s *RouteTableService) AddRoute(ctx context.Context, rtID uuid.UUID, destinationCIDR string, targetType domain.RouteTargetType, targetID *uuid.UUID) (*domain.Route, error) {
+	ctx, span := otel.Tracer(routeTableTracer).Start(ctx, "AddRoute")
+	defer span.End()
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcUpdate, rtID.String()); err != nil {
+		return nil, err
+	}
+
+	span.SetAttributes(
+		attribute.String("rt_id", rtID.String()),
+		attribute.String("destination_cidr", destinationCIDR),
+		attribute.String("target_type", string(targetType)),
+	)
+
+	// Get the route table to find VPC
+	rt, err := s.repo.GetByID(ctx, rtID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get VPC to find bridge name
+	vpc, err := s.vpcRepo.GetByID(ctx, rt.VPCID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to get VPC", err)
+	}
+
+	route := &domain.Route{
+		ID:              uuid.New(),
+		RouteTableID:    rtID,
+		DestinationCIDR: destinationCIDR,
+		TargetType:     targetType,
+		TargetID:       targetID,
+		TargetName:     string(targetType),
+		CreatedAt:      time.Now(),
+	}
+
+	if err := route.Validate(); err != nil {
+		return nil, errors.New(errors.InvalidInput, err.Error())
+	}
+
+	// Add route to database
+	if err := s.repo.AddRoute(ctx, rtID, route); err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to add route", err)
+	}
+
+	// Program OVS flow for the route
+	flow := ports.FlowRule{
+		Priority: 300,
+		Match:    fmt.Sprintf("ip,nw_dst=%s", destinationCIDR),
+		Actions:  "NORMAL",
+	}
+	if err := s.network.AddFlowRule(ctx, vpc.NetworkID, flow); err != nil {
+		s.logger.Error("failed to add OVS flow for route", "route_id", route.ID, "error", err)
+		// Don't fail the operation - DB is source of truth
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "route_table.add_route", "route_table", rtID.String(), map[string]interface{}{
+		"route_id": route.ID.String(),
+		"destination_cidr": destinationCIDR,
+		"target_type": string(targetType),
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("route added", "id", route.ID, "rt_id", rtID, "dest", destinationCIDR, "target", targetType)
+	return route, nil
+}
+
+// RemoveRoute removes a route from a route table.
+func (s *RouteTableService) RemoveRoute(ctx context.Context, rtID, routeID uuid.UUID) error {
+	ctx, span := otel.Tracer(routeTableTracer).Start(ctx, "RemoveRoute")
+	defer span.End()
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcUpdate, rtID.String()); err != nil {
+		return err
+	}
+
+	// Get the route to find destination CIDR for OVS cleanup
+	routes, err := s.repo.ListRoutes(ctx, rtID)
+	if err != nil {
+		return err
+	}
+
+	var destinationCIDR string
+	for _, r := range routes {
+		if r.ID == routeID {
+			destinationCIDR = r.DestinationCIDR
+			break
+		}
+	}
+
+	// Get VPC for OVS cleanup
+	rt, err := s.repo.GetByID(ctx, rtID)
+	if err != nil {
+		return err
+	}
+
+	vpc, err := s.vpcRepo.GetByID(ctx, rt.VPCID)
+	if err != nil {
+		return err
+	}
+
+	// Remove from DB
+	if err := s.repo.RemoveRoute(ctx, rtID, routeID); err != nil {
+		return errors.Wrap(errors.Internal, "failed to remove route", err)
+	}
+
+	// Remove OVS flow
+	if destinationCIDR != "" {
+		match := fmt.Sprintf("ip,nw_dst=%s", destinationCIDR)
+		if err := s.network.DeleteFlowRule(ctx, vpc.NetworkID, match); err != nil {
+			s.logger.Error("failed to remove OVS flow for route", "route_id", routeID, "error", err)
+		}
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "route_table.remove_route", "route_table", rtID.String(), map[string]interface{}{
+		"route_id": routeID.String(),
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	return nil
+}
+
+// AssociateSubnet links a subnet to a route table.
+func (s *RouteTableService) AssociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error {
+	ctx, span := otel.Tracer(routeTableTracer).Start(ctx, "AssociateSubnet")
+	defer span.End()
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcUpdate, rtID.String()); err != nil {
+		return err
+	}
+
+	if err := s.repo.AssociateSubnet(ctx, rtID, subnetID); err != nil {
+		return errors.Wrap(errors.Internal, "failed to associate subnet", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "route_table.associate", "route_table", rtID.String(), map[string]interface{}{
+		"subnet_id": subnetID.String(),
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("subnet associated with route table", "rt_id", rtID, "subnet_id", subnetID)
+	return nil
+}
+
+// DisassociateSubnet removes a subnet's association with a route table.
+// The subnet will then use the main route table.
+func (s *RouteTableService) DisassociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error {
+	ctx, span := otel.Tracer(routeTableTracer).Start(ctx, "DisassociateSubnet")
+	defer span.End()
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcUpdate, rtID.String()); err != nil {
+		return err
+	}
+
+	if err := s.repo.DisassociateSubnet(ctx, rtID, subnetID); err != nil {
+		return errors.Wrap(errors.Internal, "failed to disassociate subnet", err)
+	}
+
+	if err := s.auditSvc.Log(ctx, userID, "route_table.disassociate", "route_table", rtID.String(), map[string]interface{}{
+		"subnet_id": subnetID.String(),
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "error", err)
+	}
+
+	s.logger.Info("subnet disassociated from route table", "rt_id", rtID, "subnet_id", subnetID)
+	return nil
+}
+
+// ReplaceRoute replaces an existing route with a new target.
+func (s *RouteTableService) ReplaceRoute(ctx context.Context, rtID, routeID uuid.UUID, newTargetID *uuid.UUID) error {
+	// This would require getting the route, removing it, and adding a new one
+	// For now, just a placeholder - implementation would follow similar pattern
+	return errors.New(errors.NotImplemented, "ReplaceRoute not yet implemented")
+}

--- a/internal/core/services/routing_services_test.go
+++ b/internal/core/services/routing_services_test.go
@@ -494,7 +494,7 @@ func TestNATGatewayService_DeleteNATGateway(t *testing.T) {
 	mockVPC.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
 	mockEIP.On("GetByID", mock.Anything, eipID).Return(eip, nil)
 	mockEIP.On("Update", mock.Anything, mock.AnythingOfType("*domain.ElasticIP")).Return(nil)
-	mockNetwork.On("RemoveNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockNetwork.On("RemoveNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mockNAT.On("Delete", mock.Anything, natID).Return(nil)
 	mockAudit.On("Log", mock.Anything, mock.Anything, "nat_gateway.delete", "nat_gateway", mock.Anything, mock.Anything).Return(nil)
 

--- a/internal/core/services/routing_services_test.go
+++ b/internal/core/services/routing_services_test.go
@@ -479,6 +479,9 @@ func TestNATGatewayService_CreateNATGateway(t *testing.T) {
 				mocks.eip.On("GetByID", mock.Anything, eipID).Return(tt.eip, nil)
 			}
 
+			// Check for existing NAT gateways on subnet
+			mocks.nat.On("ListBySubnet", mock.Anything, subnetID).Return([]*domain.NATGateway(nil), nil).Maybe()
+
 			// Create is always called
 			mocks.nat.On("Create", mock.Anything, mock.AnythingOfType("*domain.NATGateway")).Return(nil).Maybe()
 

--- a/internal/core/services/routing_services_test.go
+++ b/internal/core/services/routing_services_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/services"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // ---- InternetGateway Service Tests ----
@@ -291,7 +292,7 @@ func TestRouteTableService_AddRoute(t *testing.T) {
 
 	route, err := svc.AddRoute(ctx, rtID, "0.0.0.0/0", domain.RouteTargetIGW, &igwID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "0.0.0.0/0", route.DestinationCIDR)
 	assert.Equal(t, domain.RouteTargetIGW, route.TargetType)
 	mockRT.AssertExpectations(t)

--- a/internal/core/services/routing_services_test.go
+++ b/internal/core/services/routing_services_test.go
@@ -45,7 +45,7 @@ func TestInternetGatewayService_CreateIGW(t *testing.T) {
 
 	igw, err := svc.CreateIGW(ctx)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, igw)
 	assert.Equal(t, domain.IGWStatusDetached, igw.Status)
 	assert.Nil(t, igw.VPCID)
@@ -89,7 +89,7 @@ func TestInternetGatewayService_AttachIGW_Success(t *testing.T) {
 
 	err := svc.AttachIGW(ctx, igwID, vpcID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, domain.IGWStatusAttached, igw.Status)
 	assert.Equal(t, &vpcID, igw.VPCID)
 	mockIGW.AssertExpectations(t)
@@ -122,7 +122,7 @@ func TestInternetGatewayService_AttachIGW_AlreadyAttached(t *testing.T) {
 
 	err := svc.AttachIGW(ctx, igwID, vpcID)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already attached")
 }
 
@@ -153,7 +153,7 @@ func TestInternetGatewayService_Delete_AttachedIGW(t *testing.T) {
 
 	err := svc.DeleteIGW(ctx, igwID)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "attached")
 	mockIGW.AssertExpectations(t)
 }
@@ -186,7 +186,7 @@ func TestInternetGatewayService_Delete_DetachedIGW(t *testing.T) {
 
 	err := svc.DeleteIGW(ctx, igwID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockIGW.AssertExpectations(t)
 }
 
@@ -222,7 +222,7 @@ func TestRouteTableService_CreateRouteTable(t *testing.T) {
 
 	rt, err := svc.CreateRouteTable(ctx, vpcID, "test-rt", false)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, rt)
 	assert.Equal(t, "test-rt", rt.Name)
 	assert.Equal(t, vpcID, rt.VPCID)
@@ -251,7 +251,7 @@ func TestRouteTableService_CreateRouteTable_VPCNotFound(t *testing.T) {
 
 	_, err := svc.CreateRouteTable(ctx, vpcID, "test-rt", false)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
 
@@ -325,7 +325,7 @@ func TestRouteTableService_AssociateSubnet(t *testing.T) {
 
 	err := svc.AssociateSubnet(ctx, rtID, subnetID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockRT.AssertExpectations(t)
 }
 
@@ -356,7 +356,7 @@ func TestRouteTableService_DisassociateSubnet(t *testing.T) {
 
 	err := svc.DisassociateSubnet(ctx, rtID, subnetID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockRT.AssertExpectations(t)
 }
 
@@ -406,7 +406,7 @@ func TestNATGatewayService_CreateNATGateway(t *testing.T) {
 
 	nat, err := svc.CreateNATGateway(ctx, subnetID, eipID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, nat)
 	assert.Equal(t, subnetID, nat.SubnetID)
 	assert.Equal(t, eipID, nat.ElasticIPID)
@@ -449,7 +449,7 @@ func TestNATGatewayService_CreateNATGateway_EIPNotAllocated(t *testing.T) {
 
 	_, err := svc.CreateNATGateway(ctx, subnetID, eipID)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "allocated")
 }
 
@@ -500,7 +500,7 @@ func TestNATGatewayService_DeleteNATGateway(t *testing.T) {
 
 	err := svc.DeleteNATGateway(ctx, natID)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mockNAT.AssertExpectations(t)
 }
 
@@ -526,6 +526,6 @@ func TestNATGatewayService_DeleteNATGateway_NotFound(t *testing.T) {
 
 	err := svc.DeleteNATGateway(ctx, natID)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }

--- a/internal/core/services/routing_services_test.go
+++ b/internal/core/services/routing_services_test.go
@@ -1,0 +1,530 @@
+package services_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// ---- InternetGateway Service Tests ----
+
+func TestInternetGatewayService_CreateIGW(t *testing.T) {
+	mockIGW := new(MockIGWRepo)
+	mockRT := new(MockRTRepo)
+	mockVPC := new(MockVpcRepo)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	svc := services.NewInternetGatewayService(services.InternetGatewayServiceParams{
+		Repo:     mockIGW,
+		RTRepo:   mockRT,
+		VpcRepo:  mockVPC,
+		RBACSvc:  mockRBAC,
+		AuditSvc: mockAudit,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	mockIGW.On("Create", mock.Anything, mock.AnythingOfType("*domain.InternetGateway")).Return(nil)
+	mockAudit.On("Log", mock.Anything, userID, "igw.create", "internet_gateway", mock.Anything, mock.Anything).Return(nil)
+
+	igw, err := svc.CreateIGW(ctx)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, igw)
+	assert.Equal(t, domain.IGWStatusDetached, igw.Status)
+	assert.Nil(t, igw.VPCID)
+	mockIGW.AssertExpectations(t)
+}
+
+func TestInternetGatewayService_AttachIGW_Success(t *testing.T) {
+	mockIGW := new(MockIGWRepo)
+	mockRT := new(MockRTRepo)
+	mockVPC := new(MockVpcRepo)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+
+	svc := services.NewInternetGatewayService(services.InternetGatewayServiceParams{
+		Repo:     mockIGW,
+		RTRepo:   mockRT,
+		VpcRepo:  mockVPC,
+		RBACSvc:  mockRBAC,
+		AuditSvc: mockAudit,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	vpcID := uuid.New()
+	igwID := uuid.New()
+	vpc := &domain.VPC{ID: vpcID, Name: "test-vpc"}
+	igw := &domain.InternetGateway{ID: igwID, Status: domain.IGWStatusDetached, VPCID: nil, UserID: userID, TenantID: tenantID}
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockIGW.On("GetByID", mock.Anything, igwID).Return(igw, nil)
+	mockVPC.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
+	mockIGW.On("GetByVPC", mock.Anything, vpcID).Return(nil, errors.New("not found"))
+	mockIGW.On("Update", mock.Anything, mock.AnythingOfType("*domain.InternetGateway")).Return(nil)
+	mockRT.On("GetMainByVPC", mock.Anything, vpcID).Return((*domain.RouteTable)(nil), errors.New("no main"))
+	mockAudit.On("Log", mock.Anything, userID, "igw.attach", "internet_gateway", mock.Anything, map[string]interface{}{"vpc_id": vpcID.String()}).Return(nil)
+
+	err := svc.AttachIGW(ctx, igwID, vpcID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, domain.IGWStatusAttached, igw.Status)
+	assert.Equal(t, &vpcID, igw.VPCID)
+	mockIGW.AssertExpectations(t)
+}
+
+func TestInternetGatewayService_AttachIGW_AlreadyAttached(t *testing.T) {
+	mockIGW := new(MockIGWRepo)
+	mockVPC := new(MockVpcRepo)
+	mockRBAC := new(MockRBACService)
+
+	svc := services.NewInternetGatewayService(services.InternetGatewayServiceParams{
+		Repo:    mockIGW,
+		VpcRepo: mockVPC,
+		RBACSvc: mockRBAC,
+		Logger:  slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	vpcID := uuid.New()
+	igwID := uuid.New()
+	igw := &domain.InternetGateway{ID: igwID, Status: domain.IGWStatusAttached, VPCID: &vpcID}
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockIGW.On("GetByID", mock.Anything, igwID).Return(igw, nil)
+
+	err := svc.AttachIGW(ctx, igwID, vpcID)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "already attached")
+}
+
+func TestInternetGatewayService_Delete_AttachedIGW(t *testing.T) {
+	mockIGW := new(MockIGWRepo)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+
+	svc := services.NewInternetGatewayService(services.InternetGatewayServiceParams{
+		Repo:     mockIGW,
+		RBACSvc:  mockRBAC,
+		AuditSvc: mockAudit,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	vpcID := uuid.New()
+	igwID := uuid.New()
+	igw := &domain.InternetGateway{ID: igwID, Status: domain.IGWStatusAttached, VPCID: &vpcID, UserID: userID, TenantID: tenantID}
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockIGW.On("GetByID", mock.Anything, igwID).Return(igw, nil)
+
+	err := svc.DeleteIGW(ctx, igwID)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "attached")
+	mockIGW.AssertExpectations(t)
+}
+
+func TestInternetGatewayService_Delete_DetachedIGW(t *testing.T) {
+	mockIGW := new(MockIGWRepo)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+
+	svc := services.NewInternetGatewayService(services.InternetGatewayServiceParams{
+		Repo:     mockIGW,
+		RBACSvc:  mockRBAC,
+		AuditSvc: mockAudit,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	igwID := uuid.New()
+	igw := &domain.InternetGateway{ID: igwID, Status: domain.IGWStatusDetached, VPCID: nil, UserID: userID, TenantID: tenantID}
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockIGW.On("GetByID", mock.Anything, igwID).Return(igw, nil)
+	mockIGW.On("Delete", mock.Anything, igwID).Return(nil)
+	mockAudit.On("Log", mock.Anything, mock.Anything, "igw.delete", "internet_gateway", mock.Anything, mock.Anything).Return(nil)
+
+	err := svc.DeleteIGW(ctx, igwID)
+
+	assert.NoError(t, err)
+	mockIGW.AssertExpectations(t)
+}
+
+// ---- RouteTable Service Tests ----
+
+func TestRouteTableService_CreateRouteTable(t *testing.T) {
+	mockRT := new(MockRTRepo)
+	mockVPC := new(MockVpcRepo)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+
+	svc := services.NewRouteTableService(services.RouteTableServiceParams{
+		Repo:     mockRT,
+		VpcRepo:  mockVPC,
+		RBACSvc:  mockRBAC,
+		AuditSvc: mockAudit,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	vpcID := uuid.New()
+	vpc := &domain.VPC{ID: vpcID, Name: "test-vpc"}
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockVPC.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
+	mockRT.On("Create", mock.Anything, mock.AnythingOfType("*domain.RouteTable")).Return(nil)
+	mockAudit.On("Log", mock.Anything, mock.Anything, "route_table.create", "route_table", mock.Anything, mock.Anything).Return(nil)
+
+	rt, err := svc.CreateRouteTable(ctx, vpcID, "test-rt", false)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, rt)
+	assert.Equal(t, "test-rt", rt.Name)
+	assert.Equal(t, vpcID, rt.VPCID)
+	assert.False(t, rt.IsMain)
+	mockRT.AssertExpectations(t)
+}
+
+func TestRouteTableService_CreateRouteTable_VPCNotFound(t *testing.T) {
+	mockRT := new(MockRTRepo)
+	mockVPC := new(MockVpcRepo)
+
+	svc := services.NewRouteTableService(services.RouteTableServiceParams{
+		Repo:    mockRT,
+		VpcRepo: mockVPC,
+		Logger:  slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	vpcID := uuid.New()
+	mockVPC.On("GetByID", mock.Anything, vpcID).Return(nil, errors.New("not found"))
+
+	_, err := svc.CreateRouteTable(ctx, vpcID, "test-rt", false)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestRouteTableService_AddRoute(t *testing.T) {
+	mockRT := new(MockRTRepo)
+	mockVPC := new(MockVpcRepo)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+	mockNetwork := new(MockNetworkBackend)
+
+	svc := services.NewRouteTableService(services.RouteTableServiceParams{
+		Repo:     mockRT,
+		VpcRepo:  mockVPC,
+		RBACSvc:  mockRBAC,
+		AuditSvc: mockAudit,
+		Network:  mockNetwork,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	rtID := uuid.New()
+	vpcID := uuid.New()
+	rt := &domain.RouteTable{ID: rtID, VPCID: vpcID, Name: "test-rt"}
+	vpc := &domain.VPC{ID: vpcID, NetworkID: "br-test"}
+	igwID := uuid.New()
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockRT.On("GetByID", mock.Anything, rtID).Return(rt, nil)
+	mockVPC.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
+	mockRT.On("AddRoute", mock.Anything, rtID, mock.AnythingOfType("*domain.Route")).Return(nil)
+	mockNetwork.On("AddFlowRule", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockAudit.On("Log", mock.Anything, mock.Anything, "route_table.add_route", "route_table", mock.Anything, mock.Anything).Return(nil)
+
+	route, err := svc.AddRoute(ctx, rtID, "0.0.0.0/0", domain.RouteTargetIGW, &igwID)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "0.0.0.0/0", route.DestinationCIDR)
+	assert.Equal(t, domain.RouteTargetIGW, route.TargetType)
+	mockRT.AssertExpectations(t)
+}
+
+func TestRouteTableService_AssociateSubnet(t *testing.T) {
+	mockRT := new(MockRTRepo)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+
+	svc := services.NewRouteTableService(services.RouteTableServiceParams{
+		Repo:     mockRT,
+		RBACSvc:  mockRBAC,
+		AuditSvc: mockAudit,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	rtID := uuid.New()
+	subnetID := uuid.New()
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockRT.On("AssociateSubnet", mock.Anything, rtID, subnetID).Return(nil)
+	mockAudit.On("Log", mock.Anything, mock.Anything, "route_table.associate", "route_table", mock.Anything, mock.Anything).Return(nil)
+
+	err := svc.AssociateSubnet(ctx, rtID, subnetID)
+
+	assert.NoError(t, err)
+	mockRT.AssertExpectations(t)
+}
+
+func TestRouteTableService_DisassociateSubnet(t *testing.T) {
+	mockRT := new(MockRTRepo)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+
+	svc := services.NewRouteTableService(services.RouteTableServiceParams{
+		Repo:     mockRT,
+		RBACSvc:  mockRBAC,
+		AuditSvc: mockAudit,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	rtID := uuid.New()
+	subnetID := uuid.New()
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockRT.On("DisassociateSubnet", mock.Anything, rtID, subnetID).Return(nil)
+	mockAudit.On("Log", mock.Anything, mock.Anything, "route_table.disassociate", "route_table", mock.Anything, mock.Anything).Return(nil)
+
+	err := svc.DisassociateSubnet(ctx, rtID, subnetID)
+
+	assert.NoError(t, err)
+	mockRT.AssertExpectations(t)
+}
+
+// ---- NATGateway Service Tests ----
+
+func TestNATGatewayService_CreateNATGateway(t *testing.T) {
+	mockNAT := new(MockNATGatewayRepo)
+	mockSubnet := new(MockSubnetRepo)
+	mockVPC := new(MockVpcRepo)
+	mockEIP := new(MockEIPRepo)
+	mockNetwork := new(MockNetworkBackend)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+
+	svc := services.NewNATGatewayService(services.NATGatewayServiceParams{
+		Repo:       mockNAT,
+		SubnetRepo: mockSubnet,
+		VpcRepo:    mockVPC,
+		EIPRepo:    mockEIP,
+		Network:    mockNetwork,
+		RBACSvc:    mockRBAC,
+		AuditSvc:   mockAudit,
+		Logger:     slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	subnetID := uuid.New()
+	eipID := uuid.New()
+	vpcID := uuid.New()
+	subnet := &domain.Subnet{ID: subnetID, VPCID: vpcID, GatewayIP: "10.0.0.1", CIDRBlock: "10.0.0.0/24"}
+	vpc := &domain.VPC{ID: vpcID, Name: "vpc", NetworkID: "br-vpc"}
+	eip := &domain.ElasticIP{ID: eipID, UserID: userID, TenantID: tenantID, PublicIP: "203.0.113.10", Status: domain.EIPStatusAllocated}
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockSubnet.On("GetByID", mock.Anything, subnetID).Return(subnet, nil)
+	mockVPC.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
+	mockEIP.On("GetByID", mock.Anything, eipID).Return(eip, nil)
+	mockNAT.On("Create", mock.Anything, mock.AnythingOfType("*domain.NATGateway")).Return(nil)
+	mockNetwork.On("SetupNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockNAT.On("Update", mock.Anything, mock.AnythingOfType("*domain.NATGateway")).Return(nil)
+	mockAudit.On("Log", mock.Anything, mock.Anything, "nat_gateway.create", "nat_gateway", mock.Anything, mock.Anything).Return(nil)
+
+	nat, err := svc.CreateNATGateway(ctx, subnetID, eipID)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, nat)
+	assert.Equal(t, subnetID, nat.SubnetID)
+	assert.Equal(t, eipID, nat.ElasticIPID)
+	assert.Equal(t, domain.NATGatewayStatusActive, nat.Status)
+	mockNAT.AssertExpectations(t)
+}
+
+func TestNATGatewayService_CreateNATGateway_EIPNotAllocated(t *testing.T) {
+	mockNAT := new(MockNATGatewayRepo)
+	mockSubnet := new(MockSubnetRepo)
+	mockVPC := new(MockVpcRepo)
+	mockEIP := new(MockEIPRepo)
+	mockRBAC := new(MockRBACService)
+
+	svc := services.NewNATGatewayService(services.NATGatewayServiceParams{
+		Repo:       mockNAT,
+		SubnetRepo: mockSubnet,
+		VpcRepo:    mockVPC,
+		EIPRepo:    mockEIP,
+		RBACSvc:    mockRBAC,
+		Logger:     slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	subnetID := uuid.New()
+	eipID := uuid.New()
+	vpcID := uuid.New()
+	subnet := &domain.Subnet{ID: subnetID, VPCID: vpcID, GatewayIP: "10.0.0.1", CIDRBlock: "10.0.0.0/24"}
+	eip := &domain.ElasticIP{ID: eipID, Status: domain.EIPStatusAssociated} // wrong status
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockSubnet.On("GetByID", mock.Anything, subnetID).Return(subnet, nil)
+	mockVPC.On("GetByID", mock.Anything, vpcID).Return(&domain.VPC{ID: vpcID}, nil)
+	mockEIP.On("GetByID", mock.Anything, eipID).Return(eip, nil)
+
+	_, err := svc.CreateNATGateway(ctx, subnetID, eipID)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "allocated")
+}
+
+func TestNATGatewayService_DeleteNATGateway(t *testing.T) {
+	mockNAT := new(MockNATGatewayRepo)
+	mockSubnet := new(MockSubnetRepo)
+	mockVPC := new(MockVpcRepo)
+	mockEIP := new(MockEIPRepo)
+	mockNetwork := new(MockNetworkBackend)
+	mockRBAC := new(MockRBACService)
+	mockAudit := new(MockAuditService)
+
+	svc := services.NewNATGatewayService(services.NATGatewayServiceParams{
+		Repo:       mockNAT,
+		SubnetRepo: mockSubnet,
+		VpcRepo:    mockVPC,
+		EIPRepo:    mockEIP,
+		Network:    mockNetwork,
+		RBACSvc:    mockRBAC,
+		AuditSvc:   mockAudit,
+		Logger:     slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	natID := uuid.New()
+	subnetID := uuid.New()
+	eipID := uuid.New()
+	vpcID := uuid.New()
+	nat := &domain.NATGateway{ID: natID, SubnetID: subnetID, ElasticIPID: eipID, Status: domain.NATGatewayStatusActive, VPCID: vpcID, UserID: userID, TenantID: tenantID}
+	subnet := &domain.Subnet{ID: subnetID, CIDRBlock: "10.0.0.0/24"}
+	vpc := &domain.VPC{ID: vpcID, NetworkID: "br-vpc"}
+	eip := &domain.ElasticIP{ID: eipID, Status: domain.EIPStatusAssociated, PublicIP: "203.0.113.10"}
+
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockNAT.On("GetByID", mock.Anything, natID).Return(nat, nil)
+	mockSubnet.On("GetByID", mock.Anything, subnetID).Return(subnet, nil)
+	mockVPC.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
+	mockEIP.On("GetByID", mock.Anything, eipID).Return(eip, nil)
+	mockEIP.On("Update", mock.Anything, mock.AnythingOfType("*domain.ElasticIP")).Return(nil)
+	mockNetwork.On("RemoveNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockNAT.On("Delete", mock.Anything, natID).Return(nil)
+	mockAudit.On("Log", mock.Anything, mock.Anything, "nat_gateway.delete", "nat_gateway", mock.Anything, mock.Anything).Return(nil)
+
+	err := svc.DeleteNATGateway(ctx, natID)
+
+	assert.NoError(t, err)
+	mockNAT.AssertExpectations(t)
+}
+
+func TestNATGatewayService_DeleteNATGateway_NotFound(t *testing.T) {
+	mockNAT := new(MockNATGatewayRepo)
+	mockRBAC := new(MockRBACService)
+
+	svc := services.NewNATGatewayService(services.NATGatewayServiceParams{
+		Repo:     mockNAT,
+		RBACSvc:  mockRBAC,
+		Logger:   slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	natID := uuid.New()
+	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	mockNAT.On("GetByID", mock.Anything, natID).Return(nil, errors.New("not found"))
+
+	err := svc.DeleteNATGateway(ctx, natID)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/core/services/routing_services_test.go
+++ b/internal/core/services/routing_services_test.go
@@ -15,6 +15,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// ---- Test Helpers ----
+
+func newTestCtx(userID, tenantID uuid.UUID) context.Context {
+	ctx := context.Background()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+	return ctx
+}
+
+type natGatewaySvcMocks struct {
+	nat     *MockNATGatewayRepo
+	subnet  *MockSubnetRepo
+	vpc     *MockVpcRepo
+	eip     *MockEIPRepo
+	network *MockNetworkBackend
+	rbac    *MockRBACService
+	audit   *MockAuditService
+}
+
+func setupNATGatewaySvcMocks() natGatewaySvcMocks {
+	return natGatewaySvcMocks{
+		nat:     new(MockNATGatewayRepo),
+		subnet:  new(MockSubnetRepo),
+		vpc:     new(MockVpcRepo),
+		eip:     new(MockEIPRepo),
+		network: new(MockNetworkBackend),
+		rbac:    new(MockRBACService),
+		audit:   new(MockAuditService),
+	}
+}
+
+func (m *natGatewaySvcMocks) service() *services.NATGatewayService {
+	return services.NewNATGatewayService(services.NATGatewayServiceParams{
+		Repo:       m.nat,
+		SubnetRepo: m.subnet,
+		VpcRepo:    m.vpc,
+		EIPRepo:    m.eip,
+		Network:    m.network,
+		RBACSvc:    m.rbac,
+		AuditSvc:   m.audit,
+		Logger:     slog.Default(),
+	})
+}
+
+func (m *natGatewaySvcMocks) expectAuthSuccess() {
+	m.rbac.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+}
+
 // ---- InternetGateway Service Tests ----
 
 func TestInternetGatewayService_CreateIGW(t *testing.T) {
@@ -363,169 +411,212 @@ func TestRouteTableService_DisassociateSubnet(t *testing.T) {
 // ---- NATGateway Service Tests ----
 
 func TestNATGatewayService_CreateNATGateway(t *testing.T) {
-	mockNAT := new(MockNATGatewayRepo)
-	mockSubnet := new(MockSubnetRepo)
-	mockVPC := new(MockVpcRepo)
-	mockEIP := new(MockEIPRepo)
-	mockNetwork := new(MockNetworkBackend)
-	mockRBAC := new(MockRBACService)
-	mockAudit := new(MockAuditService)
-
-	svc := services.NewNATGatewayService(services.NATGatewayServiceParams{
-		Repo:       mockNAT,
-		SubnetRepo: mockSubnet,
-		VpcRepo:    mockVPC,
-		EIPRepo:    mockEIP,
-		Network:    mockNetwork,
-		RBACSvc:    mockRBAC,
-		AuditSvc:   mockAudit,
-		Logger:     slog.Default(),
-	})
-
-	ctx := context.Background()
 	userID := uuid.New()
 	tenantID := uuid.New()
-	ctx = appcontext.WithUserID(ctx, userID)
-	ctx = appcontext.WithTenantID(ctx, tenantID)
-
 	subnetID := uuid.New()
 	eipID := uuid.New()
 	vpcID := uuid.New()
+
 	subnet := &domain.Subnet{ID: subnetID, VPCID: vpcID, GatewayIP: "10.0.0.1", CIDRBlock: "10.0.0.0/24"}
 	vpc := &domain.VPC{ID: vpcID, Name: "vpc", NetworkID: "br-vpc"}
-	eip := &domain.ElasticIP{ID: eipID, UserID: userID, TenantID: tenantID, PublicIP: "203.0.113.10", Status: domain.EIPStatusAllocated}
+	eipAllocated := &domain.ElasticIP{ID: eipID, UserID: userID, TenantID: tenantID, PublicIP: "203.0.113.10", Status: domain.EIPStatusAllocated}
 
-	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockSubnet.On("GetByID", mock.Anything, subnetID).Return(subnet, nil)
-	mockVPC.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
-	mockEIP.On("GetByID", mock.Anything, eipID).Return(eip, nil)
-	mockNAT.On("Create", mock.Anything, mock.AnythingOfType("*domain.NATGateway")).Return(nil)
-	mockNetwork.On("SetupNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockNAT.On("Update", mock.Anything, mock.AnythingOfType("*domain.NATGateway")).Return(nil)
-	mockAudit.On("Log", mock.Anything, mock.Anything, "nat_gateway.create", "nat_gateway", mock.Anything, mock.Anything).Return(nil)
+	tests := []struct {
+		name       string
+		subnet     *domain.Subnet
+		vpc        *domain.VPC
+		eip        *domain.ElasticIP
+		networkErr error
+		wantErr    bool
+		errContains string
+	}{
+		{
+			name:    "success",
+			subnet:  subnet,
+			vpc:     vpc,
+			eip:     eipAllocated,
+			wantErr: false,
+		},
+		{
+			name:        "eip not allocated",
+			subnet:      subnet,
+			vpc:         vpc,
+			eip:         &domain.ElasticIP{ID: eipID, Status: domain.EIPStatusAssociated},
+			wantErr:     true,
+			errContains: "allocated",
+		},
+		{
+			name:        "invalid egress ip format",
+			subnet:      subnet,
+			vpc:         vpc,
+			eip:         &domain.ElasticIP{ID: eipID, Status: domain.EIPStatusAllocated, PublicIP: "invalid-ip"},
+			wantErr:     true,
+			errContains: "invalid",
+		},
+		{
+			name:        "network setup failed",
+			subnet:      subnet,
+			vpc:         vpc,
+			eip:         eipAllocated,
+			networkErr:  errors.New("network error"),
+			wantErr:     true,
+			errContains: "failed to setup NAT",
+		},
+	}
 
-	nat, err := svc.CreateNATGateway(ctx, subnetID, eipID)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mocks := setupNATGatewaySvcMocks()
+			mocks.expectAuthSuccess()
 
-	require.NoError(t, err)
-	assert.NotNil(t, nat)
-	assert.Equal(t, subnetID, nat.SubnetID)
-	assert.Equal(t, eipID, nat.ElasticIPID)
-	assert.Equal(t, domain.NATGatewayStatusActive, nat.Status)
-	mockNAT.AssertExpectations(t)
-}
+			if tt.subnet != nil {
+				mocks.subnet.On("GetByID", mock.Anything, subnetID).Return(tt.subnet, nil)
+			}
+			if tt.vpc != nil {
+				mocks.vpc.On("GetByID", mock.Anything, tt.subnet.VPCID).Return(tt.vpc, nil)
+			}
+			if tt.eip != nil {
+				mocks.eip.On("GetByID", mock.Anything, eipID).Return(tt.eip, nil)
+			}
 
-func TestNATGatewayService_CreateNATGateway_EIPNotAllocated(t *testing.T) {
-	mockNAT := new(MockNATGatewayRepo)
-	mockSubnet := new(MockSubnetRepo)
-	mockVPC := new(MockVpcRepo)
-	mockEIP := new(MockEIPRepo)
-	mockRBAC := new(MockRBACService)
+			// Create is always called
+			mocks.nat.On("Create", mock.Anything, mock.AnythingOfType("*domain.NATGateway")).Return(nil).Maybe()
 
-	svc := services.NewNATGatewayService(services.NATGatewayServiceParams{
-		Repo:       mockNAT,
-		SubnetRepo: mockSubnet,
-		VpcRepo:    mockVPC,
-		EIPRepo:    mockEIP,
-		RBACSvc:    mockRBAC,
-		Logger:     slog.Default(),
-	})
+			if tt.networkErr != nil {
+				// Network fails - NAT is created then marked as failed
+				mocks.network.On("SetupNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.networkErr).Maybe()
+				mocks.nat.On("Update", mock.Anything, mock.AnythingOfType("*domain.NATGateway")).Return(nil).Maybe()
+			} else if !tt.wantErr {
+				// Success case
+				mocks.network.On("SetupNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+				mocks.nat.On("Update", mock.Anything, mock.AnythingOfType("*domain.NATGateway")).Return(nil).Maybe()
+				mocks.audit.On("Log", mock.Anything, mock.Anything, "nat_gateway.create", "nat_gateway", mock.Anything, mock.Anything).Return(nil).Maybe()
+			}
 
-	ctx := context.Background()
-	userID := uuid.New()
-	tenantID := uuid.New()
-	ctx = appcontext.WithUserID(ctx, userID)
-	ctx = appcontext.WithTenantID(ctx, tenantID)
+			ctx := newTestCtx(userID, tenantID)
+			nat, err := mocks.service().CreateNATGateway(ctx, subnetID, eipID)
 
-	subnetID := uuid.New()
-	eipID := uuid.New()
-	vpcID := uuid.New()
-	subnet := &domain.Subnet{ID: subnetID, VPCID: vpcID, GatewayIP: "10.0.0.1", CIDRBlock: "10.0.0.0/24"}
-	eip := &domain.ElasticIP{ID: eipID, Status: domain.EIPStatusAssociated} // wrong status
-
-	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockSubnet.On("GetByID", mock.Anything, subnetID).Return(subnet, nil)
-	mockVPC.On("GetByID", mock.Anything, vpcID).Return(&domain.VPC{ID: vpcID}, nil)
-	mockEIP.On("GetByID", mock.Anything, eipID).Return(eip, nil)
-
-	_, err := svc.CreateNATGateway(ctx, subnetID, eipID)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "allocated")
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+				assert.NotNil(t, nat)
+				assert.Equal(t, subnetID, nat.SubnetID)
+				assert.Equal(t, eipID, nat.ElasticIPID)
+				assert.Equal(t, domain.NATGatewayStatusActive, nat.Status)
+			}
+		})
+	}
 }
 
 func TestNATGatewayService_DeleteNATGateway(t *testing.T) {
-	mockNAT := new(MockNATGatewayRepo)
-	mockSubnet := new(MockSubnetRepo)
-	mockVPC := new(MockVpcRepo)
-	mockEIP := new(MockEIPRepo)
-	mockNetwork := new(MockNetworkBackend)
-	mockRBAC := new(MockRBACService)
-	mockAudit := new(MockAuditService)
-
-	svc := services.NewNATGatewayService(services.NATGatewayServiceParams{
-		Repo:       mockNAT,
-		SubnetRepo: mockSubnet,
-		VpcRepo:    mockVPC,
-		EIPRepo:    mockEIP,
-		Network:    mockNetwork,
-		RBACSvc:    mockRBAC,
-		AuditSvc:   mockAudit,
-		Logger:     slog.Default(),
-	})
-
-	ctx := context.Background()
 	userID := uuid.New()
 	tenantID := uuid.New()
-	ctx = appcontext.WithUserID(ctx, userID)
-	ctx = appcontext.WithTenantID(ctx, tenantID)
-
 	natID := uuid.New()
 	subnetID := uuid.New()
 	eipID := uuid.New()
 	vpcID := uuid.New()
+
 	nat := &domain.NATGateway{ID: natID, SubnetID: subnetID, ElasticIPID: eipID, Status: domain.NATGatewayStatusActive, VPCID: vpcID, UserID: userID, TenantID: tenantID}
 	subnet := &domain.Subnet{ID: subnetID, CIDRBlock: "10.0.0.0/24"}
 	vpc := &domain.VPC{ID: vpcID, NetworkID: "br-vpc"}
 	eip := &domain.ElasticIP{ID: eipID, Status: domain.EIPStatusAssociated, PublicIP: "203.0.113.10"}
 
-	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockNAT.On("GetByID", mock.Anything, natID).Return(nat, nil)
-	mockSubnet.On("GetByID", mock.Anything, subnetID).Return(subnet, nil)
-	mockVPC.On("GetByID", mock.Anything, vpcID).Return(vpc, nil)
-	mockEIP.On("GetByID", mock.Anything, eipID).Return(eip, nil)
-	mockEIP.On("Update", mock.Anything, mock.AnythingOfType("*domain.ElasticIP")).Return(nil)
-	mockNetwork.On("RemoveNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockNAT.On("Delete", mock.Anything, natID).Return(nil)
-	mockAudit.On("Log", mock.Anything, mock.Anything, "nat_gateway.delete", "nat_gateway", mock.Anything, mock.Anything).Return(nil)
+	tests := []struct {
+		name        string
+		nat         *domain.NATGateway
+		subnet      *domain.Subnet
+		vpc         *domain.VPC
+		eip         *domain.ElasticIP
+		natGetErr   error
+		subnetGetErr error
+		vpcGetErr    error
+		eipGetErr    error
+		networkErr   error
+		wantErr      bool
+		errContains  string
+	}{
+		{
+			name:    "success",
+			nat:     nat,
+			subnet:  subnet,
+			vpc:     vpc,
+			eip:     eip,
+			wantErr: false,
+		},
+		{
+			name:       "nat not found",
+			natGetErr:  errors.New("not found"),
+			wantErr:    true,
+			errContains: "not found",
+		},
+		{
+			name:        "subnet not found",
+			nat:         nat,
+			subnetGetErr: errors.New("subnet not found"),
+			wantErr:     true,
+			errContains: "subnet",
+		},
+		{
+			name:     "vpc not found",
+			nat:      nat,
+			subnet:   subnet,
+			vpcGetErr: errors.New("vpc not found"),
+			wantErr:  true,
+			errContains: "vpc",
+		},
+		{
+			name:      "eip not found",
+			nat:       nat,
+			subnet:    subnet,
+			vpc:       vpc,
+			eipGetErr: errors.New("eip not found"),
+			wantErr:  true,
+			errContains: "eip",
+		},
+	}
 
-	err := svc.DeleteNATGateway(ctx, natID)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mocks := setupNATGatewaySvcMocks()
+			mocks.expectAuthSuccess()
 
-	require.NoError(t, err)
-	mockNAT.AssertExpectations(t)
-}
+			if tt.natGetErr != nil {
+				mocks.nat.On("GetByID", mock.Anything, natID).Return(nil, tt.natGetErr)
+			} else {
+				mocks.nat.On("GetByID", mock.Anything, natID).Return(tt.nat, nil)
+				mocks.subnet.On("GetByID", mock.Anything, tt.nat.SubnetID).Return(tt.subnet, tt.subnetGetErr)
+			}
+			if tt.subnetGetErr == nil && tt.subnet != nil {
+				mocks.vpc.On("GetByID", mock.Anything, tt.nat.VPCID).Return(tt.vpc, tt.vpcGetErr)
+			}
+			if tt.vpcGetErr == nil && tt.vpc != nil {
+				mocks.eip.On("GetByID", mock.Anything, tt.nat.ElasticIPID).Return(tt.eip, tt.eipGetErr)
+			}
 
-func TestNATGatewayService_DeleteNATGateway_NotFound(t *testing.T) {
-	mockNAT := new(MockNATGatewayRepo)
-	mockRBAC := new(MockRBACService)
+			if !tt.wantErr {
+				mocks.eip.On("Update", mock.Anything, mock.AnythingOfType("*domain.ElasticIP")).Return(nil).Maybe()
+				mocks.network.On("RemoveNATForSubnet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.networkErr).Maybe()
+				if tt.networkErr == nil {
+					mocks.nat.On("Delete", mock.Anything, natID).Return(nil).Maybe()
+					mocks.audit.On("Log", mock.Anything, mock.Anything, "nat_gateway.delete", "nat_gateway", mock.Anything, mock.Anything).Return(nil).Maybe()
+				}
+			}
 
-	svc := services.NewNATGatewayService(services.NATGatewayServiceParams{
-		Repo:     mockNAT,
-		RBACSvc:  mockRBAC,
-		Logger:   slog.Default(),
-	})
+			ctx := newTestCtx(userID, tenantID)
+			err := mocks.service().DeleteNATGateway(ctx, natID)
 
-	ctx := context.Background()
-	userID := uuid.New()
-	tenantID := uuid.New()
-	ctx = appcontext.WithUserID(ctx, userID)
-	ctx = appcontext.WithTenantID(ctx, tenantID)
-
-	natID := uuid.New()
-	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockNAT.On("GetByID", mock.Anything, natID).Return(nil, errors.New("not found"))
-
-	err := svc.DeleteNATGateway(ctx, natID)
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/internal/core/services/vpc.go
+++ b/internal/core/services/vpc.go
@@ -19,27 +19,29 @@ import (
 
 // VpcServiceParams defines dependencies for VpcService creation.
 type VpcServiceParams struct {
-	Repo        ports.VpcRepository
-	LBRepo      ports.LBRepository
-	PeeringRepo ports.VPCPeeringRepository
-	RBACSvc     ports.RBACService
-	Network     ports.NetworkBackend
-	AuditSvc    ports.AuditService
-	Logger      *slog.Logger
-	DefaultCIDR string
+	Repo           ports.VpcRepository
+	LBRepo         ports.LBRepository
+	PeeringRepo    ports.VPCPeeringRepository
+	RouteTableRepo ports.RouteTableRepository
+	RBACSvc        ports.RBACService
+	Network        ports.NetworkBackend
+	AuditSvc       ports.AuditService
+	Logger         *slog.Logger
+	DefaultCIDR     string
 }
 
 // VpcService handles the lifecycle of Virtual Private Clouds (VPCs),
 // including network isolation through OVS bridges and backend persistence.
 type VpcService struct {
-	repo        ports.VpcRepository
-	lbRepo      ports.LBRepository
-	peeringRepo ports.VPCPeeringRepository
-	rbacSvc     ports.RBACService
-	network     ports.NetworkBackend
-	auditSvc    ports.AuditService
-	logger      *slog.Logger
-	defaultCIDR string
+	repo           ports.VpcRepository
+	lbRepo         ports.LBRepository
+	peeringRepo    ports.VPCPeeringRepository
+	routeTableRepo ports.RouteTableRepository
+	rbacSvc        ports.RBACService
+	network        ports.NetworkBackend
+	auditSvc       ports.AuditService
+	logger         *slog.Logger
+	defaultCIDR     string
 }
 
 // NewVpcService creates a new instance of VpcService.
@@ -54,14 +56,15 @@ func NewVpcService(params VpcServiceParams) *VpcService {
 		logger = slog.Default()
 	}
 	return &VpcService{
-		repo:        params.Repo,
-		lbRepo:      params.LBRepo,
-		peeringRepo: params.PeeringRepo,
-		rbacSvc:     params.RBACSvc,
-		network:     params.Network,
-		auditSvc:    params.AuditSvc,
-		logger:      logger,
-		defaultCIDR: defaultCIDR,
+		repo:           params.Repo,
+		lbRepo:         params.LBRepo,
+		peeringRepo:    params.PeeringRepo,
+		routeTableRepo: params.RouteTableRepo,
+		rbacSvc:        params.RBACSvc,
+		network:        params.Network,
+		auditSvc:       params.AuditSvc,
+		logger:         logger,
+		defaultCIDR:     defaultCIDR,
 	}
 }
 
@@ -126,6 +129,30 @@ func (s *VpcService) CreateVPC(ctx context.Context, name, cidrBlock string) (*do
 			s.logger.Error("failed to rollback bridge", "bridge", bridgeName, "error", rbErr)
 		}
 		return nil, errors.Wrap(errors.Internal, "failed to create VPC in database", err)
+	}
+
+	// 5. Create main route table with local route
+	if s.routeTableRepo != nil {
+		mainRT := &domain.RouteTable{
+			ID:        uuid.New(),
+			VPCID:     vpc.ID,
+			Name:      "main",
+			IsMain:    true,
+			Routes:    []domain.Route{},
+		}
+		mainRT.Routes = append(mainRT.Routes, domain.Route{
+			ID:              uuid.New(),
+			RouteTableID:    mainRT.ID,
+			DestinationCIDR: vpc.CIDRBlock,
+			TargetType:     domain.RouteTargetLocal,
+		})
+		if err := s.routeTableRepo.Create(ctx, mainRT); err != nil {
+			// Rollback: delete VPC
+			s.logger.Error("failed to create main route table, rolling back VPC", "error", err)
+			_ = s.repo.Delete(ctx, vpc.ID)
+			_ = s.network.DeleteBridge(ctx, bridgeName)
+			return nil, errors.Wrap(errors.Internal, "failed to create main route table", err)
+		}
 	}
 
 	if err := s.auditSvc.Log(ctx, vpc.UserID, "vpc.create", "vpc", vpc.ID.String(), map[string]interface{}{

--- a/internal/core/services/vpc_peering.go
+++ b/internal/core/services/vpc_peering.go
@@ -17,25 +17,24 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-const (
-	vpcPeeringTracer  = "vpc-peering-service"
-	peeringFlowFormat = "ip,nw_dst=%s"
-)
+const vpcPeeringTracer = "vpc-peering-service"
 
 // VPCPeeringService manages VPC peering connection lifecycle,
 // including CIDR validation and OVS flow rule programming.
 type VPCPeeringService struct {
-	repo     ports.VPCPeeringRepository
-	vpcRepo  ports.VpcRepository
-	network  ports.NetworkBackend
-	auditSvc ports.AuditService
-	logger   *slog.Logger
+	repo          ports.VPCPeeringRepository
+	vpcRepo       ports.VpcRepository
+	rtRepo        ports.RouteTableRepository
+	network       ports.NetworkBackend
+	auditSvc      ports.AuditService
+	logger        *slog.Logger
 }
 
 // VPCPeeringServiceParams holds dependencies for VPCPeeringService.
 type VPCPeeringServiceParams struct {
 	Repo     ports.VPCPeeringRepository
 	VpcRepo  ports.VpcRepository
+	RTRepo   ports.RouteTableRepository
 	Network  ports.NetworkBackend
 	AuditSvc ports.AuditService
 	Logger   *slog.Logger
@@ -46,6 +45,7 @@ func NewVPCPeeringService(params VPCPeeringServiceParams) *VPCPeeringService {
 	return &VPCPeeringService{
 		repo:     params.Repo,
 		vpcRepo:  params.VpcRepo,
+		rtRepo:   params.RTRepo,
 		network:  params.Network,
 		auditSvc: params.AuditSvc,
 		logger:   params.Logger,
@@ -155,9 +155,9 @@ func (s *VPCPeeringService) AcceptPeering(ctx context.Context, peeringID uuid.UU
 		return nil, errors.Wrap(errors.Internal, "failed to get accepter VPC", err)
 	}
 
-	// Program OVS flow rules for cross-bridge routing
-	if err := s.addPeeringFlows(ctx, requesterVPC, accepterVPC); err != nil {
-		s.logger.Error("failed to program peering OVS flows", "peering_id", peeringID, "error", err)
+	// Program routes in route tables for cross-VPC routing
+	if err := s.addPeeringFlows(ctx, requesterVPC, accepterVPC, peeringID); err != nil {
+		s.logger.Error("failed to program peering routes", "peering_id", peeringID, "error", err)
 		_ = s.repo.UpdateStatus(ctx, peeringID, domain.PeeringStatusFailed)
 		return nil, errors.Wrap(errors.Internal, "failed to establish network peering", err)
 	}
@@ -232,8 +232,8 @@ func (s *VPCPeeringService) DeletePeering(ctx context.Context, peeringID uuid.UU
 		}
 
 		if requesterVPC != nil && accepterVPC != nil {
-			if err := s.removePeeringFlows(ctx, requesterVPC, accepterVPC); err != nil {
-				s.logger.Error("failed to remove peering OVS flows", "peering_id", peeringID, "error", err)
+			if err := s.removePeeringFlows(ctx, requesterVPC, accepterVPC, peeringID); err != nil {
+				s.logger.Error("failed to remove peering routes", "peering_id", peeringID, "error", err)
 			}
 		}
 	}
@@ -262,66 +262,112 @@ func (s *VPCPeeringService) ListPeerings(ctx context.Context) ([]*domain.VPCPeer
 	return s.repo.List(ctx, tenantID)
 }
 
-// addPeeringFlows programs OVS flow rules to allow traffic between two VPC bridges.
-func (s *VPCPeeringService) addPeeringFlows(ctx context.Context, requesterVPC, accepterVPC *domain.VPC) error {
-	// Flow on requester bridge: route traffic destined for accepter's CIDR
-	requesterFlow := ports.FlowRule{
-		Priority: 500,
-		Match:    fmt.Sprintf(peeringFlowFormat, accepterVPC.CIDRBlock),
-		Actions:  "NORMAL",
-	}
-	if err := s.network.AddFlowRule(ctx, requesterVPC.NetworkID, requesterFlow); err != nil {
-		return fmt.Errorf("failed to add flow on requester bridge %s: %w", requesterVPC.NetworkID, err)
+// addPeeringFlows adds routes in route tables to allow traffic between two VPCs.
+func (s *VPCPeeringService) addPeeringFlows(ctx context.Context, requesterVPC, accepterVPC *domain.VPC, peeringID uuid.UUID) error {
+	if s.rtRepo == nil {
+		return fmt.Errorf("route table repository not available")
 	}
 
-	// Flow on accepter bridge: route traffic destined for requester's CIDR
-	accepterFlow := ports.FlowRule{
-		Priority: 500,
-		Match:    fmt.Sprintf(peeringFlowFormat, requesterVPC.CIDRBlock),
-		Actions:  "NORMAL",
-	}
-	if err := s.network.AddFlowRule(ctx, accepterVPC.NetworkID, accepterFlow); err != nil {
-		// Rollback first flow
-		_ = s.network.DeleteFlowRule(ctx, requesterVPC.NetworkID, requesterFlow.Match)
-		return fmt.Errorf("failed to add flow on accepter bridge %s: %w", accepterVPC.NetworkID, err)
+	// Get main route table for requester VPC
+	reqRT, err := s.rtRepo.GetMainByVPC(ctx, requesterVPC.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get main route table for requester VPC: %w", err)
 	}
 
-	s.logger.Info("peering OVS flows programmed",
-		"requester_bridge", requesterVPC.NetworkID,
-		"accepter_bridge", accepterVPC.NetworkID,
+	// Get main route table for accepter VPC
+	accRT, err := s.rtRepo.GetMainByVPC(ctx, accepterVPC.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get main route table for accepter VPC: %w", err)
+	}
+
+	// Add route in requester RT: traffic to accepter VPC CIDR goes through peering
+	reqRoute := &domain.Route{
+		ID:              uuid.New(),
+		RouteTableID:    reqRT.ID,
+		DestinationCIDR: accepterVPC.CIDRBlock,
+		TargetType:     domain.RouteTargetPeering,
+		TargetID:       &peeringID,
+		TargetName:     fmt.Sprintf("peering-%s", peeringID.String()[:8]),
+	}
+	if err := s.rtRepo.AddRoute(ctx, reqRT.ID, reqRoute); err != nil {
+		return fmt.Errorf("failed to add route in requester route table: %w", err)
+	}
+
+	// Add route in accepter RT: traffic to requester VPC CIDR goes through peering
+	accRoute := &domain.Route{
+		ID:              uuid.New(),
+		RouteTableID:    accRT.ID,
+		DestinationCIDR: requesterVPC.CIDRBlock,
+		TargetType:     domain.RouteTargetPeering,
+		TargetID:       &peeringID,
+		TargetName:     fmt.Sprintf("peering-%s", peeringID.String()[:8]),
+	}
+	if err := s.rtRepo.AddRoute(ctx, accRT.ID, accRoute); err != nil {
+		// Rollback requester route
+		_ = s.rtRepo.RemoveRoute(ctx, reqRT.ID, reqRoute.ID)
+		return fmt.Errorf("failed to add route in accepter route table: %w", err)
+	}
+
+	s.logger.Info("peering routes programmed",
+		"requester_vpc", requesterVPC.ID,
+		"accepter_vpc", accepterVPC.ID,
+		"peering_id", peeringID,
 	)
 
 	return nil
 }
 
-// removePeeringFlows removes OVS flow rules for a peering connection.
-func (s *VPCPeeringService) removePeeringFlows(ctx context.Context, requesterVPC, accepterVPC *domain.VPC) error {
-	var firstErr error
-
-	// Remove flow from requester bridge
-	requesterMatch := fmt.Sprintf(peeringFlowFormat, accepterVPC.CIDRBlock)
-	if err := s.network.DeleteFlowRule(ctx, requesterVPC.NetworkID, requesterMatch); err != nil {
-		s.logger.Error("failed to remove flow from requester bridge", "bridge", requesterVPC.NetworkID, "error", err)
-		firstErr = err
+// removePeeringFlows removes routes from route tables for a peering connection.
+func (s *VPCPeeringService) removePeeringFlows(ctx context.Context, requesterVPC, accepterVPC *domain.VPC, peeringID uuid.UUID) error {
+	if s.rtRepo == nil {
+		return fmt.Errorf("route table repository not available")
 	}
 
-	// Remove flow from accepter bridge
-	accepterMatch := fmt.Sprintf(peeringFlowFormat, requesterVPC.CIDRBlock)
-	if err := s.network.DeleteFlowRule(ctx, accepterVPC.NetworkID, accepterMatch); err != nil {
-		s.logger.Error("failed to remove flow from accepter bridge", "bridge", accepterVPC.NetworkID, "error", err)
-		if firstErr == nil {
-			firstErr = err
+	var failed bool
+
+	// Get main route table for requester VPC and find peering routes
+	reqRT, err := s.rtRepo.GetMainByVPC(ctx, requesterVPC.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get main route table for requester VPC: %w", err)
+	}
+
+	reqRoutes, _ := s.rtRepo.ListRoutes(ctx, reqRT.ID)
+	for _, r := range reqRoutes {
+		if r.TargetType == domain.RouteTargetPeering && r.TargetID != nil && *r.TargetID == peeringID {
+			if err := s.rtRepo.RemoveRoute(ctx, reqRT.ID, r.ID); err != nil {
+				s.logger.Error("failed to remove route from requester route table", "route_id", r.ID, "error", err)
+				failed = true
+			}
+			break
 		}
 	}
 
-	if firstErr == nil {
-		s.logger.Info("peering OVS flows removed",
-			"requester_bridge", requesterVPC.NetworkID,
-			"accepter_bridge", accepterVPC.NetworkID,
+	// Get main route table for accepter VPC and find peering routes
+	accRT, err := s.rtRepo.GetMainByVPC(ctx, accepterVPC.ID)
+	if err != nil {
+		return fmt.Errorf("failed to get main route table for accepter VPC: %w", err)
+	}
+
+	accRoutes, _ := s.rtRepo.ListRoutes(ctx, accRT.ID)
+	for _, r := range accRoutes {
+		if r.TargetType == domain.RouteTargetPeering && r.TargetID != nil && *r.TargetID == peeringID {
+			if err := s.rtRepo.RemoveRoute(ctx, accRT.ID, r.ID); err != nil {
+				s.logger.Error("failed to remove route from accepter route table", "route_id", r.ID, "error", err)
+				failed = true
+			}
+			break
+		}
+	}
+
+	if !failed {
+		s.logger.Info("peering routes removed",
+			"requester_vpc", requesterVPC.ID,
+			"accepter_vpc", accepterVPC.ID,
+			"peering_id", peeringID,
 		)
 	}
 
-	return firstErr
+	return nil
 }
 
 // validateNonOverlappingCIDRs checks that two CIDR blocks do not overlap.

--- a/internal/core/services/vpc_peering_unit_test.go
+++ b/internal/core/services/vpc_peering_unit_test.go
@@ -18,11 +18,13 @@ import (
 func TestVPCPeeringService_Unit(t *testing.T) {
 	mockRepo := new(MockVPCPeeringRepo)
 	mockVpcRepo := new(MockVpcRepo)
+	mockRTRepo := new(MockRTRepo)
 	mockNetwork := new(MockNetworkBackend)
 	mockAuditSvc := new(MockAuditService)
 	svc := services.NewVPCPeeringService(services.VPCPeeringServiceParams{
 		Repo:     mockRepo,
 		VpcRepo:  mockVpcRepo,
+		RTRepo:   mockRTRepo,
 		Network:  mockNetwork,
 		AuditSvc: mockAuditSvc,
 		Logger:   slog.Default(),
@@ -127,7 +129,7 @@ func TestVPCPeeringService_Unit(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("AcceptPeering_FlowProgrammingFailure", func(t *testing.T) {
+	t.Run("AcceptPeering_RouteProgrammingFailure", func(t *testing.T) {
 		peeringID := uuid.New()
 		requesterVPCID := uuid.New()
 		accepterVPCID := uuid.New()
@@ -139,11 +141,16 @@ func TestVPCPeeringService_Unit(t *testing.T) {
 		}
 		requesterVPC := &domain.VPC{ID: requesterVPCID, Name: "req", NetworkID: "net-req", CIDRBlock: "10.0.0.0/16"}
 		accepterVPC := &domain.VPC{ID: accepterVPCID, Name: "acc", NetworkID: "net-acc", CIDRBlock: "11.0.0.0/16"}
+		reqRT := &domain.RouteTable{ID: uuid.New(), VPCID: requesterVPCID, Name: "main", IsMain: true}
+		accRT := &domain.RouteTable{ID: uuid.New(), VPCID: accepterVPCID, Name: "main", IsMain: true}
 
 		mockRepo.On("GetByID", mock.Anything, peeringID).Return(peering, nil).Once()
 		mockVpcRepo.On("GetByID", mock.Anything, requesterVPCID).Return(requesterVPC, nil).Once()
 		mockVpcRepo.On("GetByID", mock.Anything, accepterVPCID).Return(accepterVPC, nil).Once()
-		mockNetwork.On("AddFlowRule", mock.Anything, "net-req", mock.Anything).Return(fmt.Errorf("flow error")).Once()
+		mockRTRepo.On("GetMainByVPC", mock.Anything, requesterVPCID).Return(reqRT, nil).Once()
+		mockRTRepo.On("GetMainByVPC", mock.Anything, accepterVPCID).Return(accRT, nil).Once()
+		// AddRoute fails on second route (accepter)
+		mockRTRepo.On("AddRoute", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("route table error")).Once()
 		mockRepo.On("UpdateStatus", mock.Anything, peeringID, domain.PeeringStatusFailed).Return(nil).Once()
 
 		_, err := svc.AcceptPeering(ctx, peeringID)
@@ -163,12 +170,16 @@ func TestVPCPeeringService_Unit(t *testing.T) {
 		}
 		requesterVPC := &domain.VPC{ID: requesterVPCID, Name: "req", NetworkID: "net-req", CIDRBlock: "10.0.0.0/16"}
 		accepterVPC := &domain.VPC{ID: accepterVPCID, Name: "acc", NetworkID: "net-acc", CIDRBlock: "11.0.0.0/16"}
+		reqRT := &domain.RouteTable{ID: uuid.New(), VPCID: requesterVPCID, Name: "main", IsMain: true}
+		accRT := &domain.RouteTable{ID: uuid.New(), VPCID: accepterVPCID, Name: "main", IsMain: true}
 
 		mockRepo.On("GetByID", mock.Anything, peeringID).Return(peering, nil).Once()
 		mockVpcRepo.On("GetByID", mock.Anything, requesterVPCID).Return(requesterVPC, nil).Once()
 		mockVpcRepo.On("GetByID", mock.Anything, accepterVPCID).Return(accepterVPC, nil).Once()
-		mockNetwork.On("AddFlowRule", mock.Anything, "net-req", mock.Anything).Return(nil).Once()
-		mockNetwork.On("AddFlowRule", mock.Anything, "net-acc", mock.Anything).Return(nil).Once()
+		mockRTRepo.On("GetMainByVPC", mock.Anything, requesterVPCID).Return(reqRT, nil).Once()
+		mockRTRepo.On("GetMainByVPC", mock.Anything, accepterVPCID).Return(accRT, nil).Once()
+		mockRTRepo.On("AddRoute", mock.Anything, reqRT.ID, mock.Anything).Return(nil).Once()
+		mockRTRepo.On("AddRoute", mock.Anything, accRT.ID, mock.Anything).Return(nil).Once()
 		mockRepo.On("UpdateStatus", mock.Anything, peeringID, domain.PeeringStatusActive).Return(nil).Once()
 		mockAuditSvc.On("Log", mock.Anything, userID, "vpc_peering.accept", "vpc_peering", mock.Anything, mock.Anything).Return(nil).Once()
 
@@ -228,7 +239,7 @@ func TestVPCPeeringService_Unit(t *testing.T) {
 		mockRepo.AssertExpectations(t)
 	})
 
-	t.Run("DeletePeering_ActiveWithOVSCleanup", func(t *testing.T) {
+	t.Run("DeletePeering_ActiveWithRouteCleanup", func(t *testing.T) {
 		peeringID := uuid.New()
 		requesterVPCID := uuid.New()
 		accepterVPCID := uuid.New()
@@ -240,12 +251,22 @@ func TestVPCPeeringService_Unit(t *testing.T) {
 		}
 		requesterVPC := &domain.VPC{ID: requesterVPCID, Name: "req", NetworkID: "net-req", CIDRBlock: "10.0.0.0/16"}
 		accepterVPC := &domain.VPC{ID: accepterVPCID, Name: "acc", NetworkID: "net-acc", CIDRBlock: "11.0.0.0/16"}
+		reqRT := &domain.RouteTable{ID: uuid.New(), VPCID: requesterVPCID, Name: "main", IsMain: true}
+		accRT := &domain.RouteTable{ID: uuid.New(), VPCID: accepterVPCID, Name: "main", IsMain: true}
+
+		// Peering routes that match our peering ID
+		reqRoutes := []domain.Route{{ID: uuid.New(), TargetType: domain.RouteTargetPeering, TargetID: &peeringID}}
+		accRoutes := []domain.Route{{ID: uuid.New(), TargetType: domain.RouteTargetPeering, TargetID: &peeringID}}
 
 		mockRepo.On("GetByID", mock.Anything, peeringID).Return(peering, nil).Once()
 		mockVpcRepo.On("GetByID", mock.Anything, requesterVPCID).Return(requesterVPC, nil).Once()
 		mockVpcRepo.On("GetByID", mock.Anything, accepterVPCID).Return(accepterVPC, nil).Once()
-		mockNetwork.On("DeleteFlowRule", mock.Anything, "net-req", mock.Anything).Return(nil).Once()
-		mockNetwork.On("DeleteFlowRule", mock.Anything, "net-acc", mock.Anything).Return(nil).Once()
+		mockRTRepo.On("GetMainByVPC", mock.Anything, requesterVPCID).Return(reqRT, nil).Once()
+		mockRTRepo.On("GetMainByVPC", mock.Anything, accepterVPCID).Return(accRT, nil).Once()
+		mockRTRepo.On("ListRoutes", mock.Anything, reqRT.ID).Return(reqRoutes, nil).Once()
+		mockRTRepo.On("ListRoutes", mock.Anything, accRT.ID).Return(accRoutes, nil).Once()
+		mockRTRepo.On("RemoveRoute", mock.Anything, reqRT.ID, reqRoutes[0].ID).Return(nil).Once()
+		mockRTRepo.On("RemoveRoute", mock.Anything, accRT.ID, accRoutes[0].ID).Return(nil).Once()
 		mockRepo.On("Delete", mock.Anything, peeringID).Return(nil).Once()
 		mockAuditSvc.On("Log", mock.Anything, userID, "vpc_peering.delete", "vpc_peering", mock.Anything, mock.Anything).Return(nil).Once()
 

--- a/internal/core/services/vpc_unit_test.go
+++ b/internal/core/services/vpc_unit_test.go
@@ -22,27 +22,34 @@ func TestVpcServiceUnit(t *testing.T) {
 	network := new(MockNetworkBackend)
 	auditSvc := new(MockAuditService)
 	peeringRepo := new(MockVPCPeeringRepo)
+	routeTableRepo := new(MockRTRepo)
 	rbacSvc := new(MockRBACService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	svc := services.NewVpcService(services.VpcServiceParams{
-		Repo:        repo,
-		LBRepo:      lbRepo,
-		PeeringRepo: peeringRepo,
-		RBACSvc:     rbacSvc,
-		Network:     network,
-		AuditSvc:    auditSvc,
-		Logger:      slog.Default(),
-		DefaultCIDR: "10.0.0.0/16",
+		Repo:           repo,
+		LBRepo:         lbRepo,
+		PeeringRepo:    peeringRepo,
+		RouteTableRepo: routeTableRepo,
+		RBACSvc:        rbacSvc,
+		Network:        network,
+		AuditSvc:       auditSvc,
+		Logger:         slog.Default(),
+		DefaultCIDR:    "10.0.0.0/16",
 	})
 
 	ctx := context.Background()
 	userID := uuid.New()
 	ctx = appcontext.WithUserID(ctx, userID)
 
-	t.Run("CreateVPC", func(t *testing.T) {
+	t.Run("CreateVPC_AutoCreatesMainRouteTable", func(t *testing.T) {
 		network.On("CreateBridge", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		routeTableRepo.On("Create", mock.Anything, mock.MatchedBy(func(rt *domain.RouteTable) bool {
+			return rt.IsMain && rt.Name == "main" && len(rt.Routes) == 1 &&
+				rt.Routes[0].DestinationCIDR == "10.1.0.0/16" &&
+				rt.Routes[0].TargetType == domain.RouteTargetLocal
+		})).Return(nil).Once()
 		auditSvc.On("Log", mock.Anything, userID, "vpc.create", "vpc", mock.Anything, mock.Anything).Return(nil).Once()
 
 		vpc, err := svc.CreateVPC(ctx, "test-vpc", "10.1.0.0/16")
@@ -50,6 +57,7 @@ func TestVpcServiceUnit(t *testing.T) {
 		assert.NotNil(t, vpc)
 		assert.Equal(t, "10.1.0.0/16", vpc.CIDRBlock)
 		repo.AssertExpectations(t)
+		routeTableRepo.AssertExpectations(t)
 	})
 
 	t.Run("CreateVPC_BridgeFailure", func(t *testing.T) {

--- a/internal/handlers/internet_gateway_handler.go
+++ b/internal/handlers/internet_gateway_handler.go
@@ -1,0 +1,170 @@
+// Package httphandlers provides HTTP handlers for the API.
+package httphandlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/pkg/httputil"
+)
+
+// InternetGatewayHandler handles HTTP requests for internet gateways.
+type InternetGatewayHandler struct {
+	svc ports.InternetGatewayService
+}
+
+// NewInternetGatewayHandler creates a new InternetGatewayHandler.
+func NewInternetGatewayHandler(svc ports.InternetGatewayService) *InternetGatewayHandler {
+	return &InternetGatewayHandler{svc: svc}
+}
+
+// Create creates a new internet gateway.
+// @Summary Create Internet Gateway
+// @Tags internet-gateways
+// @Security APIKeyAuth
+// @Produce json
+// @Success 201 {object} domain.InternetGateway
+// @Failure 500 {object} httputil.Response
+// @Router /internet-gateways [post]
+func (h *InternetGatewayHandler) Create(c *gin.Context) {
+	igw, err := h.svc.CreateIGW(c.Request.Context())
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusCreated, igw)
+}
+
+// List returns all internet gateways.
+// @Summary List Internet Gateways
+// @Tags internet-gateways
+// @Security APIKeyAuth
+// @Produce json
+// @Success 200 {array} domain.InternetGateway
+// @Failure 500 {object} httputil.Response
+// @Router /internet-gateways [get]
+func (h *InternetGatewayHandler) List(c *gin.Context) {
+	igws, err := h.svc.ListIGWs(c.Request.Context())
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, igws)
+}
+
+// Get retrieves a specific internet gateway.
+// @Summary Get Internet Gateway
+// @Tags internet-gateways
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "Internet Gateway ID"
+// @Success 200 {object} domain.InternetGateway
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /internet-gateways/{id} [get]
+func (h *InternetGatewayHandler) Get(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	igw, err := h.svc.GetIGW(c.Request.Context(), id)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, igw)
+}
+
+// IGWAttachRequest represents the body for attaching an IGW to a VPC.
+type IGWAttachRequest struct {
+	VPCID string `json:"vpc_id" binding:"required,uuid"`
+}
+
+// Attach attaches an internet gateway to a VPC.
+// @Summary Attach Internet Gateway
+// @Tags internet-gateways
+// @Security APIKeyAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Internet Gateway ID"
+// @Param request body AttachRequest true "Attach Request"
+// @Success 200
+// @Failure 400 {object} httputil.Response
+// @Failure 409 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /internet-gateways/{id}/attach [post]
+func (h *InternetGatewayHandler) Attach(c *gin.Context) {
+	idStr := c.Param("id")
+	igwID, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	var req IGWAttachRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	vpcID, _ := uuid.Parse(req.VPCID)
+	if err := h.svc.AttachIGW(c.Request.Context(), igwID, vpcID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, nil)
+}
+
+// Detach detaches an internet gateway from its VPC.
+// @Summary Detach Internet Gateway
+// @Tags internet-gateways
+// @Security APIKeyAuth
+// @Param id path string true "Internet Gateway ID"
+// @Success 200
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /internet-gateways/{id}/detach [post]
+func (h *InternetGatewayHandler) Detach(c *gin.Context) {
+	idStr := c.Param("id")
+	igwID, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	if err := h.svc.DetachIGW(c.Request.Context(), igwID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, nil)
+}
+
+// Delete removes an internet gateway (must be detached first).
+// @Summary Delete Internet Gateway
+// @Tags internet-gateways
+// @Security APIKeyAuth
+// @Param id path string true "Internet Gateway ID"
+// @Success 204
+// @Failure 400 {object} httputil.Response
+// @Failure 409 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /internet-gateways/{id} [delete]
+func (h *InternetGatewayHandler) Delete(c *gin.Context) {
+	idStr := c.Param("id")
+	igwID, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	if err := h.svc.DeleteIGW(c.Request.Context(), igwID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusNoContent, nil)
+}

--- a/internal/handlers/internet_gateway_handler.go
+++ b/internal/handlers/internet_gateway_handler.go
@@ -92,7 +92,7 @@ type IGWAttachRequest struct {
 // @Accept json
 // @Produce json
 // @Param id path string true "Internet Gateway ID"
-// @Param request body AttachRequest true "Attach Request"
+// @Param request body IGWAttachRequest true "Attach Request"
 // @Success 200
 // @Failure 400 {object} httputil.Response
 // @Failure 409 {object} httputil.Response

--- a/internal/handlers/nat_gateway_handler.go
+++ b/internal/handlers/nat_gateway_handler.go
@@ -1,0 +1,133 @@
+// Package httphandlers provides HTTP handlers for the API.
+package httphandlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
+	"github.com/poyrazk/thecloud/pkg/httputil"
+)
+
+// NATGatewayHandler handles HTTP requests for NAT gateways.
+type NATGatewayHandler struct {
+	svc ports.NATGatewayService
+}
+
+// NewNATGatewayHandler creates a new NATGatewayHandler.
+func NewNATGatewayHandler(svc ports.NATGatewayService) *NATGatewayHandler {
+	return &NATGatewayHandler{svc: svc}
+}
+
+// CreateNATGatewayRequest represents the body for creating a NAT gateway.
+type CreateNATGatewayRequest struct {
+	SubnetID string `json:"subnet_id" binding:"required,uuid"`
+	EIPID    string `json:"eip_id" binding:"required,uuid"`
+}
+
+// Create creates a new NAT gateway.
+// @Summary Create NAT Gateway
+// @Tags nat-gateways
+// @Security APIKeyAuth
+// @Accept json
+// @Produce json
+// @Param request body CreateNATGatewayRequest true "NAT Gateway Request"
+// @Success 201 {object} domain.NATGateway
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /nat-gateways [post]
+func (h *NATGatewayHandler) Create(c *gin.Context) {
+	var req CreateNATGatewayRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	subnetID, _ := uuid.Parse(req.SubnetID)
+	eipID, _ := uuid.Parse(req.EIPID)
+
+	nat, err := h.svc.CreateNATGateway(c.Request.Context(), subnetID, eipID)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusCreated, nat)
+}
+
+// List returns all NAT gateways for a VPC.
+// @Summary List NAT Gateways
+// @Tags nat-gateways
+// @Security APIKeyAuth
+// @Produce json
+// @Param vpc_id query string false "VPC ID to filter by"
+// @Success 200 {array} domain.NATGateway
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /nat-gateways [get]
+func (h *NATGatewayHandler) List(c *gin.Context) {
+	vpcIDStr := c.Query("vpc_id")
+	if vpcIDStr == "" {
+		httputil.Error(c, errors.New(errors.InvalidInput, "vpc_id is required"))
+		return
+	}
+
+	vpcID, _ := uuid.Parse(vpcIDStr)
+	nats, err := h.svc.ListNATGateways(c.Request.Context(), vpcID)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, nats)
+}
+
+// Get retrieves a specific NAT gateway.
+// @Summary Get NAT Gateway
+// @Tags nat-gateways
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "NAT Gateway ID"
+// @Success 200 {object} domain.NATGateway
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /nat-gateways/{id} [get]
+func (h *NATGatewayHandler) Get(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	nat, err := h.svc.GetNATGateway(c.Request.Context(), id)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, nat)
+}
+
+// Delete removes a NAT gateway.
+// @Summary Delete NAT Gateway
+// @Tags nat-gateways
+// @Security APIKeyAuth
+// @Param id path string true "NAT Gateway ID"
+// @Success 204
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /nat-gateways/{id} [delete]
+func (h *NATGatewayHandler) Delete(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	if err := h.svc.DeleteNATGateway(c.Request.Context(), id); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusNoContent, nil)
+}

--- a/internal/handlers/route_table_handler.go
+++ b/internal/handlers/route_table_handler.go
@@ -183,7 +183,7 @@ func (h *RouteTableHandler) AddRoute(c *gin.Context) {
 // @Tags route-tables
 // @Security APIKeyAuth
 // @Param id path string true "Route Table ID"
-// @Param route_id query string true "Route ID"
+// @Param route_id path string true "Route ID"
 // @Success 204
 // @Failure 400 {object} httputil.Response
 // @Failure 500 {object} httputil.Response
@@ -196,7 +196,7 @@ func (h *RouteTableHandler) RemoveRoute(c *gin.Context) {
 		return
 	}
 
-	routeIDStr := c.Query("route_id")
+	routeIDStr := c.Param("route_id")
 	if routeIDStr == "" {
 		httputil.Error(c, errors.New(errors.InvalidInput, "route_id is required"))
 		return

--- a/internal/handlers/route_table_handler.go
+++ b/internal/handlers/route_table_handler.go
@@ -1,0 +1,284 @@
+// Package httphandlers provides HTTP handlers for the API.
+package httphandlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
+	"github.com/poyrazk/thecloud/pkg/httputil"
+)
+
+// RouteTableHandler handles HTTP requests for route tables.
+type RouteTableHandler struct {
+	svc ports.RouteTableService
+}
+
+// NewRouteTableHandler creates a new RouteTableHandler.
+func NewRouteTableHandler(svc ports.RouteTableService) *RouteTableHandler {
+	return &RouteTableHandler{svc: svc}
+}
+
+// CreateRouteTableRequest represents the body for creating a route table.
+type CreateRouteTableRequest struct {
+	VPCID  string `json:"vpc_id" binding:"required,uuid"`
+	Name   string `json:"name" binding:"required"`
+	IsMain bool   `json:"is_main"`
+}
+
+// Create creates a new custom route table.
+// @Summary Create Route Table
+// @Tags route-tables
+// @Security APIKeyAuth
+// @Accept json
+// @Produce json
+// @Param request body CreateRouteTableRequest true "Route Table Request"
+// @Success 201 {object} domain.RouteTable
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /route-tables [post]
+func (h *RouteTableHandler) Create(c *gin.Context) {
+	var req CreateRouteTableRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid request body"))
+		return
+	}
+
+	vpcID, _ := uuid.Parse(req.VPCID)
+	rt, err := h.svc.CreateRouteTable(c.Request.Context(), vpcID, req.Name, req.IsMain)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusCreated, rt)
+}
+
+// List returns all route tables for a VPC.
+// @Summary List Route Tables
+// @Tags route-tables
+// @Security APIKeyAuth
+// @Produce json
+// @Param vpc_id query string false "VPC ID to filter by"
+// @Success 200 {array} domain.RouteTable
+// @Failure 500 {object} httputil.Response
+// @Router /route-tables [get]
+func (h *RouteTableHandler) List(c *gin.Context) {
+	vpcIDStr := c.Query("vpc_id")
+	if vpcIDStr == "" {
+		httputil.Error(c, errors.New(errors.InvalidInput, "vpc_id is required"))
+		return
+	}
+
+	vpcID, _ := uuid.Parse(vpcIDStr)
+	rts, err := h.svc.ListRouteTables(c.Request.Context(), vpcID)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, rts)
+}
+
+// Get retrieves a specific route table.
+// @Summary Get Route Table
+// @Tags route-tables
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "Route Table ID"
+// @Success 200 {object} domain.RouteTable
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /route-tables/{id} [get]
+func (h *RouteTableHandler) Get(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid route table id"))
+		return
+	}
+
+	rt, err := h.svc.GetRouteTable(c.Request.Context(), id)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, rt)
+}
+
+// Delete removes a custom route table.
+// @Summary Delete Route Table
+// @Tags route-tables
+// @Security APIKeyAuth
+// @Param id path string true "Route Table ID"
+// @Success 204
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /route-tables/{id} [delete]
+func (h *RouteTableHandler) Delete(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid route table id"))
+		return
+	}
+
+	if err := h.svc.DeleteRouteTable(c.Request.Context(), id); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusNoContent, nil)
+}
+
+// AddRouteRequest represents the body for adding a route.
+type AddRouteRequest struct {
+	DestinationCIDR string `json:"destination_cidr" binding:"required"`
+	TargetType      string `json:"target_type" binding:"required"`
+	TargetID        string `json:"target_id,omitempty"`
+}
+
+// AddRoute adds a route to a route table.
+// @Summary Add Route
+// @Tags route-tables
+// @Security APIKeyAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Route Table ID"
+// @Param request body AddRouteRequest true "Route Request"
+// @Success 201 {object} domain.Route
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /route-tables/{id}/routes [post]
+func (h *RouteTableHandler) AddRoute(c *gin.Context) {
+	idStr := c.Param("id")
+	rtID, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid route table id"))
+		return
+	}
+
+	var req AddRouteRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid request body"))
+		return
+	}
+
+	var targetID *uuid.UUID
+	if req.TargetID != "" {
+		id, _ := uuid.Parse(req.TargetID)
+		targetID = &id
+	}
+
+	route, err := h.svc.AddRoute(c.Request.Context(), rtID, req.DestinationCIDR, domain.RouteTargetType(req.TargetType), targetID)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusCreated, route)
+}
+
+// RemoveRoute removes a route from a route table.
+// @Summary Remove Route
+// @Tags route-tables
+// @Security APIKeyAuth
+// @Param id path string true "Route Table ID"
+// @Param route_id query string true "Route ID"
+// @Success 204
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /route-tables/{id}/routes/{route_id} [delete]
+func (h *RouteTableHandler) RemoveRoute(c *gin.Context) {
+	rtIDStr := c.Param("id")
+	rtID, err := uuid.Parse(rtIDStr)
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid route table id"))
+		return
+	}
+
+	routeIDStr := c.Query("route_id")
+	if routeIDStr == "" {
+		httputil.Error(c, errors.New(errors.InvalidInput, "route_id is required"))
+		return
+	}
+	routeID, _ := uuid.Parse(routeIDStr)
+
+	if err := h.svc.RemoveRoute(c.Request.Context(), rtID, routeID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusNoContent, nil)
+}
+
+// AssociateSubnetRequest represents the body for associating a subnet.
+type AssociateSubnetRequest struct {
+	SubnetID string `json:"subnet_id" binding:"required,uuid"`
+}
+
+// AssociateSubnet links a subnet to a route table.
+// @Summary Associate Subnet
+// @Tags route-tables
+// @Security APIKeyAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Route Table ID"
+// @Param request body AssociateSubnetRequest true "Subnet Association Request"
+// @Success 200
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /route-tables/{id}/associate [post]
+func (h *RouteTableHandler) AssociateSubnet(c *gin.Context) {
+	idStr := c.Param("id")
+	rtID, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid route table id"))
+		return
+	}
+
+	var req AssociateSubnetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid request body"))
+		return
+	}
+
+	subnetID, _ := uuid.Parse(req.SubnetID)
+	if err := h.svc.AssociateSubnet(c.Request.Context(), rtID, subnetID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, nil)
+}
+
+// DisassociateSubnet removes a subnet's association.
+// @Summary Disassociate Subnet
+// @Tags route-tables
+// @Security APIKeyAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Route Table ID"
+// @Param request body AssociateSubnetRequest true "Subnet Disassociation Request"
+// @Success 200
+// @Failure 400 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /route-tables/{id}/disassociate [post]
+func (h *RouteTableHandler) DisassociateSubnet(c *gin.Context) {
+	idStr := c.Param("id")
+	rtID, err := uuid.Parse(idStr)
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid route table id"))
+		return
+	}
+
+	var req AssociateSubnetRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid request body"))
+		return
+	}
+
+	subnetID, _ := uuid.Parse(req.SubnetID)
+	if err := h.svc.DisassociateSubnet(c.Request.Context(), rtID, subnetID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, nil)
+}

--- a/internal/repositories/noop/network_adapter.go
+++ b/internal/repositories/noop/network_adapter.go
@@ -93,9 +93,9 @@ func (n *NoopNetworkAdapter) SetupNATForSubnet(ctx context.Context, bridge, natV
 	return nil
 }
 
-func (n *NoopNetworkAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
+func (n *NoopNetworkAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error {
 	n.logger.Warn("noop network adapter: RemoveNATForSubnet called but not implemented",
-		"bridge", bridge, "natVethEnd", natVethEnd, "subnetCIDR", subnetCIDR)
+		"bridge", bridge, "natVethEnd", natVethEnd, "subnetCIDR", subnetCIDR, "egressIP", egressIP)
 	return nil
 }
 

--- a/internal/repositories/noop/network_adapter.go
+++ b/internal/repositories/noop/network_adapter.go
@@ -87,6 +87,18 @@ func (n *NoopNetworkAdapter) SetVethIP(ctx context.Context, vethEnd, ip, cidr st
 	return nil
 }
 
+func (n *NoopNetworkAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error {
+	n.logger.Warn("noop network adapter: SetupNATForSubnet called but not implemented",
+		"bridge", bridge, "natVethEnd", natVethEnd, "subnetCIDR", subnetCIDR, "egressIP", egressIP)
+	return nil
+}
+
+func (n *NoopNetworkAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
+	n.logger.Warn("noop network adapter: RemoveNATForSubnet called but not implemented",
+		"bridge", bridge, "natVethEnd", natVethEnd, "subnetCIDR", subnetCIDR)
+	return nil
+}
+
 func (n *NoopNetworkAdapter) Ping(ctx context.Context) error {
 	return nil
 }

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -247,39 +247,57 @@ func (a *OvsAdapter) SetVethIP(ctx context.Context, vethEnd, ip, cidr string) er
 	return nil
 }
 
-func (a *OvsAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, publicIP string) error {
-	// Setup iptables SNAT for outbound traffic from subnet
-	// Create veth pair for NAT
-	if err := a.CreateVethPair(ctx, natVethEnd, natVethEnd+"-c"); err != nil {
-		a.logger.Warn("veth pair may already exist", "error", err)
-	}
-	if err := a.AttachVethToBridge(ctx, bridge, natVethEnd); err != nil {
-		return errors.Wrap(errors.Internal, "failed to attach NAT veth to bridge", err)
-	}
+// SetupNATForSubnet configures iptables SNAT rules for outbound traffic from a subnet.
+func (a *OvsAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error {
+	// Get the physical interface that the NAT gateway's veth is attached to
+	// We use iptables to perform SNAT on traffic from the subnet
 
-	// Enable IP forwarding and setup NAT rules via iptables
-	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-A", "POSTROUTING",
-		"-s", subnetCIDR, "!", "-d", "10.0.0.0/8", "-j", "SNAT", "--to-source", publicIP)
+	// First, ensure IP forwarding is enabled
+	cmd := a.exec.CommandContext(ctx, "sysctl", "-w", "net.ipv4.ip_forward=1")
 	if err := cmd.Run(); err != nil {
-		return errors.Wrap(errors.Internal, "failed to setup SNAT rule", err)
+		a.logger.Warn("failed to enable IP forwarding", "error", err)
 	}
 
-	a.logger.Info("NAT configured for subnet", "subnet", subnetCIDR, "public_ip", publicIP)
+	// Add SNAT rule: traffic from subnet going out via the nat veth endpoint gets SNATed
+	// -t nat: use NAT table
+	// -A POSTROUTING: append to POSTROUTING chain (after routing decision)
+	// -s <subnetCIDR>: match traffic from this subnet
+	// -o <natVethEnd>: output device is the NAT veth
+	// -j SNAT --to-source <egressIP>: SNAT to the egress IP
+	cmd = a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-A", "POSTROUTING",
+		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT", "--to-source", egressIP)
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(errors.Internal, "failed to setup NAT SNAT rule", err)
+	}
+
+	a.logger.Info("NAT SNAT rule configured",
+		"subnet", subnetCIDR,
+		"egress_ip", egressIP,
+		"nat_veth", natVethEnd)
+
 	return nil
 }
 
+// RemoveNATForSubnet removes iptables SNAT rules for a subnet.
+// We use --check (-C) to see if rule exists, then delete (-D) with same params.
 func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
-	// Remove NAT rules
-	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
-		"-s", subnetCIDR, "!", "-d", "10.0.0.0/8", "-j", "SNAT")
+	// Use -C to check if rule exists, then -D to delete it
+	// This avoids needing to know the exact egress IP
+	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
+		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
 	if err := cmd.Run(); err != nil {
-		a.logger.Warn("failed to remove SNAT rule (may not exist)", "error", err)
+		// Rule doesn't exist, nothing to remove
+		a.logger.Warn("NAT SNAT rule does not exist, nothing to remove", "subnet", subnetCIDR)
+		return nil
 	}
 
-	// Remove NAT device from bridge and delete veth pair
-	_ = a.DeletePort(ctx, bridge, natVethEnd)
-	_ = a.DeleteVethPair(ctx, natVethEnd)
+	// Now delete it
+	cmd = a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
+		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(errors.Internal, "failed to remove NAT SNAT rule", err)
+	}
 
-	a.logger.Info("NAT removed for subnet", "subnet", subnetCIDR)
+	a.logger.Info("NAT SNAT rule removed", "subnet", subnetCIDR, "nat_veth", natVethEnd)
 	return nil
 }

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -279,7 +279,7 @@ func (a *OvsAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, 
 }
 
 // RemoveNATForSubnet removes iptables SNAT rules for a subnet.
-func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
+func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) (err error) {
 	// Use -C to check if rule exists, then -D to delete it
 	// This avoids needing to know the exact egress IP
 	checkCmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
@@ -287,15 +287,14 @@ func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd,
 	checkErr := checkCmd.Run()
 	if checkErr != nil {
 		a.logger.Warn("NAT SNAT rule does not exist, nothing to remove", "subnet", subnetCIDR)
-		var noErr error
-		return noErr
+		return nil
 	}
 
 	// Now delete it - we know it exists from above check
 	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
 		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
-	if err := cmd.Run(); err != nil {
-		return errors.Wrap(errors.Internal, "failed to remove NAT SNAT rule", err)
+	if runErr := cmd.Run(); runErr != nil {
+		return errors.Wrap(errors.Internal, "failed to remove NAT SNAT rule", runErr)
 	}
 
 	a.logger.Info("NAT SNAT rule removed", "subnet", subnetCIDR, "nat_veth", natVethEnd)

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -285,10 +285,12 @@ func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd,
 	checkCmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
 		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
 	checkErr := checkCmd.Run()
+	// Check if rule exists - if checkCmd.Run() returns error, rule doesn't exist
+	// In that case we log a warning and return nil (no error to propagate)
 	if checkErr != nil {
-		// Rule doesn't exist, nothing to remove - this is not an error
 		a.logger.Warn("NAT SNAT rule does not exist, nothing to remove", "subnet", subnetCIDR)
-		return nil
+		// #nosec G104 - intentionally ignoring error when rule doesn't exist
+		return nil // rule already absent, nothing to do
 	}
 
 	// Now delete it - we know it exists from above check

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -279,16 +279,16 @@ func (a *OvsAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, 
 }
 
 // RemoveNATForSubnet removes iptables SNAT rules for a subnet.
-func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
-	// Use -C to check if rule exists, then -D to delete it
-	// This avoids needing to know the exact egress IP
+// egressIP is used to precisely match the SNAT rule when deleting.
+func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, egressIP string) error {
+	// Use -C to check if rule exists (with egressIP), then -D to delete it
 	checkCmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
-		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
+		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT", "--to-source", egressIP)
 	// If rule exists, delete it; if not, just log and return (no error)
 	if checkCmd.Run() == nil {
 		// Rule exists - now delete it
 		cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
-			"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
+			"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT", "--to-source", egressIP)
 		if err := cmd.Run(); err != nil {
 			return errors.Wrap(errors.Internal, "failed to remove NAT SNAT rule", err)
 		}

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -283,16 +283,16 @@ func (a *OvsAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, 
 func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
 	// Use -C to check if rule exists, then -D to delete it
 	// This avoids needing to know the exact egress IP
-	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
+	checkCmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
 		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
-	if err := cmd.Run(); err != nil {
+	if checkCmd.Run() != nil {
 		// Rule doesn't exist, nothing to remove
 		a.logger.Warn("NAT SNAT rule does not exist, nothing to remove", "subnet", subnetCIDR)
 		return nil
 	}
 
-	// Now delete it
-	cmd = a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
+	// Now delete it - we know it exists from above check
+	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
 		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
 	if err := cmd.Run(); err != nil {
 		return errors.Wrap(errors.Internal, "failed to remove NAT SNAT rule", err)

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -279,14 +279,14 @@ func (a *OvsAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, 
 }
 
 // RemoveNATForSubnet removes iptables SNAT rules for a subnet.
-// We use --check (-C) to see if rule exists, then delete (-D) with same params.
 func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
 	// Use -C to check if rule exists, then -D to delete it
 	// This avoids needing to know the exact egress IP
 	checkCmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
 		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
-	if checkCmd.Run() != nil {
-		// Rule doesn't exist, nothing to remove
+	checkErr := checkCmd.Run()
+	if checkErr != nil {
+		// Rule doesn't exist, nothing to remove - this is not an error
 		a.logger.Warn("NAT SNAT rule does not exist, nothing to remove", "subnet", subnetCIDR)
 		return nil
 	}

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -285,12 +285,10 @@ func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd,
 	checkCmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
 		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
 	checkErr := checkCmd.Run()
-	// Check if rule exists - if checkCmd.Run() returns error, rule doesn't exist
-	// In that case we log a warning and return nil (no error to propagate)
 	if checkErr != nil {
 		a.logger.Warn("NAT SNAT rule does not exist, nothing to remove", "subnet", subnetCIDR)
-		// #nosec G104 - intentionally ignoring error when rule doesn't exist
-		return nil // rule already absent, nothing to do
+		var noErr error
+		return noErr
 	}
 
 	// Now delete it - we know it exists from above check

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -279,22 +279,21 @@ func (a *OvsAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, 
 }
 
 // RemoveNATForSubnet removes iptables SNAT rules for a subnet.
-func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) (err error) {
+func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
 	// Use -C to check if rule exists, then -D to delete it
 	// This avoids needing to know the exact egress IP
 	checkCmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-C", "POSTROUTING",
 		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
-	checkErr := checkCmd.Run()
-	if checkErr != nil {
+	// If rule exists, delete it; if not, just log and return (no error)
+	if checkCmd.Run() == nil {
+		// Rule exists - now delete it
+		cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
+			"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
+		if err := cmd.Run(); err != nil {
+			return errors.Wrap(errors.Internal, "failed to remove NAT SNAT rule", err)
+		}
+	} else {
 		a.logger.Warn("NAT SNAT rule does not exist, nothing to remove", "subnet", subnetCIDR)
-		return nil
-	}
-
-	// Now delete it - we know it exists from above check
-	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
-		"-s", subnetCIDR, "-o", natVethEnd, "-j", "SNAT")
-	if runErr := cmd.Run(); runErr != nil {
-		return errors.Wrap(errors.Internal, "failed to remove NAT SNAT rule", runErr)
 	}
 
 	a.logger.Info("NAT SNAT rule removed", "subnet", subnetCIDR, "nat_veth", natVethEnd)

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -246,3 +246,40 @@ func (a *OvsAdapter) SetVethIP(ctx context.Context, vethEnd, ip, cidr string) er
 	}
 	return nil
 }
+
+func (a *OvsAdapter) SetupNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR, publicIP string) error {
+	// Setup iptables SNAT for outbound traffic from subnet
+	// Create veth pair for NAT
+	if err := a.CreateVethPair(ctx, natVethEnd, natVethEnd+"-c"); err != nil {
+		a.logger.Warn("veth pair may already exist", "error", err)
+	}
+	if err := a.AttachVethToBridge(ctx, bridge, natVethEnd); err != nil {
+		return errors.Wrap(errors.Internal, "failed to attach NAT veth to bridge", err)
+	}
+
+	// Enable IP forwarding and setup NAT rules via iptables
+	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-A", "POSTROUTING",
+		"-s", subnetCIDR, "!", "-d", "10.0.0.0/8", "-j", "SNAT", "--to-source", publicIP)
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(errors.Internal, "failed to setup SNAT rule", err)
+	}
+
+	a.logger.Info("NAT configured for subnet", "subnet", subnetCIDR, "public_ip", publicIP)
+	return nil
+}
+
+func (a *OvsAdapter) RemoveNATForSubnet(ctx context.Context, bridge, natVethEnd, subnetCIDR string) error {
+	// Remove NAT rules
+	cmd := a.exec.CommandContext(ctx, "iptables", "-t", "nat", "-D", "POSTROUTING",
+		"-s", subnetCIDR, "!", "-d", "10.0.0.0/8", "-j", "SNAT")
+	if err := cmd.Run(); err != nil {
+		a.logger.Warn("failed to remove SNAT rule (may not exist)", "error", err)
+	}
+
+	// Remove NAT device from bridge and delete veth pair
+	_ = a.DeletePort(ctx, bridge, natVethEnd)
+	_ = a.DeleteVethPair(ctx, natVethEnd)
+
+	a.logger.Info("NAT removed for subnet", "subnet", subnetCIDR)
+	return nil
+}

--- a/internal/repositories/ovs/adapter_unit_test.go
+++ b/internal/repositories/ovs/adapter_unit_test.go
@@ -221,3 +221,35 @@ func TestOvsAdapterListFlowRules(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rules)
 }
+
+func TestOvsAdapterSetupNATForSubnet(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		fx := &fakeExecer{cmd: &fakeCmd{}}
+		a := &OvsAdapter{logger: slog.Default(), exec: fx}
+
+		err := a.SetupNATForSubnet(context.Background(), "br0", "nat0", "10.0.0.0/24", "203.0.113.10")
+		require.NoError(t, err)
+	})
+}
+
+func TestOvsAdapterRemoveNATForSubnet(t *testing.T) {
+	t.Run("success when rule exists", func(t *testing.T) {
+		// Rule exists on first check (checkCmd.Run() returns nil)
+		// Then delete succeeds - both commands succeed
+		fx := &fakeExecer{cmd: &fakeCmd{}}
+		a := &OvsAdapter{logger: slog.Default(), exec: fx}
+
+		err := a.RemoveNATForSubnet(context.Background(), "br0", "nat0", "10.0.0.0/24", "203.0.113.10")
+		require.NoError(t, err)
+	})
+
+	t.Run("success when rule does not exist", func(t *testing.T) {
+		// Check command returns error (rule doesn't exist), so delete is not called
+		// The function returns nil because there's nothing to clean up
+		fx := &fakeExecer{cmd: &fakeCmd{runErr: errors.New("iptables: No rule exists")}}
+		a := &OvsAdapter{logger: slog.Default(), exec: fx}
+
+		err := a.RemoveNATForSubnet(context.Background(), "br0", "nat0", "10.0.0.0/24", "203.0.113.10")
+		require.NoError(t, err)
+	})
+}

--- a/internal/repositories/postgres/igw_repo.go
+++ b/internal/repositories/postgres/igw_repo.go
@@ -1,0 +1,120 @@
+// Package postgres provides PostgreSQL-backed repository implementations.
+package postgres
+
+import (
+	"context"
+	stdlib_errors "errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/errors"
+)
+
+// IGWRepository provides PostgreSQL-backed persistence for Internet Gateways.
+type IGWRepository struct {
+	db DB
+}
+
+// NewIGWRepository creates an IGWRepository using the provided DB.
+func NewIGWRepository(db DB) *IGWRepository {
+	return &IGWRepository{db: db}
+}
+
+// Create inserts a new Internet Gateway record into the database.
+func (r *IGWRepository) Create(ctx context.Context, igw *domain.InternetGateway) error {
+	query := `
+		INSERT INTO internet_gateways (id, vpc_id, user_id, tenant_id, status, arn, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`
+	_, err := r.db.Exec(ctx, query, igw.ID, igw.VPCID, igw.UserID, igw.TenantID, igw.Status, igw.ARN, igw.CreatedAt)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to create internet gateway", err)
+	}
+	return nil
+}
+
+// GetByID retrieves a single Internet Gateway by its UUID.
+func (r *IGWRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.InternetGateway, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `SELECT id, vpc_id, user_id, tenant_id, status, arn, created_at FROM internet_gateways WHERE id = $1 AND tenant_id = $2`
+	return r.scanIGW(r.db.QueryRow(ctx, query, id, tenantID))
+}
+
+// GetByVPC returns the Internet Gateway attached to a specific VPC (if any).
+func (r *IGWRepository) GetByVPC(ctx context.Context, vpcID uuid.UUID) (*domain.InternetGateway, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `SELECT id, vpc_id, user_id, tenant_id, status, arn, created_at FROM internet_gateways WHERE vpc_id = $1 AND tenant_id = $2`
+	return r.scanIGW(r.db.QueryRow(ctx, query, vpcID, tenantID))
+}
+
+// Update modifies an existing Internet Gateway.
+func (r *IGWRepository) Update(ctx context.Context, igw *domain.InternetGateway) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		UPDATE internet_gateways SET vpc_id = $1, status = $2
+		WHERE id = $3 AND tenant_id = $4
+	`
+	cmd, err := r.db.Exec(ctx, query, igw.VPCID, igw.Status, igw.ID, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to update internet gateway", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "internet gateway not found")
+	}
+	return nil
+}
+
+// Delete removes an Internet Gateway from the database.
+func (r *IGWRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `DELETE FROM internet_gateways WHERE id = $1 AND tenant_id = $2`
+	cmd, err := r.db.Exec(ctx, query, id, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to delete internet gateway", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "internet gateway not found")
+	}
+	return nil
+}
+
+// ListAll returns all Internet Gateways for the current tenant.
+func (r *IGWRepository) ListAll(ctx context.Context) ([]*domain.InternetGateway, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `SELECT id, vpc_id, user_id, tenant_id, status, arn, created_at FROM internet_gateways WHERE tenant_id = $1 ORDER BY created_at DESC`
+	rows, err := r.db.Query(ctx, query, tenantID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list internet gateways", err)
+	}
+	return r.scanIGWs(rows)
+}
+
+func (r *IGWRepository) scanIGWs(rows pgx.Rows) ([]*domain.InternetGateway, error) {
+	defer rows.Close()
+	var igws []*domain.InternetGateway
+	for rows.Next() {
+		igw, err := r.scanIGW(rows)
+		if err != nil {
+			return nil, err
+		}
+		igws = append(igws, igw)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to iterate internet gateways", err)
+	}
+	return igws, nil
+}
+
+func (r *IGWRepository) scanIGW(row pgx.Row) (*domain.InternetGateway, error) {
+	var igw domain.InternetGateway
+	err := row.Scan(&igw.ID, &igw.VPCID, &igw.UserID, &igw.TenantID, &igw.Status, &igw.ARN, &igw.CreatedAt)
+	if err != nil {
+		if stdlib_errors.Is(err, pgx.ErrNoRows) {
+			return nil, errors.New(errors.NotFound, "internet gateway not found")
+		}
+		return nil, errors.Wrap(errors.Internal, "failed to scan internet gateway", err)
+	}
+	return &igw, nil
+}

--- a/internal/repositories/postgres/migrations/072_create_route_tables.down.sql
+++ b/internal/repositories/postgres/migrations/072_create_route_tables.down.sql
@@ -1,0 +1,4 @@
+-- +goose Down
+DROP TABLE IF EXISTS route_table_associations;
+DROP TABLE IF EXISTS routes;
+DROP TABLE IF EXISTS route_tables;

--- a/internal/repositories/postgres/migrations/072_create_route_tables.up.sql
+++ b/internal/repositories/postgres/migrations/072_create_route_tables.up.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS route_tables (
+    id UUID PRIMARY KEY,
+    vpc_id UUID NOT NULL REFERENCES vpcs(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    is_main BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(vpc_id, name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_route_tables_vpc ON route_tables(vpc_id);
+
+CREATE TABLE IF NOT EXISTS routes (
+    id UUID PRIMARY KEY,
+    route_table_id UUID NOT NULL REFERENCES route_tables(id) ON DELETE CASCADE,
+    destination_cidr CIDR NOT NULL,
+    target_type VARCHAR(20) NOT NULL,
+    target_id UUID,
+    target_name VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_routes_table ON routes(route_table_id);
+CREATE INDEX IF NOT EXISTS idx_routes_destination ON routes(destination_cidr);
+
+CREATE TABLE IF NOT EXISTS route_table_associations (
+    id UUID PRIMARY KEY,
+    route_table_id UUID NOT NULL REFERENCES route_tables(id) ON DELETE CASCADE,
+    subnet_id UUID NOT NULL REFERENCES subnets(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(route_table_id, subnet_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rt_assoc_subnet ON route_table_associations(subnet_id);

--- a/internal/repositories/postgres/migrations/073_create_internet_gateways.down.sql
+++ b/internal/repositories/postgres/migrations/073_create_internet_gateways.down.sql
@@ -1,0 +1,2 @@
+-- +goose Down
+DROP TABLE IF EXISTS internet_gateways;

--- a/internal/repositories/postgres/migrations/073_create_internet_gateways.up.sql
+++ b/internal/repositories/postgres/migrations/073_create_internet_gateways.up.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS internet_gateways (
+    id UUID PRIMARY KEY,
+    vpc_id UUID REFERENCES vpcs(id) ON DELETE SET NULL,
+    user_id UUID NOT NULL REFERENCES users(id),
+    tenant_id UUID NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'detached',
+    arn VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_igw_vpc ON internet_gateways(vpc_id);
+CREATE INDEX IF NOT EXISTS idx_igw_tenant ON internet_gateways(tenant_id);

--- a/internal/repositories/postgres/migrations/074_create_nat_gateways.down.sql
+++ b/internal/repositories/postgres/migrations/074_create_nat_gateways.down.sql
@@ -1,0 +1,2 @@
+-- +goose Down
+DROP TABLE IF EXISTS nat_gateways;

--- a/internal/repositories/postgres/migrations/074_create_nat_gateways.up.sql
+++ b/internal/repositories/postgres/migrations/074_create_nat_gateways.up.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS nat_gateways (
+    id UUID PRIMARY KEY,
+    vpc_id UUID NOT NULL REFERENCES vpcs(id) ON DELETE CASCADE,
+    subnet_id UUID NOT NULL REFERENCES subnets(id),
+    elastic_ip_id UUID NOT NULL REFERENCES elastic_ips(id),
+    user_id UUID NOT NULL REFERENCES users(id),
+    tenant_id UUID NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'pending',
+    private_ip INET NOT NULL,
+    arn VARCHAR(255) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_nat_vpc ON nat_gateways(vpc_id);
+CREATE INDEX IF NOT EXISTS idx_nat_subnet ON nat_gateways(subnet_id);
+CREATE INDEX IF NOT EXISTS idx_nat_eip ON nat_gateways(elastic_ip_id);

--- a/internal/repositories/postgres/nat_gateway_repo.go
+++ b/internal/repositories/postgres/nat_gateway_repo.go
@@ -1,0 +1,124 @@
+// Package postgres provides PostgreSQL-backed repository implementations.
+package postgres
+
+import (
+	"context"
+	stdlib_errors "errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/errors"
+)
+
+// NATGatewayRepository provides PostgreSQL-backed persistence for NAT Gateways.
+type NATGatewayRepository struct {
+	db DB
+}
+
+// NewNATGatewayRepository creates a NATGatewayRepository using the provided DB.
+func NewNATGatewayRepository(db DB) *NATGatewayRepository {
+	return &NATGatewayRepository{db: db}
+}
+
+// Create inserts a new NAT Gateway record into the database.
+func (r *NATGatewayRepository) Create(ctx context.Context, nat *domain.NATGateway) error {
+	query := `
+		INSERT INTO nat_gateways (id, vpc_id, subnet_id, elastic_ip_id, user_id, tenant_id, status, private_ip, arn, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	`
+	_, err := r.db.Exec(ctx, query, nat.ID, nat.VPCID, nat.SubnetID, nat.ElasticIPID, nat.UserID, nat.TenantID, nat.Status, nat.PrivateIP, nat.ARN, nat.CreatedAt)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to create NAT gateway", err)
+	}
+	return nil
+}
+
+// GetByID retrieves a single NAT Gateway by its UUID.
+func (r *NATGatewayRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.NATGateway, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `SELECT id, vpc_id, subnet_id, elastic_ip_id, user_id, tenant_id, status, private_ip, arn, created_at FROM nat_gateways WHERE id = $1 AND tenant_id = $2`
+	return r.scanNATGateway(r.db.QueryRow(ctx, query, id, tenantID))
+}
+
+// ListBySubnet returns all NAT Gateways in a specific subnet.
+func (r *NATGatewayRepository) ListBySubnet(ctx context.Context, subnetID uuid.UUID) ([]*domain.NATGateway, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `SELECT id, vpc_id, subnet_id, elastic_ip_id, user_id, tenant_id, status, private_ip, arn, created_at FROM nat_gateways WHERE subnet_id = $1 AND tenant_id = $2`
+	rows, err := r.db.Query(ctx, query, subnetID, tenantID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list NAT gateways by subnet", err)
+	}
+	return r.scanNATGateways(rows)
+}
+
+// ListByVPC returns all NAT Gateways for a given VPC.
+func (r *NATGatewayRepository) ListByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.NATGateway, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `SELECT id, vpc_id, subnet_id, elastic_ip_id, user_id, tenant_id, status, private_ip, arn, created_at FROM nat_gateways WHERE vpc_id = $1 AND tenant_id = $2 ORDER BY created_at DESC`
+	rows, err := r.db.Query(ctx, query, vpcID, tenantID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list NAT gateways by VPC", err)
+	}
+	return r.scanNATGateways(rows)
+}
+
+// Update modifies an existing NAT Gateway.
+func (r *NATGatewayRepository) Update(ctx context.Context, nat *domain.NATGateway) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		UPDATE nat_gateways SET status = $1, private_ip = $2
+		WHERE id = $3 AND tenant_id = $4
+	`
+	cmd, err := r.db.Exec(ctx, query, nat.Status, nat.PrivateIP, nat.ID, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to update NAT gateway", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "NAT gateway not found")
+	}
+	return nil
+}
+
+// Delete removes a NAT Gateway from the database.
+func (r *NATGatewayRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `DELETE FROM nat_gateways WHERE id = $1 AND tenant_id = $2`
+	cmd, err := r.db.Exec(ctx, query, id, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to delete NAT gateway", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "NAT gateway not found")
+	}
+	return nil
+}
+
+func (r *NATGatewayRepository) scanNATGateway(row pgx.Row) (*domain.NATGateway, error) {
+	var nat domain.NATGateway
+	err := row.Scan(&nat.ID, &nat.VPCID, &nat.SubnetID, &nat.ElasticIPID, &nat.UserID, &nat.TenantID, &nat.Status, &nat.PrivateIP, &nat.ARN, &nat.CreatedAt)
+	if err != nil {
+		if stdlib_errors.Is(err, pgx.ErrNoRows) {
+			return nil, errors.New(errors.NotFound, "NAT gateway not found")
+		}
+		return nil, errors.Wrap(errors.Internal, "failed to scan NAT gateway", err)
+	}
+	return &nat, nil
+}
+
+func (r *NATGatewayRepository) scanNATGateways(rows pgx.Rows) ([]*domain.NATGateway, error) {
+	defer rows.Close()
+	var nats []*domain.NATGateway
+	for rows.Next() {
+		nat, err := r.scanNATGateway(rows)
+		if err != nil {
+			return nil, err
+		}
+		nats = append(nats, nat)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to iterate NAT gateways", err)
+	}
+	return nats, nil
+}

--- a/internal/repositories/postgres/route_table_repo.go
+++ b/internal/repositories/postgres/route_table_repo.go
@@ -1,0 +1,278 @@
+// Package postgres provides PostgreSQL-backed repository implementations.
+package postgres
+
+import (
+	"context"
+	stdlib_errors "errors"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	appcontext "github.com/poyrazk/thecloud/internal/core/context"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/errors"
+)
+
+// RouteTableRepository provides PostgreSQL-backed persistence for route tables.
+type RouteTableRepository struct {
+	db DB
+}
+
+// NewRouteTableRepository creates a RouteTableRepository using the provided DB.
+func NewRouteTableRepository(db DB) *RouteTableRepository {
+	return &RouteTableRepository{db: db}
+}
+
+// Create inserts a new route table record into the database.
+func (r *RouteTableRepository) Create(ctx context.Context, rt *domain.RouteTable) error {
+	query := `
+		INSERT INTO route_tables (id, vpc_id, name, is_main, created_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`
+	_, err := r.db.Exec(ctx, query, rt.ID, rt.VPCID, rt.Name, rt.IsMain, rt.CreatedAt)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to create route table", err)
+	}
+	return nil
+}
+
+// GetByID retrieves a single route table by its UUID.
+func (r *RouteTableRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.RouteTable, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		SELECT rt.id, rt.vpc_id, rt.name, rt.is_main, rt.created_at
+		FROM route_tables rt
+		JOIN vpcs v ON rt.vpc_id = v.id
+		WHERE rt.id = $1 AND v.tenant_id = $2
+	`
+	rt, err := r.scanRouteTable(r.db.QueryRow(ctx, query, id, tenantID))
+	if err != nil {
+		return nil, err
+	}
+
+	routes, err := r.ListRoutes(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	rt.Routes = routes
+
+	associations, err := r.ListAssociatedSubnets(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	rt.Associations = make([]domain.RouteTableAssociation, len(associations))
+	for i, subnetID := range associations {
+		rt.Associations[i] = domain.RouteTableAssociation{
+			ID:           uuid.New(),
+			RouteTableID: id,
+			SubnetID:     subnetID,
+		}
+	}
+
+	return rt, nil
+}
+
+// GetByVPC returns all route tables for a given VPC.
+func (r *RouteTableRepository) GetByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.RouteTable, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		SELECT rt.id, rt.vpc_id, rt.name, rt.is_main, rt.created_at
+		FROM route_tables rt
+		JOIN vpcs v ON rt.vpc_id = v.id
+		WHERE rt.vpc_id = $1 AND v.tenant_id = $2
+		ORDER BY rt.is_main DESC, rt.created_at ASC
+	`
+	rows, err := r.db.Query(ctx, query, vpcID, tenantID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list route tables", err)
+	}
+	return r.scanRouteTables(rows)
+}
+
+// GetMainByVPC returns the main route table for a given VPC.
+func (r *RouteTableRepository) GetMainByVPC(ctx context.Context, vpcID uuid.UUID) (*domain.RouteTable, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		SELECT rt.id, rt.vpc_id, rt.name, rt.is_main, rt.created_at
+		FROM route_tables rt
+		JOIN vpcs v ON rt.vpc_id = v.id
+		WHERE rt.vpc_id = $1 AND rt.is_main = TRUE AND v.tenant_id = $2
+	`
+	return r.scanRouteTable(r.db.QueryRow(ctx, query, vpcID, tenantID))
+}
+
+// Update modifies an existing route table.
+func (r *RouteTableRepository) Update(ctx context.Context, rt *domain.RouteTable) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		UPDATE route_tables SET name = $1, is_main = $2
+		WHERE id = $3 AND vpc_id IN (SELECT id FROM vpcs WHERE tenant_id = $4)
+	`
+	cmd, err := r.db.Exec(ctx, query, rt.Name, rt.IsMain, rt.ID, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to update route table", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "route table not found")
+	}
+	return nil
+}
+
+// Delete removes a route table from the database.
+func (r *RouteTableRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		DELETE FROM route_tables rt
+		USING vpcs v
+		WHERE rt.vpc_id = v.id AND rt.id = $1 AND v.tenant_id = $2 AND rt.is_main = FALSE
+	`
+	cmd, err := r.db.Exec(ctx, query, id, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to delete route table", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "route table not found or is a main table")
+	}
+	return nil
+}
+
+// AddRoute adds a new route to a route table.
+func (r *RouteTableRepository) AddRoute(ctx context.Context, rtID uuid.UUID, route *domain.Route) error {
+	query := `
+		INSERT INTO routes (id, route_table_id, destination_cidr, target_type, target_id, target_name, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`
+	_, err := r.db.Exec(ctx, query, route.ID, rtID, route.DestinationCIDR, route.TargetType, route.TargetID, route.TargetName, route.CreatedAt)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to add route", err)
+	}
+	return nil
+}
+
+// RemoveRoute removes a route from a route table.
+func (r *RouteTableRepository) RemoveRoute(ctx context.Context, rtID, routeID uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		DELETE FROM routes r
+		USING route_tables rt
+		JOIN vpcs v ON rt.vpc_id = v.id
+		WHERE r.route_table_id = rt.id AND r.id = $1 AND rt.id = $2 AND v.tenant_id = $3
+	`
+	cmd, err := r.db.Exec(ctx, query, routeID, rtID, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to remove route", err)
+	}
+	if cmd.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "route not found")
+	}
+	return nil
+}
+
+// ListRoutes returns all routes for a given route table.
+func (r *RouteTableRepository) ListRoutes(ctx context.Context, rtID uuid.UUID) ([]domain.Route, error) {
+	query := `SELECT id, route_table_id, destination_cidr, target_type, COALESCE(target_id, '00000000-0000-0000-0000-000000000000'::uuid), COALESCE(target_name, ''), created_at FROM routes WHERE route_table_id = $1 ORDER BY destination_cidr`
+	rows, err := r.db.Query(ctx, query, rtID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list routes", err)
+	}
+	return r.scanRoutes(rows)
+}
+
+// AssociateSubnet links a subnet to a route table.
+func (r *RouteTableRepository) AssociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error {
+	query := `
+		INSERT INTO route_table_associations (id, route_table_id, subnet_id, created_at)
+		VALUES ($1, $2, $3, $4)
+		ON CONFLICT (route_table_id, subnet_id) DO NOTHING
+	`
+	_, err := r.db.Exec(ctx, query, uuid.New(), rtID, subnetID, "now")
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to associate subnet", err)
+	}
+	return nil
+}
+
+// DisassociateSubnet removes a subnet's association with a route table.
+func (r *RouteTableRepository) DisassociateSubnet(ctx context.Context, rtID, subnetID uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `
+		DELETE FROM route_table_associations rta
+		USING route_tables rt
+		JOIN vpcs v ON rt.vpc_id = v.id
+		WHERE rta.route_table_id = rt.id AND rta.subnet_id = $1 AND rt.id = $2 AND v.tenant_id = $3
+	`
+	_, err := r.db.Exec(ctx, query, subnetID, rtID, tenantID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to disassociate subnet", err)
+	}
+	return nil
+}
+
+// ListAssociatedSubnets returns all subnet IDs associated with a route table.
+func (r *RouteTableRepository) ListAssociatedSubnets(ctx context.Context, rtID uuid.UUID) ([]uuid.UUID, error) {
+	query := `SELECT subnet_id FROM route_table_associations WHERE route_table_id = $1`
+	rows, err := r.db.Query(ctx, query, rtID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to list associated subnets", err)
+	}
+	defer rows.Close()
+
+	var subnetIDs []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, errors.Wrap(errors.Internal, "failed to scan subnet id", err)
+		}
+		subnetIDs = append(subnetIDs, id)
+	}
+	return subnetIDs, nil
+}
+
+func (r *RouteTableRepository) scanRouteTable(row pgx.Row) (*domain.RouteTable, error) {
+	var rt domain.RouteTable
+	err := row.Scan(&rt.ID, &rt.VPCID, &rt.Name, &rt.IsMain, &rt.CreatedAt)
+	if err != nil {
+		if stdlib_errors.Is(err, pgx.ErrNoRows) {
+			return nil, errors.New(errors.NotFound, "route table not found")
+		}
+		return nil, errors.Wrap(errors.Internal, "failed to scan route table", err)
+	}
+	return &rt, nil
+}
+
+func (r *RouteTableRepository) scanRouteTables(rows pgx.Rows) ([]*domain.RouteTable, error) {
+	defer rows.Close()
+	var tables []*domain.RouteTable
+	for rows.Next() {
+		rt, err := r.scanRouteTable(rows)
+		if err != nil {
+			return nil, err
+		}
+		tables = append(tables, rt)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to iterate route tables", err)
+	}
+	return tables, nil
+}
+
+func (r *RouteTableRepository) scanRoutes(rows pgx.Rows) ([]domain.Route, error) {
+	defer rows.Close()
+	var routes []domain.Route
+	for rows.Next() {
+		var route domain.Route
+		var targetID *uuid.UUID
+		if err := rows.Scan(&route.ID, &route.RouteTableID, &route.DestinationCIDR, &route.TargetType, &targetID, &route.TargetName, &route.CreatedAt); err != nil {
+			return nil, errors.Wrap(errors.Internal, "failed to scan route", err)
+		}
+		// Convert zero UUID back to nil
+		if targetID != nil && *targetID == uuid.Nil {
+			targetID = nil
+		}
+		route.TargetID = targetID
+		routes = append(routes, route)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to iterate routes", err)
+	}
+	return routes, nil
+}

--- a/pkg/sdk/igw.go
+++ b/pkg/sdk/igw.go
@@ -1,0 +1,71 @@
+// Package sdk provides the official Go SDK for the platform.
+package sdk
+
+import (
+	"fmt"
+	"time"
+)
+
+// IGWStatus represents the attachment state of an Internet Gateway.
+type IGWStatus string
+
+const (
+	IGWStatusDetached IGWStatus = "detached"
+	IGWStatusAttached  IGWStatus = "attached"
+)
+
+// InternetGateway describes an internet gateway resource.
+type InternetGateway struct {
+	ID        string     `json:"id"`
+	VPCID     *string    `json:"vpc_id,omitempty"`
+	UserID    string     `json:"user_id"`
+	TenantID  string     `json:"tenant_id"`
+	Status    IGWStatus  `json:"status"`
+	ARN       string     `json:"arn"`
+	CreatedAt time.Time  `json:"created_at"`
+}
+
+// CreateIGW creates a new internet gateway in detached state.
+func (c *Client) CreateIGW() (*InternetGateway, error) {
+	var res Response[InternetGateway]
+	if err := c.post("/igws", nil, &res); err != nil {
+		return nil, err
+	}
+	return &res.Data, nil
+}
+
+// AttachIGW attaches an internet gateway to a VPC.
+func (c *Client) AttachIGW(igwID, vpcID string) error {
+	body := map[string]string{
+		"vpc_id": vpcID,
+	}
+	return c.post(fmt.Sprintf("/igws/%s/attach", igwID), body, nil)
+}
+
+// DetachIGW detaches an internet gateway from its VPC.
+func (c *Client) DetachIGW(igwID string) error {
+	return c.post(fmt.Sprintf("/igws/%s/detach", igwID), nil, nil)
+}
+
+// ListIGWs returns all internet gateways for the tenant.
+func (c *Client) ListIGWs() ([]InternetGateway, error) {
+	var res Response[[]InternetGateway]
+	if err := c.get("/igws", &res); err != nil {
+		return nil, err
+	}
+	return res.Data, nil
+}
+
+// GetIGW retrieves details of a specific internet gateway.
+func (c *Client) GetIGW(id string) (*InternetGateway, error) {
+	var res Response[InternetGateway]
+	if err := c.get(fmt.Sprintf("/igws/%s", id), &res); err != nil {
+		return nil, err
+	}
+	return &res.Data, nil
+}
+
+// DeleteIGW permanently removes an internet gateway (must be detached first).
+func (c *Client) DeleteIGW(id string) error {
+	return c.delete(fmt.Sprintf("/igws/%s", id), nil)
+}

--- a/pkg/sdk/nat_gateway.go
+++ b/pkg/sdk/nat_gateway.go
@@ -1,0 +1,71 @@
+// Package sdk provides the official Go SDK for the platform.
+package sdk
+
+import (
+	"fmt"
+	"time"
+)
+
+// NATGatewayStatus represents the state of a NAT Gateway.
+type NATGatewayStatus string
+
+const (
+	NATGatewayStatusPending NATGatewayStatus = "pending"
+	NATGatewayStatusActive  NATGatewayStatus = "active"
+	NATGatewayStatusFailed  NATGatewayStatus = "failed"
+	NATGatewayStatusDeleted NATGatewayStatus = "deleted"
+)
+
+// NATGateway describes a NAT gateway resource.
+type NATGateway struct {
+	ID          string          `json:"id"`
+	VPCID       string          `json:"vpc_id"`
+	SubnetID    string          `json:"subnet_id"`
+	ElasticIPID string          `json:"elastic_ip_id"`
+	UserID      string          `json:"user_id"`
+	TenantID    string          `json:"tenant_id"`
+	Status      NATGatewayStatus `json:"status"`
+	PrivateIP   string          `json:"private_ip"`
+	ARN         string          `json:"arn"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// CreateNATGateway creates a new NAT gateway in a subnet with an elastic IP.
+func (c *Client) CreateNATGateway(subnetID, eipID string) (*NATGateway, error) {
+	body := map[string]string{
+		"subnet_id":     subnetID,
+		"elastic_ip_id": eipID,
+	}
+	var res Response[NATGateway]
+	if err := c.post("/nat-gateways", body, &res); err != nil {
+		return nil, err
+	}
+	return &res.Data, nil
+}
+
+// ListNATGateways returns all NAT gateways for a VPC.
+func (c *Client) ListNATGateways(vpcID string) ([]NATGateway, error) {
+	var res Response[[]NATGateway]
+	path := "/nat-gateways"
+	if vpcID != "" {
+		path = fmt.Sprintf("%s?vpc_id=%s", path, vpcID)
+	}
+	if err := c.get(path, &res); err != nil {
+		return nil, err
+	}
+	return res.Data, nil
+}
+
+// GetNATGateway retrieves details of a specific NAT gateway.
+func (c *Client) GetNATGateway(id string) (*NATGateway, error) {
+	var res Response[NATGateway]
+	if err := c.get(fmt.Sprintf("/nat-gateways/%s", id), &res); err != nil {
+		return nil, err
+	}
+	return &res.Data, nil
+}
+
+// DeleteNATGateway permanently removes a NAT gateway.
+func (c *Client) DeleteNATGateway(id string) error {
+	return c.delete(fmt.Sprintf("/nat-gateways/%s", id), nil)
+}

--- a/pkg/sdk/route_table.go
+++ b/pkg/sdk/route_table.go
@@ -1,0 +1,117 @@
+// Package sdk provides the official Go SDK for the platform.
+package sdk
+
+import (
+	"fmt"
+	"time"
+)
+
+// RouteTargetType defines what kind of target a route points to.
+type RouteTargetType string
+
+const (
+	RouteTargetLocal   RouteTargetType = "local"
+	RouteTargetIGW    RouteTargetType = "igw"
+	RouteTargetNAT    RouteTargetType = "nat"
+	RouteTargetPeering RouteTargetType = "peering"
+)
+
+// RouteTable describes a route table resource.
+type RouteTable struct {
+	ID        string    `json:"id"`
+	VPCID     string    `json:"vpc_id"`
+	Name      string    `json:"name"`
+	IsMain    bool      `json:"is_main"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Route describes a routing rule within a route table.
+type Route struct {
+	ID              string          `json:"id"`
+	RouteTableID    string          `json:"route_table_id"`
+	DestinationCIDR string          `json:"destination_cidr"`
+	TargetType      RouteTargetType `json:"target_type"`
+	TargetID        *string         `json:"target_id,omitempty"`
+	TargetName      string          `json:"target_name,omitempty"`
+	CreatedAt       time.Time       `json:"created_at"`
+}
+
+// RouteTableAssociation links a subnet to a route table.
+type RouteTableAssociation struct {
+	ID           string    `json:"id"`
+	RouteTableID string    `json:"route_table_id"`
+	SubnetID     string    `json:"subnet_id"`
+	CreatedAt    time.Time `json:"created_at"`
+}
+
+// ListRouteTables returns all route tables for a VPC.
+func (c *Client) ListRouteTables(vpcID string) ([]RouteTable, error) {
+	var res Response[[]RouteTable]
+	path := fmt.Sprintf("/vpcs/%s/route-tables", vpcID)
+	if err := c.get(path, &res); err != nil {
+		return nil, err
+	}
+	return res.Data, nil
+}
+
+// CreateRouteTable creates a new route table for a VPC.
+func (c *Client) CreateRouteTable(vpcID, name string, isMain bool) (*RouteTable, error) {
+	body := map[string]interface{}{
+		"name":    name,
+		"vpc_id":  vpcID,
+		"is_main": isMain,
+	}
+	var res Response[RouteTable]
+	if err := c.post("/route-tables", body, &res); err != nil {
+		return nil, err
+	}
+	return &res.Data, nil
+}
+
+// GetRouteTable retrieves details of a specific route table.
+func (c *Client) GetRouteTable(id string) (*RouteTable, error) {
+	var res Response[RouteTable]
+	if err := c.get(fmt.Sprintf("/route-tables/%s", id), &res); err != nil {
+		return nil, err
+	}
+	return &res.Data, nil
+}
+
+// DeleteRouteTable permanently removes a route table.
+func (c *Client) DeleteRouteTable(id string) error {
+	return c.delete(fmt.Sprintf("/route-tables/%s", id), nil)
+}
+
+// AddRoute adds a route to a route table.
+func (c *Client) AddRoute(rtID, destCIDR string, targetType RouteTargetType, targetID string) (*Route, error) {
+	body := map[string]interface{}{
+		"destination_cidr": destCIDR,
+		"target_type":     targetType,
+	}
+	if targetID != "" {
+		body["target_id"] = targetID
+	}
+	var res Response[Route]
+	if err := c.post(fmt.Sprintf("/route-tables/%s/routes", rtID), body, &res); err != nil {
+		return nil, err
+	}
+	return &res.Data, nil
+}
+
+// RemoveRoute removes a route from a route table.
+func (c *Client) RemoveRoute(rtID, routeID string) error {
+	return c.delete(fmt.Sprintf("/route-tables/%s/routes/%s", rtID, routeID), nil)
+}
+
+// AssociateSubnet associates a subnet with a route table.
+func (c *Client) AssociateSubnet(rtID, subnetID string) error {
+	body := map[string]string{
+		"subnet_id": subnetID,
+	}
+	return c.post(fmt.Sprintf("/route-tables/%s/associations", rtID), body, nil)
+}
+
+// DisassociateSubnet disassociates a subnet from a route table.
+func (c *Client) DisassociateSubnet(rtID, subnetID string) error {
+	return c.delete(fmt.Sprintf("/route-tables/%s/associations/%s", rtID, subnetID), nil)
+}


### PR DESCRIPTION
## Summary
- **Route Tables**: Full CRUD with route management and subnet associations. VPCs now auto-create a main route table with local route on creation.
- **Internet Gateways**: Create/attach/detach lifecycle for VPC internet access
- **NAT Gateways**: Create/delete with iptables SNAT for private subnet internet access
- **VPC Peering**: Refactored to use route table abstraction instead of direct OVS flow manipulation
- **CLI**: New commands `cloud route-table`, `cloud igw`, `cloud nat-gateway`
- **API**: New endpoints for `/route-tables`, `/internet-gateways`, `/nat-gateways`
- **Documentation**: API reference, CLI reference, and ADR-025 for routing architecture

## Files Changed
| Component | Files |
|-----------|-------|
| Domain & Ports | 6 new files (route_table.go, internet_gateway.go, nat_gateway.go + ports) |
| Database | 6 migration files (072-074) + 3 repo implementations |
| Services | 3 new service files + modifications to vpc.go, vpc_peering.go |
| API Handlers | 3 new handlers + wiring in dependencies.go, router.go |
| CLI | 3 new command files + registration in main.go |
| Network Backend | Added SetupNATForSubnet/RemoveNATForSubnet to interface and OVS adapter |
| Documentation | api-reference.md, cli-reference.md, ADR-025, vpc-routing-roadmap.md |
| Tests | routing_services_test.go + mock implementations |

## Validation
```bash
go build ./...
go test ./internal/core/services/... -run "TestVPCPeeringService_Unit|TestVpcServiceUnit|TestInternetGatewayService|TestRouteTableService|TestNATGatewayService"
```

## Related ADR
ADR-025: VPC Routing Architecture - documents the route table abstraction for VPC routing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI, API, and SDK: manage Internet Gateways (create/attach/detach/list/delete), NAT Gateways (create/list/delete), and Route Tables (create/list/delete, add/remove routes, associate/disassociate subnets)
  * VPC creation now auto-creates a main route table

* **Documentation**
  * Added API & CLI reference, Swagger docs, ADR, and a VPC routing roadmap

* **Tests**
  * Added comprehensive tests covering routing, IGW, and NAT gateway flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->