### PR TITLE
fix: stop timer before returning in HealingWorker goroutine

### DIFF
--- a/internal/workers/healing_worker.go
+++ b/internal/workers/healing_worker.go
@@ -101,10 +101,13 @@ func (w *HealingWorker) healERRORInstances(ctx context.Context) {
 			defer func() { <-w.semaphore }() // Release semaphore token
 
 			// Wait a bit to avoid race conditions with recent failures
+			timer := time.NewTimer(w.healingDelay)
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				return
-			case <-time.After(w.healingDelay):
+			case <-timer.C:
+				timer.Stop()
 			}
 
 			w.logger.Info("initiating healing restart", "instance_id", id)

--- a/internal/workers/healing_worker.go
+++ b/internal/workers/healing_worker.go
@@ -102,12 +102,11 @@ func (w *HealingWorker) healERRORInstances(ctx context.Context) {
 
 			// Wait a bit to avoid race conditions with recent failures
 			timer := time.NewTimer(w.healingDelay)
+			defer timer.Stop()
 			select {
 			case <-ctx.Done():
-				timer.Stop()
 				return
 			case <-timer.C:
-				timer.Stop()
 			}
 
 			w.logger.Info("initiating healing restart", "instance_id", id)

--- a/internal/workers/healing_worker_test.go
+++ b/internal/workers/healing_worker_test.go
@@ -209,6 +209,38 @@ func TestHealingWorker(t *testing.T) {
 	}
 }
 
+func TestHealingWorker_ContextCancelled_BeforeTimerFires(t *testing.T) {
+	repo := new(mockInstanceRepo)
+	svc := new(mockInstanceSvc)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	worker := NewHealingWorker(svc, repo, logger)
+	worker.healingDelay = 100 * time.Millisecond // Short but won't fire before ctx cancel
+
+	erroredInstance := &domain.Instance{
+		ID:       uuid.MustParse("00000000-0000-0000-0000-000000000001"),
+		Status:   domain.StatusError,
+		UserID:   uuid.New(),
+		TenantID: uuid.New(),
+	}
+
+	repo.On("ListAll", mock.Anything).Return([]*domain.Instance{erroredInstance}, nil)
+	// StopInstance and StartInstance must NOT be called — ctx cancelled before timer fires
+	svc.On("StopInstance", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(nil).Maybe()
+	svc.On("StartInstance", mock.Anything, "00000000-0000-0000-0000-000000000001").Return(nil).Maybe()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	worker.healERRORInstances(ctx)
+
+	// Cancel immediately — ctx.Done() should fire before the 100ms timer
+	cancel()
+	worker.reconcileWG.Wait()
+
+	// Verify the goroutine hit ctx.Done() and bailed out before calling StopInstance
+	svc.AssertNotCalled(t, "StopInstance", mock.Anything, "00000000-0000-0000-0000-000000000001")
+	repo.AssertExpectations(t)
+}
+
 func TestHealingWorker_Run(t *testing.T) {
 	repo := new(mockInstanceRepo)
 	svc := new(mockInstanceSvc)

--- a/internal/workers/healing_worker_test.go
+++ b/internal/workers/healing_worker_test.go
@@ -236,8 +236,9 @@ func TestHealingWorker_ContextCancelled_BeforeTimerFires(t *testing.T) {
 	cancel()
 	worker.reconcileWG.Wait()
 
-	// Verify the goroutine hit ctx.Done() and bailed out before calling StopInstance
+	// Verify the goroutine hit ctx.Done() and bailed out before calling StopInstance or StartInstance
 	svc.AssertNotCalled(t, "StopInstance", mock.Anything, "00000000-0000-0000-0000-000000000001")
+	svc.AssertNotCalled(t, "StartInstance", mock.Anything, "00000000-0000-0000-0000-000000000001")
 	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary

Fixes a goroutine leak in the `HealingWorker` when context is cancelled. When `ctx.Done()` fires, the healing goroutine returned immediately but `time.After(w.healingDelay)` created a timer that was never stopped — leaking a goroutine every time a healing task was cancelled.

## Fix

Replace `time.After(w.healingDelay)` with `time.NewTimer(w.healingDelay)` and explicitly call `timer.Stop()` on both the `ctx.Done()` path and after `timer.C` fires.

## Test plan

- [x] `go test ./internal/workers/... -short -v -run HealingWorker` — all 5 subtests pass (including new ctx-cancelled test)
- [x] `go build ./...` — builds clean
- [x] `go vet ./internal/workers/...` — clean

Fixes #335