### PR TITLE
feat(serverless): add secret integration for CloudFunctions

### DIFF
--- a/cmd/cloud/function.go
+++ b/cmd/cloud/function.go
@@ -222,11 +222,16 @@ var updateFnCmd = &cobra.Command{
 		var envVars []*sdk.EnvVar
 		for _, e := range envVarsStr {
 			parts := strings.SplitN(e, "=", 2)
-			if len(parts) == 2 {
-				envVars = append(envVars, &sdk.EnvVar{Key: parts[0], Value: parts[1]})
-			} else {
+			if len(parts) != 2 {
 				return fmt.Errorf("invalid env var format: %q, expected KEY=VALUE", e)
 			}
+			envVar := &sdk.EnvVar{Key: parts[0]}
+			if strings.HasPrefix(parts[1], "@") {
+				envVar.SecretRef = parts[1] // e.g. "@my-api-key"
+			} else {
+				envVar.Value = parts[1]
+			}
+			envVars = append(envVars, envVar)
 		}
 
 		fn, err := client.UpdateFunction(targetID, &sdk.FunctionUpdateRequest{

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -170,6 +170,7 @@ This document provides a comprehensive overview of every feature currently imple
 - **Handler Configuration**: Specify entry point file for each function.
 - **Partial Updates**: Update timeout, memory, handler, and status via `PATCH /functions/:id`.
 - **Environment Variables**: Inject key-value env vars at runtime without code changes.
+- **Secret Integration**: Env vars can reference secrets (`@secretname`) resolved at invocation time via SecretService — no plaintext secrets stored in the database.
 
 ### 8. Load Balancer (ELB)
 **What it is**: Distribute incoming HTTP traffic across multiple instances.

--- a/docs/adr/ADR-025-function-env-vars-and-partial-updates.md
+++ b/docs/adr/ADR-025-function-env-vars-and-partial-updates.md
@@ -71,7 +71,7 @@ return ports.RunTaskOptions{Env: env, ...}
 - Supports secrets rotation without code changes
 - Same function code can be used with different configurations
 
-**Security note:** Env vars in containers are visible to any user who can inspect the container. Secrets should use the SecretService instead.
+**Security note:** Env vars in containers are visible to any user who can inspect the container. Plain-text env vars are suitable for non-sensitive configuration. For secrets, use the SecretService integration described below.
 
 ### 4. Validation Rules
 
@@ -81,6 +81,37 @@ return ports.RunTaskOptions{Env: env, ...}
 | `MemoryMB` | 64–10240 MB | Container resource limits; practical upper bound |
 
 Validation occurs in the service layer before calling the repository.
+
+### 5. Secret Integration
+
+Environment variables can reference secrets stored in the SecretService using `@secretname` syntax. Secrets are resolved dynamically at invocation time (not stored in the function record), enabling rotation without code changes.
+
+**EnvVar structure:**
+```go
+type EnvVar struct {
+    Key       string `json:"key"`
+    Value     string `json:"value,omitempty"`
+    SecretRef string `json:"secret_ref,omitempty"` // e.g. "@my-api-key"
+}
+```
+
+**Constraint:** `Value` and `SecretRef` are mutually exclusive — at least one must be set. This is validated in `FunctionUpdate.Validate()`.
+
+**Resolution flow:**
+1. At update time, the user sets `--env API_KEY=@my-secret` (CLI) or `{"key":"API_KEY","secret_ref":"@my-secret"}` (API)
+2. The `SecretRef` is stored in `env_vars` JSONB — no plaintext secret touches the database
+3. At invocation, `buildTaskOptions` calls `SecretService.GetSecretByName(ctx, "my-secret")` to resolve the secret
+4. The secret value is injected as a JSON object: `API_KEY={"key":"API_KEY","value":"s3cr3t"}`
+
+**Why dynamic resolution:**
+- Secrets can be rotated in SecretService without updating the function
+- No plaintext secrets in the database
+- If secret resolution fails, the env var is skipped (warning logged) rather than failing the invocation
+
+**Alternative considered: Store encrypted secret at update time**
+- Would require storing the encryption key alongside the function
+- Rotation would still require function update to re-encrypt
+- Rejected in favor of runtime resolution for better secret hygiene
 
 ## Consequences
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -938,16 +938,25 @@ Get execution logs.
 
 ### PATCH /functions/:id
 Update a function's configuration (timeout, memory, handler, environment variables).
+
+**Environment variables** — each entry can be either a plain-text value or a secret reference, but not both:
 ```json
 {
   "handler": "newhandler.js",
   "timeout": 300,
   "memory_mb": 256,
   "env_vars": [
-    { "key": "FOO", "value": "bar" }
+    { "key": "FOO", "value": "bar" },
+    { "key": "API_KEY", "secret_ref": "@my-api-key" }
   ]
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | Env var name |
+| `value` | string | Plain-text value (mutually exclusive with `secret_ref`) |
+| `secret_ref` | string | Secret name reference with `@` prefix (e.g. `"@my-api-key"`) |
 
 ### GET /function-schedules
 List all function schedules.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -809,7 +809,7 @@ cloud function update my-func --env FOO=bar --env DEBUG=true
 - `--handler`, `-H`: Handler name
 - `--timeout`: Timeout in seconds (1-900)
 - `--memory`: Memory in MB (64-10240)
-- `--env`: Environment variable KEY=VALUE (can be repeated)
+- `--env`: Environment variable `KEY=VALUE` or `KEY=@secretname` for secrets (can be repeated)
 
 ### `fn-schedule create`
 

--- a/docs/guides/functions.md
+++ b/docs/guides/functions.md
@@ -54,10 +54,36 @@ cloud fn update hello --env FOO=bar --env DB_HOST=localhost
 Environment variables are injected at runtime into the function container:
 
 ```bash
-cloud fn update my-func --env API_KEY=secret --env DEBUG=true
+cloud fn update my-func --env FOO=bar --env DEBUG=true
 ```
 
 Environment variables are available via `process.env` (Node.js), `os.environ` (Python), or `os.Getenv` (Go, Java).
+
+### Using Secrets
+
+For sensitive values like API keys and database passwords, reference secrets stored in the SecretService:
+
+```bash
+cloud fn update my-func --env API_KEY=@my-api-key --env DB_PASSWORD=@db-secret
+```
+
+The `@secretname` syntax resolves the secret at invocation time (not at update time). This means:
+- Secrets are never stored as plain text in the database
+- You can rotate secrets in the SecretService without updating the function
+- If a secret cannot be resolved, the env var is skipped and a warning is logged
+
+The resolved secret is injected as a JSON object:
+```
+API_KEY={"key":"API_KEY","value":"s3cr3t"}
+```
+
+Your function code can parse this:
+```javascript
+const apiKeyObj = JSON.parse(process.env.API_KEY);
+console.log(apiKeyObj.value); // s3cr3t
+```
+
+**Note:** Plain-text env vars (`--env FOO=bar`) and secret refs (`--env FOO=@my-secret`) cannot be mixed on the same env var entry — each entry must be one or the other.
 
 ### Available Update Options
 

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -281,7 +281,7 @@ func InitServices(c ServiceConfig) (*Services, *Workers, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to init secret service: %w", err)
 	}
-	fnSvc := services.NewFunctionService(c.Repos.Function, rbacSvc, c.Compute, fileStore, auditSvc, c.Logger)
+	fnSvc := services.NewFunctionService(c.Repos.Function, rbacSvc, c.Compute, fileStore, auditSvc, secretSvc, c.Logger)
 	fnSchedSvc := services.NewFunctionScheduleService(c.Repos.FunctionSchedule, c.Repos.Function, rbacSvc, eventSvc, auditSvc, c.Logger)
 	cacheSvc := services.NewCacheService(c.Repos.Cache, rbacSvc, c.Compute, c.Repos.Vpc, eventSvc, auditSvc, c.Logger)
 	queueSvc := services.NewQueueService(c.Repos.Queue, rbacSvc, eventSvc, auditSvc, c.Logger)

--- a/internal/core/domain/function.go
+++ b/internal/core/domain/function.go
@@ -9,9 +9,11 @@ import (
 )
 
 // EnvVar represents a key-value environment variable for a function.
+// Value and SecretRef are mutually exclusive — at least one must be set when an EnvVar is provided.
 type EnvVar struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key       string `json:"key"`
+	Value     string `json:"value,omitempty"`
+	SecretRef string `json:"secret_ref,omitempty"` // reference to a Secret, e.g. "@my-api-key"
 }
 
 // FunctionUpdate describes fields that can be updated on a function.
@@ -34,6 +36,14 @@ func (u *FunctionUpdate) Validate() error {
 	}
 	if u.MemoryMB != nil && (*u.MemoryMB < 64 || *u.MemoryMB > 10240) {
 		return errors.New(errors.InvalidInput, "memory must be between 64 and 10240 MB")
+	}
+	for _, e := range u.EnvVars {
+		if e.Value != "" && e.SecretRef != "" {
+			return errors.New(errors.InvalidInput, "env var cannot have both value and secret_ref")
+		}
+		if e.Value == "" && e.SecretRef == "" {
+			return errors.New(errors.InvalidInput, "env var must have either value or secret_ref")
+		}
 	}
 	return nil
 }

--- a/internal/core/domain/function_test.go
+++ b/internal/core/domain/function_test.go
@@ -1,0 +1,90 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFunctionUpdate_Validate(t *testing.T) {
+	t.Run("timeout_too_low", func(t *testing.T) {
+		timeout := 0
+		err := (&FunctionUpdate{Timeout: &timeout}).Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "timeout")
+	})
+
+	t.Run("timeout_too_high", func(t *testing.T) {
+		timeout := 901
+		err := (&FunctionUpdate{Timeout: &timeout}).Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "timeout")
+	})
+
+	t.Run("memory_too_low", func(t *testing.T) {
+		mem := 32
+		err := (&FunctionUpdate{MemoryMB: &mem}).Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "memory")
+	})
+
+	t.Run("memory_too_high", func(t *testing.T) {
+		mem := 10241
+		err := (&FunctionUpdate{MemoryMB: &mem}).Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "memory")
+	})
+
+	t.Run("valid_timeout_and_memory", func(t *testing.T) {
+		timeout := 300
+		mem := 256
+		err := (&FunctionUpdate{Timeout: &timeout, MemoryMB: &mem}).Validate()
+		assert.Nil(t, err)
+	})
+
+	t.Run("env_var_both_value_and_secret_ref", func(t *testing.T) {
+		u := &FunctionUpdate{
+			EnvVars: []*EnvVar{{Key: "API_KEY", Value: "plain", SecretRef: "@secret"}},
+		}
+		err := u.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot have both")
+	})
+
+	t.Run("env_var_neither_value_nor_secret_ref", func(t *testing.T) {
+		u := &FunctionUpdate{
+			EnvVars: []*EnvVar{{Key: "API_KEY"}},
+		}
+		err := u.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "either value or secret_ref")
+	})
+
+	t.Run("env_var_only_value", func(t *testing.T) {
+		u := &FunctionUpdate{
+			EnvVars: []*EnvVar{{Key: "FOO", Value: "bar"}},
+		}
+		err := u.Validate()
+		assert.Nil(t, err)
+	})
+
+	t.Run("env_var_only_secret_ref", func(t *testing.T) {
+		u := &FunctionUpdate{
+			EnvVars: []*EnvVar{{Key: "API_KEY", SecretRef: "@my-secret"}},
+		}
+		err := u.Validate()
+		assert.Nil(t, err)
+	})
+
+	t.Run("env_var_mixed_one_invalid", func(t *testing.T) {
+		u := &FunctionUpdate{
+			EnvVars: []*EnvVar{
+				{Key: "FOO", Value: "bar"},
+				{Key: "BAR"}, // missing both value and secret_ref
+			},
+		}
+		err := u.Validate()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "either value or secret_ref")
+	})
+}

--- a/internal/core/domain/function_test.go
+++ b/internal/core/domain/function_test.go
@@ -4,34 +4,35 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestFunctionUpdate_Validate(t *testing.T) {
+func TestFunctionUpdateValidate(t *testing.T) {
 	t.Run("timeout_too_low", func(t *testing.T) {
 		timeout := 0
 		err := (&FunctionUpdate{Timeout: &timeout}).Validate()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "timeout")
 	})
 
 	t.Run("timeout_too_high", func(t *testing.T) {
 		timeout := 901
 		err := (&FunctionUpdate{Timeout: &timeout}).Validate()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "timeout")
 	})
 
 	t.Run("memory_too_low", func(t *testing.T) {
 		mem := 32
 		err := (&FunctionUpdate{MemoryMB: &mem}).Validate()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "memory")
 	})
 
 	t.Run("memory_too_high", func(t *testing.T) {
 		mem := 10241
 		err := (&FunctionUpdate{MemoryMB: &mem}).Validate()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "memory")
 	})
 
@@ -39,7 +40,7 @@ func TestFunctionUpdate_Validate(t *testing.T) {
 		timeout := 300
 		mem := 256
 		err := (&FunctionUpdate{Timeout: &timeout, MemoryMB: &mem}).Validate()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("env_var_both_value_and_secret_ref", func(t *testing.T) {
@@ -47,7 +48,7 @@ func TestFunctionUpdate_Validate(t *testing.T) {
 			EnvVars: []*EnvVar{{Key: "API_KEY", Value: "plain", SecretRef: "@secret"}},
 		}
 		err := u.Validate()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot have both")
 	})
 
@@ -56,7 +57,7 @@ func TestFunctionUpdate_Validate(t *testing.T) {
 			EnvVars: []*EnvVar{{Key: "API_KEY"}},
 		}
 		err := u.Validate()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "either value or secret_ref")
 	})
 
@@ -65,7 +66,7 @@ func TestFunctionUpdate_Validate(t *testing.T) {
 			EnvVars: []*EnvVar{{Key: "FOO", Value: "bar"}},
 		}
 		err := u.Validate()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("env_var_only_secret_ref", func(t *testing.T) {
@@ -73,7 +74,7 @@ func TestFunctionUpdate_Validate(t *testing.T) {
 			EnvVars: []*EnvVar{{Key: "API_KEY", SecretRef: "@my-secret"}},
 		}
 		err := u.Validate()
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 	})
 
 	t.Run("env_var_mixed_one_invalid", func(t *testing.T) {
@@ -84,7 +85,7 @@ func TestFunctionUpdate_Validate(t *testing.T) {
 			},
 		}
 		err := u.Validate()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "either value or secret_ref")
 	})
 }

--- a/internal/core/services/benchmarks_test.go
+++ b/internal/core/services/benchmarks_test.go
@@ -130,9 +130,10 @@ func BenchmarkFunctionServiceInvoke(b *testing.B) {
 	fileStore := &noop.NoopFileStore{}
 	auditSvc := &noop.NoopAuditService{}
 	rbacSvc := &noop.NoopRBACService{}
+	secretSvc := &noop.NoopSecretService{}
 	logger := slog.Default()
 
-	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, logger)
+	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, secretSvc, logger)
 
 	ctx := context.Background()
 	id := uuid.New()
@@ -450,9 +451,10 @@ func BenchmarkFunctionServiceList(b *testing.B) {
 	fileStore := &noop.NoopFileStore{}
 	auditSvc := &noop.NoopAuditService{}
 	rbacSvc := &noop.NoopRBACService{}
+	secretSvc := &noop.NoopSecretService{}
 	logger := slog.Default()
 
-	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, logger)
+	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, secretSvc, logger)
 
 	ctx := context.Background()
 

--- a/internal/core/services/database_integration_test.go
+++ b/internal/core/services/database_integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/repositories/noop"
 	"github.com/poyrazk/thecloud/internal/repositories/postgres"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +40,7 @@ func setupDatabaseServiceTest(t *testing.T) (ports.DatabaseService, ports.Databa
 
 	eventRepo := postgres.NewEventRepository(db)
 
-	rbacSvc := new(MockRBACService) 
+	rbacSvc := new(MockRBACService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	auditRepo := postgres.NewAuditRepository(db)
 	eventSvc := services.NewEventService(services.EventServiceParams{Repo: eventRepo, RBACSvc: rbacSvc, Logger: slog.Default()})
@@ -47,7 +48,7 @@ func setupDatabaseServiceTest(t *testing.T) (ports.DatabaseService, ports.Databa
 
 	volRepo := postgres.NewVolumeRepository(db)
 	storage := noop.NewNoopStorageBackendAdapter()
-	volumeSvc := services.NewVolumeService(volRepo, storage, eventSvc, auditSvc, slog.Default())
+	volumeSvc := services.NewVolumeService(services.VolumeServiceParams{Repo: volRepo, Storage: storage, EventSvc: eventSvc, AuditSvc: auditSvc, Logger: slog.Default()})
 
 	logger := slog.Default()
 

--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"encoding/json"
 	stdlib_errors "errors"
 	"fmt"
 	"io"
@@ -44,17 +45,19 @@ type FunctionService struct {
 	compute   ports.ComputeBackend
 	fileStore ports.FileStore
 	auditSvc  ports.AuditService
+	secretSvc ports.SecretService
 	logger    *slog.Logger
 }
 
 // NewFunctionService constructs a FunctionService with its dependencies.
-func NewFunctionService(repo ports.FunctionRepository, rbacSvc ports.RBACService, compute ports.ComputeBackend, fileStore ports.FileStore, auditSvc ports.AuditService, logger *slog.Logger) *FunctionService {
+func NewFunctionService(repo ports.FunctionRepository, rbacSvc ports.RBACService, compute ports.ComputeBackend, fileStore ports.FileStore, auditSvc ports.AuditService, secretSvc ports.SecretService, logger *slog.Logger) *FunctionService {
 	return &FunctionService{
 		repo:      repo,
 		rbacSvc:   rbacSvc,
 		compute:   compute,
 		fileStore: fileStore,
 		auditSvc:  auditSvc,
+		secretSvc: secretSvc,
 		logger:    logger,
 	}
 }
@@ -258,7 +261,7 @@ func (s *FunctionService) runInvocation(ctx context.Context, f *domain.Function,
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
-	opts := s.buildTaskOptions(f, tmpDir, payload)
+	opts := s.buildTaskOptions(ctx, f, tmpDir, payload)
 
 	containerID, _, err := s.compute.RunTask(ctx, opts)
 	if err != nil {
@@ -276,7 +279,7 @@ func (s *FunctionService) runInvocation(ctx context.Context, f *domain.Function,
 	return i, nil
 }
 
-func (s *FunctionService) buildTaskOptions(f *domain.Function, tmpDir string, payload []byte) ports.RunTaskOptions {
+func (s *FunctionService) buildTaskOptions(ctx context.Context, f *domain.Function, tmpDir string, payload []byte) ports.RunTaskOptions {
 	config := runtimes[f.Runtime]
 	pidsLimit := int64(50)
 
@@ -284,7 +287,20 @@ func (s *FunctionService) buildTaskOptions(f *domain.Function, tmpDir string, pa
 
 	env := []string{fmt.Sprintf("PAYLOAD=%s", string(payload))}
 	for _, e := range f.EnvVars {
-		env = append(env, e.Key+"="+e.Value)
+		if e.SecretRef != "" {
+			// Resolve secret reference at invocation time (dynamic)
+			name := strings.TrimPrefix(e.SecretRef, "@")
+			secret, err := s.secretSvc.GetSecretByName(ctx, name)
+			if err != nil {
+				s.logger.Warn("failed to resolve secret", "ref", e.SecretRef, "key", e.Key, "error", err)
+				continue // skip rather than failing the invocation
+			}
+			// Inject as JSON object: {"key": "...", "value": "..."}
+			secretJSON, _ := json.Marshal(map[string]string{"key": e.Key, "value": secret.EncryptedValue})
+			env = append(env, e.Key+"="+string(secretJSON))
+		} else {
+			env = append(env, e.Key+"="+e.Value)
+		}
 	}
 
 	return ports.RunTaskOptions{

--- a/internal/core/services/function_internal_test.go
+++ b/internal/core/services/function_internal_test.go
@@ -4,15 +4,49 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// testSecretSvc is a test double for SecretService.
+type testSecretSvc struct {
+	val string
+	err error
+}
+
+func (t *testSecretSvc) CreateSecret(ctx context.Context, name, value, desc string) (*domain.Secret, error) {
+	return &domain.Secret{ID: uuid.New(), Name: name}, nil
+}
+func (t *testSecretSvc) GetSecret(ctx context.Context, id uuid.UUID) (*domain.Secret, error) {
+	return &domain.Secret{ID: id}, nil
+}
+func (t *testSecretSvc) GetSecretByName(ctx context.Context, name string) (*domain.Secret, error) {
+	if t.err != nil {
+		return nil, t.err
+	}
+	return &domain.Secret{ID: uuid.New(), Name: name, EncryptedValue: t.val}, nil
+}
+func (t *testSecretSvc) ListSecrets(ctx context.Context) ([]*domain.Secret, error)  { return nil, nil }
+func (t *testSecretSvc) DeleteSecret(ctx context.Context, id uuid.UUID) error    { return nil }
+func (t *testSecretSvc) Encrypt(ctx context.Context, userID uuid.UUID, plain string) (string, error) {
+	return plain, nil
+}
+func (t *testSecretSvc) Decrypt(ctx context.Context, userID uuid.UUID, cipher string) (string, error) {
+	return cipher, nil
+}
+
+// compile-time check that testSecretSvc satisfies ports.SecretService
+var _ ports.SecretService = (*testSecretSvc)(nil)
 
 func TestFunctionService_InternalExtract(t *testing.T) {
 	s := &FunctionService{logger: slog.Default()}
@@ -47,20 +81,69 @@ func TestFunctionService_InternalExtract(t *testing.T) {
 }
 
 func TestFunctionService_BuildTaskOptions(t *testing.T) {
-	s := &FunctionService{}
-	f := &domain.Function{
-		Runtime:  "nodejs20",
-		Handler:  "index.handler",
-		MemoryMB: 256,
-	}
-	tmpDir := "/tmp/fn-123"
-	payload := []byte(`{"foo":"bar"}`)
+	t.Run("basic", func(t *testing.T) {
+		s := &FunctionService{logger: slog.Default()}
+		f := &domain.Function{
+			Runtime:  "nodejs20",
+			Handler:  "index.handler",
+			MemoryMB: 256,
+		}
+		tmpDir := "/tmp/fn-123"
+		payload := []byte(`{"foo":"bar"}`)
 
-	opts := s.buildTaskOptions(context.Background(), f, tmpDir, payload)
-	assert.Equal(t, "node:20-alpine", opts.Image)
-	assert.Equal(t, []string{"node", "./index.handler"}, opts.Command)
-	assert.Contains(t, opts.Env[0], "PAYLOAD=")
-	assert.Equal(t, int64(256), opts.MemoryMB)
+		opts := s.buildTaskOptions(context.Background(), f, tmpDir, payload)
+		assert.Equal(t, "node:20-alpine", opts.Image)
+		assert.Equal(t, []string{"node", "./index.handler"}, opts.Command)
+		assert.Contains(t, opts.Env[0], "PAYLOAD=")
+		assert.Equal(t, int64(256), opts.MemoryMB)
+	})
+
+	t.Run("withSecretRef", func(t *testing.T) {
+		secretSvc := &testSecretSvc{val: "s3cr3t"}
+		s := &FunctionService{
+			secretSvc: secretSvc,
+			logger:    slog.Default(),
+		}
+		f := &domain.Function{
+			Runtime:  "nodejs20",
+			Handler:  "index.handler",
+			MemoryMB: 256,
+			EnvVars:  []*domain.EnvVar{{Key: "API_KEY", SecretRef: "@my-secret"}},
+		}
+
+		opts := s.buildTaskOptions(context.Background(), f, "/tmp/test", []byte("{}"))
+
+		var apiKeyEnv string
+		for _, e := range opts.Env {
+			if strings.HasPrefix(e, "API_KEY=") {
+				apiKeyEnv = e
+				break
+			}
+		}
+		assert.NotEmpty(t, apiKeyEnv)
+		assert.Contains(t, apiKeyEnv, `"key":"API_KEY"`)
+		assert.Contains(t, apiKeyEnv, `"value":"s3cr3t"`)
+	})
+
+	t.Run("secretResolutionFailure", func(t *testing.T) {
+		secretSvc := &testSecretSvc{err: errors.New("secret not found")}
+		s := &FunctionService{
+			secretSvc: secretSvc,
+			logger:    slog.Default(),
+		}
+		f := &domain.Function{
+			Runtime:  "nodejs20",
+			Handler:  "index.handler",
+			MemoryMB: 256,
+			EnvVars:  []*domain.EnvVar{{Key: "API_KEY", SecretRef: "@missing"}},
+		}
+
+		opts := s.buildTaskOptions(context.Background(), f, "/tmp/test", []byte("{}"))
+
+		for _, e := range opts.Env {
+			assert.NotContains(t, e, "API_KEY")
+		}
+	})
 }
 
 func TestFunctionService_NormalizeHandler(t *testing.T) {

--- a/internal/core/services/function_internal_test.go
+++ b/internal/core/services/function_internal_test.go
@@ -3,6 +3,7 @@ package services
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -55,7 +56,7 @@ func TestFunctionService_BuildTaskOptions(t *testing.T) {
 	tmpDir := "/tmp/fn-123"
 	payload := []byte(`{"foo":"bar"}`)
 
-	opts := s.buildTaskOptions(f, tmpDir, payload)
+	opts := s.buildTaskOptions(context.Background(), f, tmpDir, payload)
 	assert.Equal(t, "node:20-alpine", opts.Image)
 	assert.Equal(t, []string{"node", "./index.handler"}, opts.Command)
 	assert.Contains(t, opts.Env[0], "PAYLOAD=")

--- a/internal/core/services/function_test.go
+++ b/internal/core/services/function_test.go
@@ -26,13 +26,14 @@ import (
 
 const indexJSMockFile = "index.js"
 
-func setupFunctionServiceTest(t *testing.T) (*services.FunctionService, ports.FunctionRepository, context.Context) {
+func setupFunctionServiceTest(t *testing.T) (*services.FunctionService, ports.FunctionRepository, ports.SecretService, context.Context) {
 	t.Helper()
 	db := setupDB(t)
 	cleanDB(t, db)
 	ctx := setupTestUser(t, db)
 
 	repo := postgres.NewFunctionRepository(db)
+	secretRepo := postgres.NewSecretRepository(db)
 
 	compute, err := docker.NewDockerAdapter(slog.Default())
 	require.NoError(t, err)
@@ -50,11 +51,29 @@ func setupFunctionServiceTest(t *testing.T) (*services.FunctionService, ports.Fu
 		RBACSvc: rbacSvc,
 	})
 
+	eventRepo := postgres.NewEventRepository(db)
+	eventSvc := services.NewEventService(services.EventServiceParams{
+		Repo:    eventRepo,
+		RBACSvc: rbacSvc,
+	})
+
+	masterKey := "test-master-key-32-chars-long-!!!"
+	secretSvc, err := services.NewSecretService(services.SecretServiceParams{
+		Repo:        secretRepo,
+		RBACSvc:     rbacSvc,
+		EventSvc:    eventSvc,
+		AuditSvc:    auditSvc,
+		Logger:      slog.Default(),
+		MasterKey:   masterKey,
+		Environment: "test",
+	})
+	require.NoError(t, err)
+
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, logger)
+	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, secretSvc, logger)
 
-	return svc, repo, ctx
+	return svc, repo, secretSvc, ctx
 }
 
 
@@ -72,7 +91,7 @@ func createZip(t *testing.T, content string) []byte {
 }
 
 func TestFunctionServiceCreateFunctionSuccess(t *testing.T) {
-	svc, repo, ctx := setupFunctionServiceTest(t)
+	svc, repo, _, ctx := setupFunctionServiceTest(t)
 	userID := appcontext.UserIDFromContext(ctx)
 
 	name := "test-func"
@@ -97,7 +116,7 @@ func TestFunctionServiceCreateFunctionSuccess(t *testing.T) {
 func TestFunctionServiceInvokeFunctionSuccess(t *testing.T) {
 	// Skip if we don't want to actually run docker in all environments,
 	// but here we are aiming for real integration.
-	svc, _, ctx := setupFunctionServiceTest(t)
+	svc, _, _, ctx := setupFunctionServiceTest(t)
 
 	code := createZip(t, `
 const payload = process.env.PAYLOAD;
@@ -116,7 +135,7 @@ process.exit(0);
 }
 
 func TestFunctionServiceDeleteFunctionSuccess(t *testing.T) {
-	svc, repo, ctx := setupFunctionServiceTest(t)
+	svc, repo, _, ctx := setupFunctionServiceTest(t)
 
 	code := createZip(t, "console.log(1)")
 	f, _ := svc.CreateFunction(ctx, "to-delete", "nodejs20", indexJSMockFile, code)
@@ -130,7 +149,7 @@ func TestFunctionServiceDeleteFunctionSuccess(t *testing.T) {
 }
 
 func TestFunctionServiceListFunctions(t *testing.T) {
-	svc, _, ctx := setupFunctionServiceTest(t)
+	svc, _, _, ctx := setupFunctionServiceTest(t)
 	code := createZip(t, "1")
 	_, _ = svc.CreateFunction(ctx, "fn1", "nodejs20", indexJSMockFile, code)
 	_, _ = svc.CreateFunction(ctx, "fn2", "nodejs20", indexJSMockFile, code)
@@ -141,7 +160,7 @@ func TestFunctionServiceListFunctions(t *testing.T) {
 }
 
 func TestFunctionServiceGetFunction(t *testing.T) {
-	svc, _, ctx := setupFunctionServiceTest(t)
+	svc, _, _, ctx := setupFunctionServiceTest(t)
 	code := createZip(t, "1")
 	f, _ := svc.CreateFunction(ctx, "get-me", "nodejs20", indexJSMockFile, code)
 
@@ -151,7 +170,7 @@ func TestFunctionServiceGetFunction(t *testing.T) {
 }
 
 func TestFunctionServiceInvokeAsync(t *testing.T) {
-	svc, repo, ctx := setupFunctionServiceTest(t)
+	svc, repo, _, ctx := setupFunctionServiceTest(t)
 	code := createZip(t, "console.log('async')")
 	f, _ := svc.CreateFunction(ctx, "async-test", "nodejs20", indexJSMockFile, code)
 
@@ -175,7 +194,7 @@ func TestFunctionServiceInvokeAsync(t *testing.T) {
 }
 
 func TestFunctionServiceZipSlipProtection(t *testing.T) {
-	svc, _, ctx := setupFunctionServiceTest(t)
+	svc, _, _, ctx := setupFunctionServiceTest(t)
 
 	// Create malicious zip
 	buf := new(bytes.Buffer)
@@ -191,4 +210,124 @@ func TestFunctionServiceZipSlipProtection(t *testing.T) {
 	assert.NotNil(t, inv)
 	assert.Equal(t, "FAILED", inv.Status)
 	assert.Contains(t, inv.Logs, "invalid file path in zip")
+}
+
+func TestFunctionServiceSecretEnvVarIntegration(t *testing.T) {
+	svc, _, secretSvc, ctx := setupFunctionServiceTest(t)
+
+	// Create a secret to reference
+	secret, err := secretSvc.CreateSecret(ctx, "my-api-key", "s3cr3t-value", "test secret")
+	require.NoError(t, err)
+
+	t.Run("plainTextEnvVar", func(t *testing.T) {
+		code := createZip(t, `
+console.log("ENV_FOO=" + process.env.FOO);
+process.exit(0);
+`)
+		f, err := svc.CreateFunction(ctx, "env-plain", "nodejs20", indexJSMockFile, code)
+		require.NoError(t, err)
+
+		// Update with plain text env var
+		timeout := 300
+		mem := 256
+		_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{
+			EnvVars:  []*domain.EnvVar{{Key: "FOO", Value: "bar"}},
+			Timeout:  &timeout,
+			MemoryMB: &mem,
+		})
+		require.NoError(t, err)
+
+		// Invoke and verify
+		inv, err := svc.InvokeFunction(ctx, f.ID, []byte("{}"), false)
+		require.NoError(t, err)
+		assert.Equal(t, "SUCCESS", inv.Status)
+		assert.Contains(t, inv.Logs, "ENV_FOO=bar")
+	})
+
+	t.Run("secretRefEnvVar", func(t *testing.T) {
+		code := createZip(t, `
+const foo = JSON.parse(process.env.FOO || '{}');
+console.log("KEY=" + foo.key);
+console.log("VAL=" + foo.value);
+process.exit(0);
+`)
+		f, err := svc.CreateFunction(ctx, "env-secret", "nodejs20", indexJSMockFile, code)
+		require.NoError(t, err)
+
+		// Update with secret ref
+		timeout := 300
+		mem := 256
+		_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{
+			EnvVars:  []*domain.EnvVar{{Key: "FOO", SecretRef: "@my-api-key"}},
+			Timeout:  &timeout,
+			MemoryMB: &mem,
+		})
+		require.NoError(t, err)
+
+		// Invoke and verify JSON injection format
+		inv, err := svc.InvokeFunction(ctx, f.ID, []byte("{}"), false)
+		require.NoError(t, err)
+		assert.Equal(t, "SUCCESS", inv.Status)
+		assert.Contains(t, inv.Logs, `"key":"FOO"`)
+		assert.Contains(t, inv.Logs, `"value":"s3cr3t-value"`)
+	})
+
+	t.Run("secretRefMissing_skipsEnvVar", func(t *testing.T) {
+		code := createZip(t, `
+console.log("HAS_BAZ=" + (process.env.BAZ !== undefined));
+process.exit(0);
+`)
+		f, err := svc.CreateFunction(ctx, "env-missing-secret", "nodejs20", indexJSMockFile, code)
+		require.NoError(t, err)
+
+		// Update with reference to non-existent secret
+		timeout := 300
+		mem := 256
+		_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{
+			EnvVars:  []*domain.EnvVar{{Key: "BAZ", SecretRef: "@nonexistent-secret"}},
+			Timeout:  &timeout,
+			MemoryMB: &mem,
+		})
+		require.NoError(t, err)
+
+		// Invoke — missing secret should be skipped, BAZ not set
+		inv, err := svc.InvokeFunction(ctx, f.ID, []byte("{}"), false)
+		require.NoError(t, err)
+		assert.Equal(t, "SUCCESS", inv.Status)
+		assert.Contains(t, inv.Logs, "HAS_BAZ=false")
+	})
+
+	t.Run("mixedPlainTextAndSecretRef", func(t *testing.T) {
+		code := createZip(t, `
+const foo = JSON.parse(process.env.FOO || '{}');
+const bar = process.env.BAR;
+console.log("KEY=" + foo.key);
+console.log("VAL=" + foo.value);
+console.log("BAR=" + bar);
+process.exit(0);
+`)
+		f, err := svc.CreateFunction(ctx, "env-mixed", "nodejs20", indexJSMockFile, code)
+		require.NoError(t, err)
+
+		timeout := 300
+		mem := 256
+		_, err = svc.UpdateFunction(ctx, f.ID, &domain.FunctionUpdate{
+			EnvVars: []*domain.EnvVar{
+				{Key: "FOO", SecretRef: "@my-api-key"},
+				{Key: "BAR", Value: "plain-value"},
+			},
+			Timeout:  &timeout,
+			MemoryMB: &mem,
+		})
+		require.NoError(t, err)
+
+		inv, err := svc.InvokeFunction(ctx, f.ID, []byte("{}"), false)
+		require.NoError(t, err)
+		assert.Equal(t, "SUCCESS", inv.Status)
+		assert.Contains(t, inv.Logs, `"key":"FOO"`)
+		assert.Contains(t, inv.Logs, `"value":"s3cr3t-value"`)
+		assert.Contains(t, inv.Logs, "BAR=plain-value")
+	})
+
+	_ = secret // used in secretRefEnvVar
 }

--- a/internal/core/services/function_test.go
+++ b/internal/core/services/function_test.go
@@ -215,8 +215,8 @@ func TestFunctionServiceZipSlipProtection(t *testing.T) {
 func TestFunctionServiceSecretEnvVarIntegration(t *testing.T) {
 	svc, _, secretSvc, ctx := setupFunctionServiceTest(t)
 
-	// Create a secret to reference
-	secret, err := secretSvc.CreateSecret(ctx, "my-api-key", "s3cr3t-value", "test secret")
+	// Create a secret to reference (resolved by name in sub-tests)
+	_, err := secretSvc.CreateSecret(ctx, "my-api-key", "s3cr3t-value", "test secret")
 	require.NoError(t, err)
 
 	t.Run("plainTextEnvVar", func(t *testing.T) {
@@ -328,6 +328,4 @@ process.exit(0);
 		assert.Contains(t, inv.Logs, `"value":"s3cr3t-value"`)
 		assert.Contains(t, inv.Logs, "BAR=plain-value")
 	})
-
-	_ = secret // used in secretRefEnvVar
 }

--- a/internal/core/services/function_unit_test.go
+++ b/internal/core/services/function_unit_test.go
@@ -32,9 +32,10 @@ func testFunctionServiceBasicOps(t *testing.T) {
 	fileStore := new(MockFileStore)
 	auditSvc := new(MockAuditService)
 	rbacSvc := new(MockRBACService)
+	secretSvc := new(MockSecretService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, slog.Default())
+	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, secretSvc, slog.Default())
 
 	ctx := context.Background()
 	userID := uuid.New()
@@ -87,9 +88,10 @@ func testFunctionServiceCreateFunction(t *testing.T) {
 	fileStore := new(MockFileStore)
 	auditSvc := new(MockAuditService)
 	rbacSvc := new(MockRBACService)
+	secretSvc := new(MockSecretService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, slog.Default())
+	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, secretSvc, slog.Default())
 
 	ctx := appcontext.WithUserID(context.Background(), uuid.New())
 	userID := appcontext.UserIDFromContext(ctx)
@@ -118,9 +120,10 @@ func testFunctionServiceInvokeFunction(t *testing.T) {
 	fileStore := new(MockFileStore)
 	auditSvc := new(MockAuditService)
 	rbacSvc := new(MockRBACService)
+	secretSvc := new(MockSecretService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, slog.Default())
+	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, secretSvc, slog.Default())
 
 	ctx := context.Background()
 	id := uuid.New()
@@ -181,8 +184,9 @@ func testFunctionServiceInvokeFunction(t *testing.T) {
 func testFunctionServiceCreateFunctionUnsupportedRuntime(t *testing.T) {
 	repo := new(MockFunctionRepo)
 	rbacSvc := new(MockRBACService)
+	secretSvc := new(MockSecretService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	svc := services.NewFunctionService(repo, rbacSvc, nil, nil, nil, slog.Default())
+	svc := services.NewFunctionService(repo, rbacSvc, nil, nil, nil, secretSvc, slog.Default())
 	ctx := appcontext.WithUserID(context.Background(), uuid.New())
 
 	_, err := svc.CreateFunction(ctx, "fail", "cobol99", "handler", []byte("code"))
@@ -196,9 +200,10 @@ func testFunctionServiceUpdateFunction(t *testing.T) {
 	fileStore := new(MockFileStore)
 	auditSvc := new(MockAuditService)
 	rbacSvc := new(MockRBACService)
+	secretSvc := new(MockSecretService)
 	rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, slog.Default())
+	svc := services.NewFunctionService(repo, rbacSvc, compute, fileStore, auditSvc, secretSvc, slog.Default())
 
 	ctx := appcontext.WithUserID(context.Background(), uuid.New())
 	id := uuid.New()

--- a/internal/core/services/system_integration_test.go
+++ b/internal/core/services/system_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/poyrazk/thecloud/internal/repositories/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 // SyncTaskQueue for system tests to execute jobs immediately or locally

--- a/pkg/sdk/function.go
+++ b/pkg/sdk/function.go
@@ -26,8 +26,9 @@ type Function struct {
 
 // EnvVar represents a key-value environment variable.
 type EnvVar struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key       string `json:"key"`
+	Value     string `json:"value,omitempty"`
+	SecretRef string `json:"secret_ref,omitempty"`
 }
 
 // FunctionUpdateRequest describes fields that can be updated.


### PR DESCRIPTION
## Summary

Add dynamic secret resolution for CloudFunctions environment variables. Functions can reference secrets stored in the SecretService using `@secretname` syntax — secrets are resolved at invocation time (not stored in DB), enabling rotation without code changes.

## Changes

- **Domain** (`EnvVar`): Add `SecretRef` field; mutual-exclusion validation (`Value` and `SecretRef` cannot both be set)
- **Service** (`FunctionService`): Thread `secretSvc` dependency; `buildTaskOptions` resolves `SecretRef` at invocation time via `GetSecretByName`, injects as JSON `{key, value}`
- **CLI** (`cloud fn update`): Parse `@` prefix in `--env KEY=@secretname` and set `SecretRef`
- **SDK**: `EnvVar` struct updated with `SecretRef` field
- **API**: `FunctionService` constructor updated to accept `secretSvc`

## Test Coverage

- Domain: `FunctionUpdate.Validate` — timeout/memory bounds, mutual-exclusion cases (10 sub-tests)
- Unit: `buildTaskOptions` — basic env, secret ref injection, resolution failure skip (3 sub-tests)
- Integration: full CreateFunction → UpdateFunction → InvokeFunction flow (4 sub-tests)

## Docs

- ADR-025 Section 5: Secret Integration (resolution flow, constraints, alternatives considered)
- `docs/guides/functions.md`: "Using Secrets" section with CLI examples and Node.js JSON parsing sample
- `docs/api-reference.md`: `PATCH /functions/:id` with `secret_ref` field
- `docs/cli-reference.md`: `--env` flag with `@secretname` syntax

## Test plan

- [x] `go test ./internal/core/services/... -short` — unit tests pass
- [ ] CI passes (all workflows)
- [ ] Manual: `cloud fn update my-func --env API_KEY=@my-key && cloud fn invoke my-func` — verify JSON injection in logs