### PR TITLE
fix(security): stop logging plaintext password reset tokens

### DIFF
--- a/internal/core/services/password_reset.go
+++ b/internal/core/services/password_reset.go
@@ -75,10 +75,9 @@ func (s *PasswordResetService) RequestReset(ctx context.Context, email string) e
 		return err
 	}
 
-	// Note: EmailService integration is pending.
-	// For MVP/Demo: Log the token so we can test it manually.
-	// Future: Inject and use EmailService here.
-	s.logger.Debug("password reset token", "email", email, "token", token)
+	// TODO: deliver `token` via an injected EmailService once available.
+	// Never log or persist the plaintext token — its only safe destination is the user.
+	s.logger.Info("password reset token issued", "user_id", user.ID, "token_id", resetToken.ID)
 
 	return nil
 }


### PR DESCRIPTION
Removes the Debug log emitting the plaintext password reset token. Replaced with a non-sensitive Info log (user_id + token row id).
  Plaintext token must reach the user via email only.

Closes #293