### PR TITLE
fix: replace time.After with time.NewTimer in retry loops

### DIFF
--- a/internal/core/services/function_schedule_worker.go
+++ b/internal/core/services/function_schedule_worker.go
@@ -109,11 +109,14 @@ func (w *FunctionScheduleWorker) runSchedule(ctx context.Context, sched *domain.
 	if err := w.repo.CompleteScheduleRun(ctx, run, sched, nextRun); err != nil {
 		log.Printf("FunctionScheduleWorker: failed to complete schedule run, retrying: %v", err)
 		for i := 1; i <= 3; i++ {
+			timer := time.NewTimer(time.Duration(i) * time.Second)
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				log.Printf("FunctionScheduleWorker: context cancelled during retry")
 				return
-			case <-time.After(time.Duration(i) * time.Second):
+			case <-timer.C:
+				timer.Stop()
 			}
 			if err := w.repo.CompleteScheduleRun(ctx, run, sched, nextRun); err == nil {
 				return

--- a/internal/repositories/docker/adapter.go
+++ b/internal/repositories/docker/adapter.go
@@ -471,10 +471,13 @@ func (a *DockerAdapter) GetInstancePort(ctx context.Context, containerID string,
 		}
 
 		// Wait and retry
+		timer := time.NewTimer(500 * time.Millisecond)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return 0, ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case <-timer.C:
+			timer.Stop()
 			continue
 		}
 	}
@@ -870,10 +873,13 @@ func (a *DockerAdapter) GetInstanceIP(ctx context.Context, id string) (string, e
 
 	retry:
 		// Wait and retry
+		timer := time.NewTimer(500 * time.Millisecond)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return "", ctx.Err()
-		case <-time.After(500 * time.Millisecond):
+		case <-timer.C:
+			timer.Stop()
 			continue
 		}
 	}

--- a/internal/repositories/k8s/provisioner.go
+++ b/internal/repositories/k8s/provisioner.go
@@ -375,11 +375,13 @@ func (p *KubeadmProvisioner) waitForKubeconfig(ctx context.Context, cluster *dom
 			return out, nil
 		}
 
+		timer := time.NewTimer(10 * time.Second)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return "", ctx.Err()
-		case <-time.After(10 * time.Second):
-			continue
+		case <-timer.C:
+			timer.Stop()
 		}
 	}
 	return "", fmt.Errorf("timed out waiting for kubeconfig")


### PR DESCRIPTION
## Summary

Fixes goroutine/timer leaks in 4 retry loops where `time.After` was used. `time.After` creates a timer goroutine that is only cleaned up when the channel fires — in loops that may exit early, previously-created timers leak indefinitely.

## Fix

Replace `time.After(delay)` with `time.NewTimer(delay)` + explicit `timer.Stop()` on ctx.Done() path and after timer fires.

## Changed Locations

| Function | File | Retry Pattern |
|---|---|---|
| `GetInstancePort` | `internal/repositories/docker/adapter.go` | 30 × 500ms |
| `GetInstanceIP` | `internal/repositories/docker/adapter.go` | 30 × 500ms (goto retry) |
| `waitForKubeconfig` | `internal/repositories/k8s/provisioner.go` | unbounded × 10s |
| `ProcessSchedules` | `internal/core/services/function_schedule_worker.go` | 3 × (1s/2s/3s) backoff |

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/repositories/docker/... -run GetInstancePort` — PASS
- [x] `go test ./internal/repositories/docker/... -run GetInstanceIP` — PASS
- [x] `go test ./internal/repositories/k8s/... -run KubeadmProvisioner` — PASS
- [x] `go test ./internal/core/services/... -run FunctionScheduleWorker` — PASS

Fixes #328