### PR TITLE
fix: prevent panic when nameservers is empty in CreateZone

### DIFF
--- a/internal/adapters/dns/powerdns.go
+++ b/internal/adapters/dns/powerdns.go
@@ -47,6 +47,10 @@ func (b *PowerDNSBackend) ensureTrailingDot(name string) string {
 func (b *PowerDNSBackend) CreateZone(ctx context.Context, zoneName string, nameservers []string) error {
 	zoneName = b.ensureTrailingDot(zoneName)
 
+	if len(nameservers) == 0 {
+		return fmt.Errorf("cannot create zone: nameservers must not be empty")
+	}
+
 	zone := &powerdns.Zone{
 		Name:        powerdns.String(zoneName),
 		Kind:        powerdns.ZoneKindPtr(powerdns.NativeZoneKind),

--- a/internal/adapters/dns/powerdns_test.go
+++ b/internal/adapters/dns/powerdns_test.go
@@ -19,6 +19,20 @@ const (
 	testPDNSZone = "example.com."
 )
 
+func TestPowerDNSCreateZoneEmptyNameservers(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	backend, err := NewPowerDNSBackend("http://localhost", testPDNSKey, "localhost", logger)
+	require.NoError(t, err)
+
+	err = backend.CreateZone(context.Background(), testPDNSZone, []string{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nameservers must not be empty")
+
+	err = backend.CreateZone(context.Background(), testPDNSZone, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nameservers must not be empty")
+}
+
 func TestPowerDNSCreateZone(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, testPDNSKey, r.Header.Get("X-API-Key"))


### PR DESCRIPTION
## Summary
- Add guard clause in `PowerDNSBackend.CreateZone` to return error instead of panicking when `nameservers` slice is nil or empty
- Fixes #334

## Changes
- `internal/adapters/dns/powerdns.go`: Add nil/empty check before accessing `nameservers[0]`
- `internal/adapters/dns/powerdns_test.go`: Add `TestPowerDNSCreateZoneEmptyNameservers` test case

## Test plan
- [x] `go test ./internal/adapters/dns/... -v` passes