### PR TITLE
fix(security): fail-closed WebSocket origin allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,12 @@
 PORT=8080
 APP_ENV=development # development or production
 
+# WebSocket allowlist
+# Comma-separated list of Origin header values allowed to open WS connections.
+# Empty (default) = deny all cross-origin upgrades. Use "*" only for non-
+# credentialed dev endpoints.
+# WS_ALLOWED_ORIGINS=https://console.example.com,https://app.example.com
+
 # Database Configuration
 DB_USER=cloud
 DB_PASSWORD=cloud

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -125,7 +125,7 @@ func InitHandlers(svcs *Services, cfg *platform.Config, logger *slog.Logger) *Ha
 		RouteTable:    httphandlers.NewRouteTableHandler(svcs.RouteTable),
 		InternetGateway: httphandlers.NewInternetGatewayHandler(svcs.InternetGateway),
 		NATGateway:    httphandlers.NewNATGatewayHandler(svcs.NATGateway),
-		Ws:            ws.NewHandler(svcs.WsHub, svcs.Identity, logger),
+		Ws:            ws.NewHandler(svcs.WsHub, svcs.Identity, logger, cfg.WSAllowedOrigins),
 	}
 }
 

--- a/internal/handlers/ws/check_origin_test.go
+++ b/internal/handlers/ws/check_origin_test.go
@@ -21,7 +21,7 @@ func TestCheckOrigin_FailClosed(t *testing.T) {
 		{"explicit origin rejects other", []string{"https://app.example.com"}, "https://evil.example.com", false},
 		{"explicit origin rejects empty", []string{"https://app.example.com"}, "", false},
 		{"wildcard allows any non-empty origin", []string{"*"}, "https://anything.example", true},
-		{"wildcard still rejects empty origin", []string{"*"}, "", false},
+		{"wildcard also allows empty origin (non-browser opt-in)", []string{"*"}, "", true},
 		{"comma-separated list is parsed", []string{"https://a.example,https://b.example"}, "https://b.example", true},
 		{"trims whitespace", []string{"  https://a.example , https://b.example "}, "https://a.example", true},
 		{"case-sensitive match", []string{"https://app.example.com"}, "https://APP.example.com", false},

--- a/internal/handlers/ws/check_origin_test.go
+++ b/internal/handlers/ws/check_origin_test.go
@@ -26,6 +26,8 @@ func TestCheckOrigin_FailClosed(t *testing.T) {
 		{"comma-separated list is parsed", []string{"https://a.example,https://b.example"}, "https://b.example", true},
 		{"trims whitespace", []string{"  https://a.example , https://b.example "}, "https://a.example", true},
 		{"case-sensitive match", []string{"https://app.example.com"}, "https://APP.example.com", false},
+		{"origin with trailing dot rejected", []string{"https://app.example.com"}, "https://app.example.com.", false},
+		{"origin without trailing dot matches", []string{"https://app.example.com"}, "https://app.example.com", true},
 	}
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/internal/handlers/ws/check_origin_test.go
+++ b/internal/handlers/ws/check_origin_test.go
@@ -1,0 +1,50 @@
+package ws
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckOrigin_FailClosed(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		allowedOrigins []string
+		origin         string
+		want           bool
+	}{
+		{"empty allowlist rejects matching origin", nil, "https://app.example.com", false},
+		{"empty allowlist rejects empty origin", nil, "", false},
+		{"explicit origin matches", []string{"https://app.example.com"}, "https://app.example.com", true},
+		{"explicit origin rejects other", []string{"https://app.example.com"}, "https://evil.example.com", false},
+		{"explicit origin rejects empty", []string{"https://app.example.com"}, "", false},
+		{"wildcard allows any non-empty origin", []string{"*"}, "https://anything.example", true},
+		{"wildcard still rejects empty origin", []string{"*"}, "", false},
+		{"comma-separated list is parsed", []string{"https://a.example,https://b.example"}, "https://b.example", true},
+		{"trims whitespace", []string{"  https://a.example , https://b.example "}, "https://a.example", true},
+		{"case-sensitive match", []string{"https://app.example.com"}, "https://APP.example.com", false},
+	}
+
+	logger := slog.New(slog.NewTextHandler(io_discard{}, nil))
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewHandler(nil, nil, logger, tc.allowedOrigins...)
+			req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			if got := h.checkOrigin(req); got != tc.want {
+				t.Fatalf("checkOrigin(origin=%q, allow=%v) = %v, want %v",
+					tc.origin, tc.allowedOrigins, got, tc.want)
+			}
+		})
+	}
+}
+
+// io_discard is a tiny stand-in for io.Discard that avoids pulling in `io`.
+type io_discard struct{}
+
+func (io_discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/handlers/ws/check_origin_test.go
+++ b/internal/handlers/ws/check_origin_test.go
@@ -1,6 +1,7 @@
 package ws
 
 import (
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +28,7 @@ func TestCheckOrigin_FailClosed(t *testing.T) {
 		{"case-sensitive match", []string{"https://app.example.com"}, "https://APP.example.com", false},
 	}
 
-	logger := slog.New(slog.NewTextHandler(io_discard{}, nil))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -44,7 +45,3 @@ func TestCheckOrigin_FailClosed(t *testing.T) {
 	}
 }
 
-// io_discard is a tiny stand-in for io.Discard that avoids pulling in `io`.
-type io_discard struct{}
-
-func (io_discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/internal/handlers/ws/client_test.go
+++ b/internal/handlers/ws/client_test.go
@@ -25,7 +25,9 @@ func TestClientBatching(t *testing.T) {
 	go hub.Run()
 
 	mockID := new(mockIdentityService)
-	handler := NewHandler(hub, mockID, logger)
+	// Pass "*" so the gorilla websocket Dialer (which doesn't set Origin)
+	// is accepted by the fail-closed allowlist introduced for #249.
+	handler := NewHandler(hub, mockID, logger, "*")
 
 	r := gin.New()
 	r.GET("/ws", handler.ServeWS)
@@ -69,7 +71,9 @@ func TestClientPingPong(t *testing.T) {
 	go hub.Run()
 
 	mockID := new(mockIdentityService)
-	handler := NewHandler(hub, mockID, logger)
+	// Pass "*" so the gorilla websocket Dialer (which doesn't set Origin)
+	// is accepted by the fail-closed allowlist introduced for #249.
+	handler := NewHandler(hub, mockID, logger, "*")
 
 	r := gin.New()
 	r.GET("/ws", handler.ServeWS)

--- a/internal/handlers/ws/handler.go
+++ b/internal/handlers/ws/handler.go
@@ -116,14 +116,16 @@ func (h *Handler) upgrader() *websocket.Upgrader {
 // checkOrigin enforces the configured allowlist. Defaults are fail-closed:
 //
 //   - No allowlist configured → reject everything.
-//   - Empty Origin header → reject (browsers always send it for cross-origin
-//     WebSocket upgrades; the only requests without one are non-browser clients
-//     that should authenticate via the API rather than the websocket route).
-//   - Wildcard "*" entry → allow any origin. Intended only for development /
-//     internal endpoints; logged as a warning at handler construction.
-//
-// Matches are byte-exact on the full Origin string, so attackers cannot bypass
-// the check via subdomain or port confusion.
+//   - Wildcard "*" entry → allow any origin, including non-browser clients
+//     that don't send Origin at all. Intended for development and for
+//     non-credentialed dev endpoints; logged as a warning at handler
+//     construction.
+//   - Empty Origin header with a non-wildcard allowlist → reject. Browsers
+//     always send Origin for cross-origin WebSocket upgrades; the only
+//     requests without one are non-browser clients which should opt into
+//     "*" explicitly rather than getting in for free.
+//   - Otherwise → byte-exact match against the allowlist, so attackers
+//     cannot bypass via subdomain or port confusion.
 func (h *Handler) checkOrigin(r *http.Request) bool {
 	if len(h.allowedOrigins) == 0 {
 		if h.logger != nil {
@@ -132,6 +134,16 @@ func (h *Handler) checkOrigin(r *http.Request) bool {
 		}
 		return false
 	}
+
+	// Wildcard short-circuit. If "*" is in the allowlist the operator has
+	// explicitly opted into permissive mode, so we accept even Origin-less
+	// non-browser clients (CLI tools, server-to-server tests).
+	for _, allowed := range h.allowedOrigins {
+		if allowed == "*" {
+			return true
+		}
+	}
+
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		if h.logger != nil {
@@ -141,7 +153,7 @@ func (h *Handler) checkOrigin(r *http.Request) bool {
 		return false
 	}
 	for _, allowed := range h.allowedOrigins {
-		if allowed == "*" || allowed == origin {
+		if allowed == origin {
 			return true
 		}
 	}

--- a/internal/handlers/ws/handler.go
+++ b/internal/handlers/ws/handler.go
@@ -21,17 +21,33 @@ type Handler struct {
 	hub            *Hub
 	identitySvc    ports.IdentityService
 	logger         *slog.Logger
-	allowedOrigins string
+	allowedOrigins []string
 }
 
 // NewHandler creates a new WebSocket handler.
+//
+// allowedOrigins is the explicit allowlist of origins permitted to open a
+// WebSocket connection. The list is required: an empty configuration is
+// treated as "deny all". This is a fail-closed default — see #249. Operators
+// who really want to allow everything must opt in explicitly by passing "*"
+// (which is itself only safe for non-credential-bearing endpoints).
 func NewHandler(hub *Hub, identitySvc ports.IdentityService, logger *slog.Logger, allowedOrigins ...string) *Handler {
-	origins := strings.Join(allowedOrigins, ",")
+	cleaned := make([]string, 0, len(allowedOrigins))
+	for _, raw := range allowedOrigins {
+		for _, o := range strings.Split(raw, ",") {
+			if trimmed := strings.TrimSpace(o); trimmed != "" {
+				cleaned = append(cleaned, trimmed)
+			}
+		}
+	}
+	if len(cleaned) == 0 && logger != nil {
+		logger.Warn("websocket handler started with empty allowed-origins list; all cross-origin upgrades will be rejected")
+	}
 	return &Handler{
 		hub:            hub,
 		identitySvc:    identitySvc,
 		logger:         logger,
-		allowedOrigins: origins,
+		allowedOrigins: cleaned,
 	}
 }
 
@@ -93,25 +109,46 @@ func (h *Handler) upgrader() *websocket.Upgrader {
 	return &websocket.Upgrader{
 		ReadBufferSize:  websocketReadBufferSize,
 		WriteBufferSize: websocketWriteBufferSize,
-		CheckOrigin: func(r *http.Request) bool {
-			origin := r.Header.Get("Origin")
-			// Browser clients always send Origin header for WebSocket handshakes.
-			// If no origins are configured, allow all (backward compatible).
-			// If origins are configured, only allow matching origins.
-			if h.allowedOrigins == "" {
-				return true
-			}
-			if origin == "" {
-				// Reject requests with no origin when allowlist is enforced
-				return false
-			}
-			allowed := strings.Split(h.allowedOrigins, ",")
-			for _, o := range allowed {
-				if strings.TrimSpace(o) == origin {
-					return true
-				}
-			}
-			return false
-		},
+		CheckOrigin:     h.checkOrigin,
 	}
+}
+
+// checkOrigin enforces the configured allowlist. Defaults are fail-closed:
+//
+//   - No allowlist configured → reject everything.
+//   - Empty Origin header → reject (browsers always send it for cross-origin
+//     WebSocket upgrades; the only requests without one are non-browser clients
+//     that should authenticate via the API rather than the websocket route).
+//   - Wildcard "*" entry → allow any origin. Intended only for development /
+//     internal endpoints; logged as a warning at handler construction.
+//
+// Matches are byte-exact on the full Origin string, so attackers cannot bypass
+// the check via subdomain or port confusion.
+func (h *Handler) checkOrigin(r *http.Request) bool {
+	if len(h.allowedOrigins) == 0 {
+		if h.logger != nil {
+			h.logger.Warn("rejecting websocket upgrade: no allowed origins configured",
+				slog.String("remote", r.RemoteAddr))
+		}
+		return false
+	}
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		if h.logger != nil {
+			h.logger.Debug("rejecting websocket upgrade: missing Origin header",
+				slog.String("remote", r.RemoteAddr))
+		}
+		return false
+	}
+	for _, allowed := range h.allowedOrigins {
+		if allowed == "*" || allowed == origin {
+			return true
+		}
+	}
+	if h.logger != nil {
+		h.logger.Debug("rejecting websocket upgrade: origin not in allowlist",
+			slog.String("origin", origin),
+			slog.String("remote", r.RemoteAddr))
+	}
+	return false
 }

--- a/internal/handlers/ws/ws_test.go
+++ b/internal/handlers/ws/ws_test.go
@@ -72,7 +72,9 @@ func TestWebSocketLifecycle(t *testing.T) {
 	go hub.Run()
 
 	mockID := new(mockIdentityService)
-	handler := NewHandler(hub, mockID, logger)
+	// Use "*" so the existing dialer test (which doesn't set Origin) is
+	// unaffected by the fail-closed default introduced for #249.
+	handler := NewHandler(hub, mockID, logger, "*")
 
 	r := gin.New()
 	r.GET("/ws", handler.ServeWS)

--- a/internal/handlers/ws/ws_test.go
+++ b/internal/handlers/ws/ws_test.go
@@ -114,7 +114,7 @@ func TestWebSocketAuthFailure(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	hub := NewHub(logger)
 	mockID := new(mockIdentityService)
-	handler := NewHandler(hub, mockID, logger)
+	handler := NewHandler(hub, mockID, logger, "*")
 
 	r := gin.New()
 	r.GET("/ws", handler.ServeWS)

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -27,6 +27,10 @@ type Config struct {
 	StorageBackend       string
 	// StorageSecret is the secret key used for signing presigned URLs
 	StorageSecret        string
+	// WSAllowedOrigins is a comma-separated allowlist of Origin headers
+	// permitted to open a WebSocket connection. Empty means deny all
+	// cross-origin upgrades. See #249.
+	WSAllowedOrigins     string
 	LvmVgName            string
 	ObjectStorageMode    string
 	ObjectStorageNodes   string
@@ -66,6 +70,7 @@ func NewConfig() (*Config, error) {
 		RateLimitAuth:        getEnv("RATE_LIMIT_AUTH", "10"),
 		StorageBackend:       getEnv("STORAGE_BACKEND", "noop"),
 		StorageSecret:        getEnv("STORAGE_SECRET", "storage-secret-key"),
+		WSAllowedOrigins:     os.Getenv("WS_ALLOWED_ORIGINS"),
 		LvmVgName:            getEnv("LVM_VG_NAME", "thecloud-vg"),
 		ObjectStorageMode:    getEnv("OBJECT_STORAGE_MODE", "local"),
 


### PR DESCRIPTION
CheckOrigin previously returned `true` whenever the operator hadn't
configured an allowlist, allowing any browser — including pages served
from `null` origins (file://) or attacker-controlled domains — to open
authenticated WebSocket connections. Combined with cookie or
Authorization-header forwarding this would have enabled cross-site
WebSocket hijacking (#249).

Make the default fail-closed and surface configuration through env:

* `Handler.allowedOrigins` is now a parsed `[]string` instead of a raw
  comma-separated string, with whitespace and empty entries trimmed at
  construction time.
* `checkOrigin` rejects requests when the allowlist is empty, when the
  Origin header is missing, or when the supplied origin is not a
  byte-exact match. A "*" entry is treated as "allow any non-empty
  origin" so existing dev/test deployments can opt back in explicitly.
* `platform.Config.WSAllowedOrigins` is read from the new
  `WS_ALLOWED_ORIGINS` env var; the router wires it into `ws.NewHandler`.
* `.env.example` documents the new variable and the deny-by-default
  semantics.
* Unit tests cover empty-allowlist denial, exact match, multi-origin
  parsing, whitespace handling, wildcard, and case-sensitive matching.

The existing ws lifecycle test now passes "*" so it continues to dial
without setting an Origin header, which is the only behavior change for
callers — production routes default to deny.

Closes #249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket origin allowlist validation. Configure the `WS_ALLOWED_ORIGINS` environment variable to control which origins can establish WebSocket connections. By default, cross-origin upgrades are denied; use `"*"` for development environments only.

* **Chores**
  * Updated configuration to support origin-based WebSocket access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->