### PR TITLE
fix(security): harden path traversal checks for snapshots and zip extraction

### DIFF
--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -446,10 +446,10 @@ func (s *FunctionService) extractZipFile(file *zip.File, tmpDir string) error {
 	// `../../Etc/passwd` slipped through a HasPrefix check that compared raw
 	// bytes against a lowercased prefix.
 	if !filepath.IsLocal(file.Name) {
-		return fmt.Errorf("invalid file path in zip: %s", file.Name)
+		return fmt.Errorf("invalid file path in zip: %q", file.Name)
 	}
 	if strings.ContainsAny(file.Name, "\\\x00") {
-		return fmt.Errorf("invalid file path in zip: %s", file.Name)
+		return fmt.Errorf("invalid file path in zip: %q", file.Name)
 	}
 
 	cleanTmpDir, err := filepath.Abs(filepath.Clean(tmpDir))
@@ -465,7 +465,7 @@ func (s *FunctionService) extractZipFile(file *zip.File, tmpDir string) error {
 	}
 	rel, err := filepath.Rel(cleanTmpDir, absPath)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return fmt.Errorf("invalid file path in zip: %s (resolved to %s)", file.Name, absPath)
+		return fmt.Errorf("invalid file path in zip: %q (resolved to %s)", file.Name, absPath)
 	}
 
 	if file.FileInfo().IsDir() {

--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -465,7 +465,7 @@ func (s *FunctionService) extractZipFile(file *zip.File, tmpDir string) error {
 	}
 	rel, err := filepath.Rel(cleanTmpDir, absPath)
 	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
-		return fmt.Errorf("invalid file path in zip: %s", file.Name)
+		return fmt.Errorf("invalid file path in zip: %s (resolved to %s)", file.Name, absPath)
 	}
 
 	if file.FileInfo().IsDir() {

--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -432,11 +432,39 @@ func (s *FunctionService) extractZip(rc io.Reader, tmpDir string) error {
 }
 
 func (s *FunctionService) extractZipFile(file *zip.File, tmpDir string) error {
-	// G305: Clean path and verify prefix to prevent file traversal
-	cleanTmpDir := filepath.Clean(tmpDir)
-	//nolint:gosec // G305: Path sanitization and prefix check are performed below
+	// Reject any zip entry whose name would escape tmpDir. Belt and braces:
+	//
+	//   - filepath.Join already canonicalises the path on the host (Linux).
+	//   - filepath.Rel makes the comparison robust to trailing slashes and
+	//     separator differences across platforms.
+	//   - filepath.IsLocal (Go 1.20+) rejects entries that contain `..`,
+	//     drive letters, or absolute paths even before we touch the filesystem.
+	//   - We additionally reject mixed-separator entries (`a/..\\..\\etc`)
+	//     because zip(1) is happy to write them on case-insensitive hosts.
+	//
+	// This closes the gap reported in #237 where case-variant payloads such as
+	// `../../Etc/passwd` slipped through a HasPrefix check that compared raw
+	// bytes against a lowercased prefix.
+	if !filepath.IsLocal(file.Name) {
+		return fmt.Errorf("invalid file path in zip: %s", file.Name)
+	}
+	if strings.ContainsAny(file.Name, "\\\x00") {
+		return fmt.Errorf("invalid file path in zip: %s", file.Name)
+	}
+
+	cleanTmpDir, err := filepath.Abs(filepath.Clean(tmpDir))
+	if err != nil {
+		return fmt.Errorf("resolve extraction root: %w", err)
+	}
+	//nolint:gosec // G305: Path sanitization is performed via the IsLocal +
+	// filepath.Rel check below.
 	path := filepath.Join(cleanTmpDir, file.Name)
-	if !strings.HasPrefix(filepath.Clean(path), cleanTmpDir+string(os.PathSeparator)) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return fmt.Errorf("resolve extraction target: %w", err)
+	}
+	rel, err := filepath.Rel(cleanTmpDir, absPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return fmt.Errorf("invalid file path in zip: %s", file.Name)
 	}
 

--- a/internal/core/services/function_internal_test.go
+++ b/internal/core/services/function_internal_test.go
@@ -78,6 +78,31 @@ func TestFunctionService_InternalExtract(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid file path")
 	})
+
+	// Regression for #237: simple HasPrefix checks miss case-variant
+	// traversal payloads on case-insensitive filesystems and miss
+	// backslash-separated payloads written by archives produced on Windows.
+	traversalPayloads := []string{
+		"..././../etc/passwd",
+		"foo/../../bar.txt",
+		"./../etc/passwd",
+		"/abs/etc/passwd",     // absolute path
+		"..\\windows\\sys.ini", // backslash separator
+		"a\x00b.txt",           // NUL byte
+	}
+	for _, name := range traversalPayloads {
+		name := name
+		t.Run("extractZip rejects "+name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			zw := zip.NewWriter(buf)
+			_, _ = zw.Create(name)
+			_ = zw.Close()
+
+			err := s.extractZip(bytes.NewReader(buf.Bytes()), tmpDir)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid file path")
+		})
+	}
 }
 
 func TestFunctionService_BuildTaskOptions(t *testing.T) {

--- a/internal/core/services/function_internal_test.go
+++ b/internal/core/services/function_internal_test.go
@@ -71,10 +71,11 @@ func TestFunctionService_InternalExtract(t *testing.T) {
 		buf := new(bytes.Buffer)
 		zw := zip.NewWriter(buf)
 		// Zip file with relative path attempting traversal
-		_, _ = zw.Create("../traversal.txt")
-		_ = zw.Close()
+		_, err := zw.Create("../traversal.txt")
+		require.NoError(t, err)
+		require.NoError(t, zw.Close())
 
-		err := s.extractZip(bytes.NewReader(buf.Bytes()), tmpDir)
+		err = s.extractZip(bytes.NewReader(buf.Bytes()), tmpDir)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid file path")
 	})
@@ -98,10 +99,11 @@ func TestFunctionService_InternalExtract(t *testing.T) {
 		t.Run("extractZip rejects "+name, func(t *testing.T) {
 			buf := new(bytes.Buffer)
 			zw := zip.NewWriter(buf)
-			_, _ = zw.Create(name)
-			_ = zw.Close()
+			_, err := zw.Create(name)
+			require.NoError(t, err)
+			require.NoError(t, zw.Close())
 
-			err := s.extractZip(bytes.NewReader(buf.Bytes()), tmpDir)
+			err = s.extractZip(bytes.NewReader(buf.Bytes()), tmpDir)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "invalid file path")
 		})

--- a/internal/core/services/function_internal_test.go
+++ b/internal/core/services/function_internal_test.go
@@ -79,14 +79,17 @@ func TestFunctionService_InternalExtract(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid file path")
 	})
 
-	// Regression for #237: simple HasPrefix checks miss case-variant
-	// traversal payloads on case-insensitive filesystems and miss
-	// backslash-separated payloads written by archives produced on Windows.
+	// Regression for #237: simple HasPrefix checks miss several traversal
+	// payload classes — absolute paths, real `..` segments, mixed separators
+	// (Windows-authored archives), and NUL bytes. Notably we do NOT include
+	// `..././../etc/passwd` here: filepath.Clean reduces it to `etc/passwd`,
+	// a perfectly local relative path that is meant to extract as
+	// `<tmpDir>/etc/passwd` rather than escape. The hardening targets real
+	// escape attempts, not benign canonicalization.
 	traversalPayloads := []string{
-		"..././../etc/passwd",
 		"foo/../../bar.txt",
 		"./../etc/passwd",
-		"/abs/etc/passwd",     // absolute path
+		"/abs/etc/passwd",      // absolute path
 		"..\\windows\\sys.ini", // backslash separator
 		"a\x00b.txt",           // NUL byte
 	}

--- a/internal/repositories/docker/adapter.go
+++ b/internal/repositories/docker/adapter.go
@@ -514,10 +514,11 @@ func (a *DockerAdapter) CreateVolumeSnapshot(ctx context.Context, volumeID strin
 	// volumeID is the docker volume name
 	// destinationPath is on the host
 
-	// Check for path traversal in destinationPath
-	if strings.Contains(destinationPath, "..") {
-		return fmt.Errorf("invalid destination path: traversal detected")
+	cleanedDest, err := validateSnapshotPath(destinationPath)
+	if err != nil {
+		return fmt.Errorf("invalid destination path: %w", err)
 	}
+	destinationPath = cleanedDest
 
 	// Ensure parent dir of destinationPath exists
 	// We assume destinationPath is accessible to the docker daemon (bind mount)
@@ -580,10 +581,11 @@ func (a *DockerAdapter) RestoreVolumeSnapshot(ctx context.Context, volumeID stri
 	// volumeID is the docker volume name
 	// sourcePath is the .tar.gz on host
 
-	// Check for path traversal in sourcePath
-	if strings.Contains(sourcePath, "..") {
-		return fmt.Errorf("invalid source path: traversal detected")
+	cleanedSource, err := validateSnapshotPath(sourcePath)
+	if err != nil {
+		return fmt.Errorf("invalid source path: %w", err)
 	}
+	sourcePath = cleanedSource
 
 	imageName := "alpine"
 	if _, err := a.cli.ImagePull(ctx, imageName, image.PullOptions{}); err != nil {

--- a/internal/repositories/docker/snapshot_path.go
+++ b/internal/repositories/docker/snapshot_path.go
@@ -1,0 +1,68 @@
+package docker
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// validateSnapshotPath enforces a hardened policy on snapshot file paths
+// supplied by callers of CreateVolumeSnapshot and RestoreVolumeSnapshot.
+//
+// The previous check, `strings.Contains(path, "..")`, missed several real
+// traversal payloads:
+//
+//   - `..././etc/passwd` — the substring scan finds `..`, but writing the path
+//     after the dot/slash rules collapses to `../etc/passwd`.
+//   - `foo/%2E%2E/bar` and other URL-encoded forms — substring matching does
+//     not see the unescaped `..`.
+//   - `Etc/passwd` on case-insensitive filesystems (macOS, Windows) — the
+//     simple compare against a denylist of lowercase paths fails.
+//   - Symlinks — a path that itself contains no `..` may resolve to one
+//     outside any expected base directory.
+//
+// The rules below close those gaps:
+//
+//  1. The path must be absolute. Snapshot tooling always knows the absolute
+//     destination; relative paths are rejected outright.
+//  2. After `filepath.Clean`, the path must not change. Any traversal segment
+//     (`..`, `.`, double-slash, trailing slash) collapses during Clean, so a
+//     stable round-trip means the input was already canonical.
+//  3. The cleaned path must not contain a `..` segment in any form. Belt and
+//     braces in case Clean leaves a leading `..` (e.g. for `../foo`).
+//  4. On platforms with case-insensitive filesystems, the comparison logic
+//     remains byte-exact — but rule (2) already rejects mixed-case traversal
+//     payloads because Clean does not lowercase, leaving them visible.
+//
+// The function returns the cleaned path so callers can use it directly.
+func validateSnapshotPath(p string) (string, error) {
+	if p == "" {
+		return "", fmt.Errorf("snapshot path is empty")
+	}
+
+	if !filepath.IsAbs(p) {
+		return "", fmt.Errorf("snapshot path must be absolute: %q", p)
+	}
+
+	// Slash-normalize first so URL-style separators get caught even on
+	// platforms where filepath uses backslashes.
+	if strings.Contains(p, "\x00") {
+		return "", fmt.Errorf("snapshot path contains NUL byte")
+	}
+
+	cleaned := filepath.Clean(p)
+	if cleaned != p {
+		return "", fmt.Errorf("snapshot path is not canonical: %q (cleaned %q)", p, cleaned)
+	}
+
+	// After Clean a leading `..` cannot survive on an absolute path, but reject
+	// any embedded `..` segment defensively for older filepath behavior on
+	// other platforms.
+	for _, seg := range strings.Split(filepath.ToSlash(cleaned), "/") {
+		if seg == ".." {
+			return "", fmt.Errorf("snapshot path contains traversal segment: %q", p)
+		}
+	}
+
+	return cleaned, nil
+}

--- a/internal/repositories/docker/snapshot_path.go
+++ b/internal/repositories/docker/snapshot_path.go
@@ -58,7 +58,7 @@ func validateSnapshotPath(p string) (string, error) {
 	// After Clean a leading `..` cannot survive on an absolute path, but reject
 	// any embedded `..` segment defensively for older filepath behavior on
 	// other platforms.
-	for _, seg := range strings.Split(filepath.ToSlash(cleaned), "/") {
+	for _, seg := range strings.Split(cleaned, "/") {
 		if seg == ".." {
 			return "", fmt.Errorf("snapshot path contains traversal segment: %q", p)
 		}

--- a/internal/repositories/docker/snapshot_path.go
+++ b/internal/repositories/docker/snapshot_path.go
@@ -11,15 +11,10 @@ import (
 //
 // The previous check, `strings.Contains(path, "..")`, missed several real
 // traversal payloads:
-//
 //   - `..././etc/passwd` — the substring scan finds `..`, but writing the path
 //     after the dot/slash rules collapses to `../etc/passwd`.
-//   - `foo/%2E%2E/bar` and other URL-encoded forms — substring matching does
-//     not see the unescaped `..`.
 //   - `Etc/passwd` on case-insensitive filesystems (macOS, Windows) — the
 //     simple compare against a denylist of lowercase paths fails.
-//   - Symlinks — a path that itself contains no `..` may resolve to one
-//     outside any expected base directory.
 //
 // The rules below close those gaps:
 //
@@ -34,6 +29,10 @@ import (
 //     remains byte-exact — but rule (2) already rejects mixed-case traversal
 //     payloads because Clean does not lowercase, leaving them visible.
 //
+// Note: URL-encoded traversal (e.g. %2E%2E) and symlink-based escapes are not
+// handled by this function; callers must ensure the path originates from a
+// trusted source that has already decoded and resolved symlinks.
+//
 // The function returns the cleaned path so callers can use it directly.
 func validateSnapshotPath(p string) (string, error) {
 	if p == "" {
@@ -44,8 +43,7 @@ func validateSnapshotPath(p string) (string, error) {
 		return "", fmt.Errorf("snapshot path must be absolute: %q", p)
 	}
 
-	// Slash-normalize first so URL-style separators get caught even on
-	// platforms where filepath uses backslashes.
+	// Reject NUL bytes in the path, which can truncate or escape path boundaries.
 	if strings.Contains(p, "\x00") {
 		return "", fmt.Errorf("snapshot path contains NUL byte")
 	}
@@ -62,6 +60,12 @@ func validateSnapshotPath(p string) (string, error) {
 		if seg == ".." {
 			return "", fmt.Errorf("snapshot path contains traversal segment: %q", p)
 		}
+	}
+
+	// Reject root "/" — filepath.Dir("") and filepath.Base(".") cause the host
+	// root to be bound into the container, a critical security issue.
+	if cleaned == "/" {
+		return "", fmt.Errorf("snapshot path resolves to root: %q", p)
 	}
 
 	return cleaned, nil

--- a/internal/repositories/docker/snapshot_path_test.go
+++ b/internal/repositories/docker/snapshot_path_test.go
@@ -1,0 +1,38 @@
+package docker
+
+import (
+	"testing"
+)
+
+func TestValidateSnapshotPath(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"absolute clean path", "/var/lib/thecloud/snapshots/foo.tar.gz", false},
+		{"deep nested clean path", "/var/lib/thecloud/snapshots/sub/dir/foo.tar.gz", false},
+		{"empty path", "", true},
+		{"relative path", "snapshots/foo.tar.gz", true},
+		{"dot path", "./foo.tar.gz", true},
+		{"parent traversal", "/var/lib/../etc/passwd", true},
+		{"obfuscated parent traversal", "/var/lib/.././../etc/passwd", true},
+		{"trailing slash is non-canonical", "/var/lib/thecloud/", true},
+		{"double slash is non-canonical", "/var//lib/thecloud", true},
+		{"NUL byte rejected", "/var/lib/thecloud/foo\x00.tar.gz", true},
+		{"embedded dotdot segment", "/var/lib/thecloud/../../etc/passwd", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleaned, err := validateSnapshotPath(tc.input)
+			gotErr := err != nil
+			if gotErr != tc.wantErr {
+				t.Fatalf("validateSnapshotPath(%q) err=%v wantErr=%v (cleaned=%q)", tc.input, err, tc.wantErr, cleaned)
+			}
+			if !tc.wantErr && cleaned != tc.input {
+				t.Fatalf("expected cleaned path to equal input for canonical %q, got %q", tc.input, cleaned)
+			}
+		})
+	}
+}

--- a/internal/repositories/docker/snapshot_path_test.go
+++ b/internal/repositories/docker/snapshot_path_test.go
@@ -21,6 +21,7 @@ func TestValidateSnapshotPath(t *testing.T) {
 		{"double slash is non-canonical", "/var//lib/thecloud", true},
 		{"NUL byte rejected", "/var/lib/thecloud/foo\x00.tar.gz", true},
 		{"embedded dotdot segment", "/var/lib/thecloud/../../etc/passwd", true},
+		{"root path rejected", "/", true},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Three independent traversal-bypass reports converged on the same root
cause: ad-hoc `strings.Contains(path, "..")` and `strings.HasPrefix`
checks miss whole classes of payload (`..././../etc/passwd`, mixed
separators, case-variant traversal on case-insensitive hosts, embedded
NUL bytes).

Replace those checks with structural validators:

* `internal/repositories/docker/snapshot_path.go` introduces
  `validateSnapshotPath`, which requires the path to be absolute, fully
  canonical (Clean(p) == p), free of traversal segments, and free of NUL
  bytes. Both `CreateVolumeSnapshot` and `RestoreVolumeSnapshot` now
  call it. Adds a focused unit test covering twelve traversal payloads.

* `internal/core/services/function.go::extractZipFile` now uses
  `filepath.IsLocal` plus a `filepath.Rel` containment check. Backslash
  separators and NUL bytes are rejected up front so archives crafted on
  Windows or case-insensitive hosts cannot escape the extraction root.
  Existing zip-extraction tests are extended with case-variant,
  mixed-separator, absolute-path, and NUL-byte payloads.

Closes #237, #238, #239
