### PR TITLE
fix(#348): improve WebSocket Hub shutdown safety and robustness

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -59,7 +59,6 @@ type AppDeps struct {
 	StartHTTPServer    func(*http.Server) error
 	ShutdownHTTPServer func(context.Context, *http.Server) error
 	NotifySignals      func(chan<- os.Signal, ...os.Signal)
-	Shutdown           func()
 }
 
 // DefaultDeps returns the production dependency wiring for the API server.

--- a/internal/api/setup/dependencies.go
+++ b/internal/api/setup/dependencies.go
@@ -182,6 +182,9 @@ type Services struct {
 
 // Shutdown cleanly stops all services.
 func (s *Services) Shutdown() {
+	if s == nil || s.WsHub == nil {
+		return
+	}
 	s.WsHub.Stop()
 }
 

--- a/internal/handlers/ws/hub.go
+++ b/internal/handlers/ws/hub.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
@@ -20,13 +21,14 @@ type Hub struct {
 	unregister chan *Client
 	stopCh     chan struct{}
 	stoppedCh  chan struct{}
+	isOpen     atomic.Bool
 	mu         sync.RWMutex
 	logger     *slog.Logger
 }
 
 // NewHub creates a new WebSocket hub.
 func NewHub(logger *slog.Logger) *Hub {
-	return &Hub{
+	h := &Hub{
 		clients:    make(map[*Client]bool),
 		broadcast:  make(chan []byte, 256),
 		register:   make(chan *Client),
@@ -35,6 +37,8 @@ func NewHub(logger *slog.Logger) *Hub {
 		stoppedCh:  make(chan struct{}),
 		logger:     logger,
 	}
+	h.isOpen.Store(true)
+	return h
 }
 
 // Run starts the hub's main loop.
@@ -43,6 +47,7 @@ func (h *Hub) Run() {
 	for {
 		select {
 		case <-h.stopCh:
+			h.cleanupClients()
 			return
 		case client := <-h.register:
 			h.mu.Lock()
@@ -76,9 +81,23 @@ func (h *Hub) Run() {
 	}
 }
 
-// Stop signals the hub to shut down. Safe to call once.
+// cleanupClients closes all client connections and decrements metrics.
+func (h *Hub) cleanupClients() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for client := range h.clients {
+		close(client.send)
+		delete(h.clients, client)
+		platform.WSConnectionsActive.Dec()
+	}
+}
+
+// Stop signals the hub to shut down. Safe to call multiple times.
 func (h *Hub) Stop() {
-	close(h.stopCh)
+	if h.isOpen.Load() {
+		h.isOpen.Store(false)
+		close(h.stopCh)
+	}
 }
 
 // Stopped returns a channel that is closed when Run() has exited.
@@ -88,6 +107,9 @@ func (h *Hub) Stopped() <-chan struct{} {
 
 // BroadcastEvent sends a WSEvent to all connected clients.
 func (h *Hub) BroadcastEvent(event *domain.WSEvent) {
+	if !h.isOpen.Load() {
+		return
+	}
 	data, err := json.Marshal(event)
 	if err != nil {
 		h.logger.Error("failed to marshal event", slog.String("error", err.Error()))
@@ -100,6 +122,9 @@ func (h *Hub) BroadcastEvent(event *domain.WSEvent) {
 // If userID is not nil, further filter to that specific user.
 // Collects clients to remove under RLock, then removes them via unregister channel.
 func (h *Hub) BroadcastEventToTenant(ctx context.Context, event *domain.WSEvent, tenantID uuid.UUID, userID *uuid.UUID) error {
+	if !h.isOpen.Load() {
+		return nil
+	}
 	data, err := json.Marshal(event)
 	if err != nil {
 		return err
@@ -153,10 +178,16 @@ func (h *Hub) ClientCount() int {
 
 // Register adds a client to the hub.
 func (h *Hub) Register(client *Client) {
+	if !h.isOpen.Load() {
+		return
+	}
 	h.register <- client
 }
 
 // Unregister removes a client from the hub.
 func (h *Hub) Unregister(client *Client) {
+	if !h.isOpen.Load() {
+		return
+	}
 	h.unregister <- client
 }

--- a/internal/handlers/ws/ws_test.go
+++ b/internal/handlers/ws/ws_test.go
@@ -161,3 +161,20 @@ func TestHubShutdown(t *testing.T) {
 		t.Fatal("hub.Run() did not exit within 1s after Stop()")
 	}
 }
+
+func TestHubStopIdempotent(t *testing.T) {
+	t.Parallel()
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	hub := NewHub(logger)
+	go hub.Run()
+
+	hub.Stop()
+	hub.Stop() // safe to call twice
+	hub.Stop() // and again
+
+	select {
+	case <-hub.Stopped():
+	case <-time.After(time.Second):
+		t.Fatal("hub.Run() did not exit within 1s after Stop()")
+	}
+}


### PR DESCRIPTION
## Summary

Applies Copilot review suggestions to make the Hub shutdown mechanism production-ready:

- **`Stop()` is now idempotent** — uses `isOpen` atomic flag; calling Stop() multiple times is safe
- **Client cleanup on shutdown** — `cleanupClients()` closes all client send channels and decrements `WSConnectionsActive` metrics
- **Register/Unregister/BroadcastEvent are stop-aware** — return immediately if hub is closed, preventing deadlocks
- **`Services.Shutdown()` is nil-safe** — checks `s == nil || s.WsHub == nil` to avoid panic on partially-initialized Services
- **Added `TestHubStopIdempotent`** — verifies Stop() can be called multiple times safely

Fixes Copilot comments on PR #355.

## Test plan
- [x] `go test ./internal/handlers/ws/... -v -race`
- [x] `go build ./cmd/api/...`