### PR TITLE
fix(instance): fail fast on quota increment errors during resize

### DIFF
--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -824,10 +824,9 @@ func (s *InstanceService) completeResize(ctx context.Context, tenantID uuid.UUID
 			return err
 		}
 		if err := s.tenantSvc.IncrementUsage(ctx, tenantID, "vcpus", deltaCPU); err != nil {
-			quotaErrs = append(quotaErrs, fmt.Errorf("vcpu increment: %w", err))
-		} else {
-			cpuIncremented = true
+			return errors.Wrap(errors.Internal, "failed to increment vCPU quota for resize", err)
 		}
+		cpuIncremented = true
 	} else if deltaCPU < 0 {
 		if err := s.tenantSvc.DecrementUsage(ctx, tenantID, "vcpus", -deltaCPU); err != nil {
 			quotaErrs = append(quotaErrs, fmt.Errorf("vcpu decrement: %w", err))
@@ -838,10 +837,13 @@ func (s *InstanceService) completeResize(ctx context.Context, tenantID uuid.UUID
 			return err
 		}
 		if err := s.tenantSvc.IncrementUsage(ctx, tenantID, "memory", deltaMemMB); err != nil {
-			quotaErrs = append(quotaErrs, fmt.Errorf("memory increment: %w", err))
-		} else {
-			memIncremented = true
+			// Rollback the vCPU increment since memory increment failed
+			if cpuIncremented {
+				_ = s.tenantSvc.DecrementUsage(ctx, tenantID, "vcpus", deltaCPU)
+			}
+			return errors.Wrap(errors.Internal, "failed to increment memory quota for resize", err)
 		}
+		memIncremented = true
 	} else if deltaMemMB < 0 {
 		if err := s.tenantSvc.DecrementUsage(ctx, tenantID, "memory", -deltaMemMB); err != nil {
 			quotaErrs = append(quotaErrs, fmt.Errorf("memory decrement: %w", err))


### PR DESCRIPTION
## Summary
- Fix ResizeInstance returning HTTP 500 when quota IncrementUsage fails during an upsize
- Previously, increment failures were appended to quotaErrs slice and returned as a confusing 500 at end of operation
- Now we fail immediately with a clear error and roll back any partial quota changes

## Bug
When resizing up (e.g. basic-2 → standard-1), if `IncrementUsage` fails after `CheckQuota` passes (e.g. race condition, concurrent request), the error was not returned immediately. Instead it was appended to a slice and returned later as "resize succeeded but quota updates failed" which is confusing.

## Fix
- For upsize operations (deltaCPU > 0 or deltaMemMB > 0), fail immediately if IncrementUsage fails
- When memory increment fails after vCPU increment succeeded, roll back the vCPU increment
- This provides accurate error messages to users

## Test plan
- [ ] E2E test TestResizeInstance should pass (upsize basic-2 → standard-1)
- [ ] E2E test TestResizeInstanceDownsize should still pass (downsize)