### PR TITLE
fix(#348): add shutdown mechanism to WebSocket Hub.Run() goroutine

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -59,6 +59,7 @@ type AppDeps struct {
 	StartHTTPServer    func(*http.Server) error
 	ShutdownHTTPServer func(context.Context, *http.Server) error
 	NotifySignals      func(chan<- os.Signal, ...os.Signal)
+	Shutdown           func()
 }
 
 // DefaultDeps returns the production dependency wiring for the API server.
@@ -166,10 +167,10 @@ func run() error {
 		r.Use(otelgin.Middleware("compute-api"))
 	}
 
-	return runApplication(deps, cfg, logger, r, workers)
+	return runApplication(deps, cfg, logger, r, svcs, workers)
 }
 
-func runApplication(deps AppDeps, cfg *platform.Config, logger *slog.Logger, r *gin.Engine, workers *setup.Workers) error {
+func runApplication(deps AppDeps, cfg *platform.Config, logger *slog.Logger, r *gin.Engine, svcs *setup.Services, workers *setup.Workers) error {
 	role := os.Getenv("ROLE")
 	if role == "" {
 		role = "all"
@@ -219,6 +220,9 @@ func runApplication(deps AppDeps, cfg *platform.Config, logger *slog.Logger, r *
 
 	workerCancel()
 	wg.Wait()
+	if svcs != nil {
+		svcs.Shutdown()
+	}
 	logger.Info("shutdown complete")
 	return nil
 }

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -158,7 +158,7 @@ func TestRunApplicationApiRoleStartsAndShutsDown(t *testing.T) {
 		}()
 	}
 
-	err := runApplication(deps, &platform.Config{Port: "0"}, logger, gin.New(), &setup.Workers{})
+	err := runApplication(deps, &platform.Config{Port: "0"}, logger, gin.New(), nil, &setup.Workers{})
 	if err != nil {
 		t.Fatalf("runApplication returned error: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestRunApplicationWorkerRoleDoesNotStartHTTP(t *testing.T) {
 		}()
 	}
 
-	err := runApplication(deps, &platform.Config{Port: "0"}, logger, gin.New(), &setup.Workers{})
+	err := runApplication(deps, &platform.Config{Port: "0"}, logger, gin.New(), nil, &setup.Workers{})
 	if err != nil {
 		t.Fatalf("runApplication returned error: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestRunApplicationDefaultsToAllRole(t *testing.T) {
 		}()
 	}
 
-	err := runApplication(deps, &platform.Config{Port: "0"}, logger, gin.New(), &setup.Workers{})
+	err := runApplication(deps, &platform.Config{Port: "0"}, logger, gin.New(), nil, &setup.Workers{})
 	if err != nil {
 		t.Fatalf("runApplication returned error: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestRunApplicationInvalidRoleReturnsEarly(t *testing.T) {
 	}
 
 	// Should return immediately without starting anything
-	err := runApplication(deps, &platform.Config{Port: "0"}, logger, gin.New(), &setup.Workers{})
+	err := runApplication(deps, &platform.Config{Port: "0"}, logger, gin.New(), nil, &setup.Workers{})
 	if err == nil {
 		t.Fatalf("expected error for invalid role")
 	}

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -180,6 +180,11 @@ type Services struct {
 	NATGateway    *services.NATGatewayService
 }
 
+// Shutdown cleanly stops all services.
+func (s *Services) Shutdown() {
+	s.WsHub.Stop()
+}
+
 // Runner is the interface that all background workers implement.
 type Runner interface {
 	Run(context.Context, *sync.WaitGroup)

--- a/internal/handlers/ws/hub.go
+++ b/internal/handlers/ws/hub.go
@@ -18,6 +18,8 @@ type Hub struct {
 	broadcast  chan []byte
 	register   chan *Client
 	unregister chan *Client
+	stopCh     chan struct{}
+	stoppedCh  chan struct{}
 	mu         sync.RWMutex
 	logger     *slog.Logger
 }
@@ -29,14 +31,19 @@ func NewHub(logger *slog.Logger) *Hub {
 		broadcast:  make(chan []byte, 256),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
+		stopCh:     make(chan struct{}),
+		stoppedCh:  make(chan struct{}),
 		logger:     logger,
 	}
 }
 
 // Run starts the hub's main loop.
 func (h *Hub) Run() {
+	defer close(h.stoppedCh)
 	for {
 		select {
+		case <-h.stopCh:
+			return
 		case client := <-h.register:
 			h.mu.Lock()
 			h.clients[client] = true
@@ -67,6 +74,16 @@ func (h *Hub) Run() {
 			h.mu.RUnlock()
 		}
 	}
+}
+
+// Stop signals the hub to shut down. Safe to call once.
+func (h *Hub) Stop() {
+	close(h.stopCh)
+}
+
+// Stopped returns a channel that is closed when Run() has exited.
+func (h *Hub) Stopped() <-chan struct{} {
+	return h.stoppedCh
 }
 
 // BroadcastEvent sends a WSEvent to all connected clients.

--- a/internal/handlers/ws/ws_test.go
+++ b/internal/handlers/ws/ws_test.go
@@ -2,6 +2,7 @@ package ws
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -142,4 +143,19 @@ func TestWebSocketAuthFailure(t *testing.T) {
 			_ = resp.Body.Close()
 		}
 	})
+}
+
+func TestHubShutdown(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	hub := NewHub(logger)
+	go hub.Run()
+
+	hub.Stop()
+
+	select {
+	case <-hub.Stopped():
+	case <-time.After(time.Second):
+		t.Fatal("hub.Run() did not exit within 1s after Stop()")
+	}
 }


### PR DESCRIPTION
## Summary
- Adds `stopCh`/`stoppedCh` channels to `Hub` struct for graceful shutdown
- `Hub.Run()` now listens on `stopCh` and exits cleanly via `defer close(stoppedCh)`
- Adds `Stop()` and `Stopped()` methods to `Hub`
- Adds `Services.Shutdown()` that calls `WsHub.Stop()`
- Called during application shutdown after workers have stopped

## Fixes
Fixes #348 - WebSocket Hub.Run() goroutine has no shutdown mechanism

## Test plan
- [x] `go test ./internal/handlers/ws/... -v -race`
- [x] `go test ./cmd/api/...`
- [x] `go build ./cmd/api/...`