### PR TITLE
fix(security): sanitize Content-Disposition filename to prevent header injection

### DIFF
--- a/internal/handlers/storage_handler.go
+++ b/internal/handlers/storage_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,80 @@ const (
 	errInvalidUploadID = "invalid upload id"
 	headerContentSha256 = "X-Content-Sha256"
 )
+
+// contentDispositionAttachment builds a safe `Content-Disposition: attachment`
+// header for a stored object.
+//
+// Object keys can contain path segments, non-ASCII characters, control
+// characters, quotes, backslashes, or CRLF that — if interpolated naively —
+// would either corrupt the header (HTTP response splitting) or let an attacker
+// inject additional headers. The output therefore emits two parameters per
+// RFC 6266:
+//
+//   - `filename="..."`     ASCII-only fallback for legacy clients. All bytes
+//                          outside the safe printable range and the two
+//                          characters that are special inside a quoted-string
+//                          (`"` and `\`) are replaced with `_`.
+//   - `filename*=UTF-8''…` RFC 5987 percent-encoded form preserving the
+//                          original Unicode basename for modern clients.
+//
+// `path.Base` is used to discard any path segments embedded in the key. If the
+// resulting name is empty we fall back to "download".
+func contentDispositionAttachment(key string) string {
+	name := path.Base(key)
+	if name == "." || name == "/" || name == "" {
+		name = "download"
+	}
+
+	return fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`,
+		asciiFilenameFallback(name), rfc5987Encode(name))
+}
+
+// asciiFilenameFallback returns an ASCII-only sanitized copy of name suitable
+// for the legacy `filename=` parameter. Any byte that is a control character
+// (<0x20 or 0x7f), non-ASCII (>=0x80), or special inside a quoted-string is
+// replaced with `_` so the value can be safely wrapped in double quotes.
+func asciiFilenameFallback(name string) string {
+	out := make([]byte, 0, len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c < 0x20, c == 0x7f, c >= 0x80, c == '"', c == '\\':
+			out = append(out, '_')
+		default:
+			out = append(out, c)
+		}
+	}
+	if len(out) == 0 {
+		return "download"
+	}
+	return string(out)
+}
+
+// rfc5987Encode percent-encodes a value per RFC 5987 attr-char rules so it can
+// be safely placed in a `filename*` parameter.
+func rfc5987Encode(s string) string {
+	const hex = "0123456789ABCDEF"
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z',
+			c >= 'a' && c <= 'z',
+			c >= '0' && c <= '9',
+			c == '!', c == '#', c == '$', c == '&', c == '+',
+			c == '-', c == '.', c == '^', c == '_', c == '`',
+			c == '|', c == '~':
+			b.WriteByte(c)
+		default:
+			b.WriteByte('%')
+			b.WriteByte(hex[c>>4])
+			b.WriteByte(hex[c&0x0f])
+		}
+	}
+	return b.String()
+}
 
 // Upload uploads an object to a bucket
 // @Summary Upload an object
@@ -105,7 +180,7 @@ func (h *StorageHandler) Download(c *gin.Context) {
 	defer func() { _ = reader.Close() }()
 
 	// Set headers
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", key))
+	c.Header("Content-Disposition", contentDispositionAttachment(key))
 	c.Header("Content-Type", obj.ContentType)
 	c.Header("Content-Length", fmt.Sprintf("%d", obj.SizeBytes))
 
@@ -461,7 +536,7 @@ func (h *StorageHandler) ServePresignedDownload(c *gin.Context) {
 	}
 	defer func() { _ = reader.Close() }()
 
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", key))
+	c.Header("Content-Disposition", contentDispositionAttachment(key))
 	c.Header("Content-Type", obj.ContentType)
 	c.Header("Content-Length", fmt.Sprintf("%d", obj.SizeBytes))
 	_, _ = io.Copy(c.Writer, reader)

--- a/internal/handlers/storage_handler_content_disposition_test.go
+++ b/internal/handlers/storage_handler_content_disposition_test.go
@@ -1,0 +1,86 @@
+package httphandlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContentDispositionAttachment(t *testing.T) {
+	cases := []struct {
+		name           string
+		key            string
+		wantFilename   string
+		wantFilenameStar string
+	}{
+		{
+			name:             "simple ascii filename",
+			key:              "report.pdf",
+			wantFilename:     `filename="report.pdf"`,
+			wantFilenameStar: `filename*=UTF-8''report.pdf`,
+		},
+		{
+			name:             "nested key uses basename",
+			key:              "exports/2026/q1/report.pdf",
+			wantFilename:     `filename="report.pdf"`,
+			wantFilenameStar: `filename*=UTF-8''report.pdf`,
+		},
+		{
+			name:             "CRLF response splitting attempt is sanitized",
+			key:              "evil\r\nSet-Cookie: pwned=1",
+			wantFilename:     `filename="evil__Set-Cookie: pwned=1"`,
+			wantFilenameStar: `filename*=UTF-8''evil%0D%0ASet-Cookie%3A%20pwned%3D1`,
+		},
+		{
+			name:             "embedded quote and backslash are sanitized",
+			key:              `bad"name\file.txt`,
+			wantFilename:     `filename="bad_name_file.txt"`,
+			wantFilenameStar: `filename*=UTF-8''bad%22name%5Cfile.txt`,
+		},
+		{
+			name:             "non-ASCII falls back in legacy filename, preserved in filename*",
+			key:              "résumé.pdf",
+			wantFilename:     `filename="r__sum__.pdf"`, // 2 bytes per accented char both replaced
+			wantFilenameStar: `filename*=UTF-8''r%C3%A9sum%C3%A9.pdf`,
+		},
+		{
+			name:             "empty key falls back to download",
+			key:              "",
+			wantFilename:     `filename="download"`,
+			wantFilenameStar: `filename*=UTF-8''download`,
+		},
+		{
+			name:             "trailing slash falls back to download",
+			key:              "folder/",
+			wantFilename:     `filename="folder"`, // path.Base normalizes
+			wantFilenameStar: `filename*=UTF-8''folder`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := contentDispositionAttachment(tc.key)
+			if !strings.HasPrefix(got, "attachment; ") {
+				t.Errorf("missing attachment prefix: %q", got)
+			}
+			if !strings.Contains(got, tc.wantFilename) {
+				t.Errorf("missing legacy filename param\n got:  %q\n want: %q", got, tc.wantFilename)
+			}
+			if !strings.Contains(got, tc.wantFilenameStar) {
+				t.Errorf("missing filename* param\n got:  %q\n want: %q", got, tc.wantFilenameStar)
+			}
+			if strings.ContainsAny(got, "\r\n") {
+				t.Errorf("output must not contain CR/LF: %q", got)
+			}
+		})
+	}
+}
+
+func TestContentDispositionAttachment_NoCRLFEverEscapes(t *testing.T) {
+	for _, c := range []byte{'\r', '\n', 0, 0x1f, 0x7f} {
+		key := "x" + string(c) + "y"
+		got := contentDispositionAttachment(key)
+		if strings.ContainsAny(got, "\r\n") {
+			t.Fatalf("control byte 0x%02x leaked into header: %q", c, got)
+		}
+	}
+}


### PR DESCRIPTION
Object keys flowed straight into the Content-Disposition header via
fmt.Sprintf("attachment; filename=%s", key), so any key containing CRLF,
double quotes, or backslashes could split the response or inject
arbitrary headers. Path-bearing keys also leaked the full bucket path to
the client as the suggested filename.

Replace both call sites (authenticated download and presigned download)
with a single helper, contentDispositionAttachment, that:

  - reduces the key to its basename via path.Base
  - emits an ASCII-only `filename="..."` fallback with control bytes,
    non-ASCII bytes, quotes, and backslashes mapped to `_`
  - emits the full Unicode basename in `filename*=UTF-8''...` per RFC
    5987 with proper attr-char percent-encoding
  - guarantees CR/LF can never reach the wire

Add table-driven unit tests covering response-splitting, quote/backslash
injection, non-ASCII names, nested keys, and empty keys.

Closes #225, #226
