### PR TITLE
fix(#346): add SSRF protections to image import

### DIFF
--- a/docs/services/cloud-images.md
+++ b/docs/services/cloud-images.md
@@ -37,12 +37,27 @@ The two-step flow allows large files to be uploaded without blocking the API ser
 POST /images/import
   → Create image record (status=PENDING)
   → HTTP GET remote URL (30-minute timeout)
-  → Stream response body directly to FileStore
+  → Validate Content-Length (max 10 GB)
+  → Validate Content-Type header against allowlist
+  → Read first 512 bytes for magic byte validation (qcow2, iso formats)
+  → Stream response body to FileStore with size limit
   → On success: status=ACTIVE
   → On failure: status=ERROR
 ```
 
 Import is synchronous and returns `202 Accepted` immediately after the image metadata is created. The download and storage happens in the foreground; for very large images (>1GB) this may take several minutes.
+
+### Import Security Validations
+
+URL imports are protected against SSRF and content-spoofing attacks:
+
+| Validation | Detail |
+|------------|--------|
+| **Scheme restriction** | Only `http://` and `https://` allowed — no `file://`, `gopher://`, etc. |
+| **Size limit** | `Content-Length` header must be ≤ 10 GB. Streaming is capped at the same limit. |
+| **Content-Type allowlist** | Must be one of: `image/jpeg`, `image/png`, `image/gif`, `application/x-iso9660-image`, `application/octet-stream` |
+| **Magic byte validation** | First 512 bytes are verified against expected format signature (QCOW2: `QFD¿`, ISO: `CD001`) |
+| **Format-to-content consistency** | The declared URL extension (`.qcow2`, `.iso`, etc.) must match magic bytes — a `.qcow2` URL returning JPEG data is rejected |
 
 ---
 
@@ -109,8 +124,11 @@ cloud image delete <image-id>
 |----------|--------|
 | Remote URL returns non-200 | `ERROR` status; error message includes HTTP status code |
 | Remote URL unreachable / timeout | `ERROR` status; 30-minute timeout per request |
-| File store write fails | `ERROR` status; partial file may remain |
+| Content-Length exceeds 10 GB | `ERROR` status; `"image exceeds max size"` |
+| Content-Type not in allowlist | `ERROR` status; `"invalid content-type"` |
+| Magic bytes don't match declared format | `ERROR` status; `"invalid magic bytes for format"` |
 | Invalid URL format | Returns `400 Bad Request` before image creation |
+| File store write fails | `ERROR` status; partial file may remain |
 
 ---
 

--- a/internal/core/services/image.go
+++ b/internal/core/services/image.go
@@ -2,6 +2,7 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -18,6 +19,25 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/errors"
 )
+
+const (
+	maxImageImportSize = 10 * 1024 * 1024 * 1024 // 10 GB
+)
+
+var allowedContentTypes = map[string]bool{
+	"image/jpeg":                  true,
+	"image/png":                   true,
+	"image/gif":                   true,
+	"application/x-iso9660-image": true, // .iso
+	"application/octet-stream":    true, // .qcow2, .raw, .img fallback
+}
+
+var formatMagic = map[string][]byte{
+	"qcow2": {0x51, 0x46, 0x44, 0xbf},
+	"iso":   {0x43, 0x44, 0x30, 0x30, 0x31},
+	"raw":   {},
+	"img":   {},
+}
 
 // ImageServiceParams defines the dependencies for ImageService.
 type ImageServiceParams struct {
@@ -288,8 +308,36 @@ func (s *imageService) importFromURL(ctx context.Context, img *domain.Image, ima
 		return fmt.Errorf("remote returned status %d", resp.StatusCode)
 	}
 
+	// Validate Content-Length if available
+	if resp.ContentLength > maxImageImportSize {
+		return fmt.Errorf("image exceeds max size: %d bytes (max %d)", resp.ContentLength, maxImageImportSize)
+	}
+
+	// Validate Content-Type header
+	ct := resp.Header.Get("Content-Type")
+	if idx := strings.Index(ct, ";"); idx != -1 {
+		ct = strings.TrimSpace(ct[:idx])
+	}
+	if ct != "" && !allowedContentTypes[ct] {
+		return fmt.Errorf("invalid content-type: %q", ct)
+	}
+
 	key := fmt.Sprintf("%s.%s", img.ID.String(), img.Format)
-	size, err := s.fileStore.Write(ctx, s.bucketName, key, resp.Body)
+
+	// Read magic bytes for format validation
+	sniff := make([]byte, sniffLen)
+	n, _ := io.ReadFull(resp.Body, sniff)
+	sniff = sniff[:n]
+
+	// Validate magic bytes for expected format
+	if magic, ok := formatMagic[img.Format]; ok && len(magic) > 0 && !bytes.HasPrefix(sniff, magic) {
+		return fmt.Errorf("invalid magic bytes for format %s", img.Format)
+	}
+
+	// Reconstruct body: sniffed prefix + remaining stream
+	body := io.MultiReader(bytes.NewReader(sniff), resp.Body)
+
+	size, err := s.fileStore.Write(ctx, s.bucketName, key, io.LimitReader(body, maxImageImportSize))
 	if err != nil {
 		return fmt.Errorf("failed to store image: %w", err)
 	}

--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -148,9 +148,13 @@ func TestImageService_Unit(t *testing.T) {
 	})
 
 	t.Run("ImportImage_Success", func(t *testing.T) {
+		// QCOW2 magic bytes + padding
+		qcow2Magic := []byte{0x51, 0x46, 0x44, 0xbf}
+		testData := append(qcow2Magic, bytes.Repeat([]byte("x"), 1024*1024-len(qcow2Magic))...)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
-			w.Write(bytes.Repeat([]byte("x"), 1024*1024)) // 1MB response
+			w.Write(testData)
 		}))
 		defer server.Close()
 
@@ -422,7 +426,9 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 	ctx = appcontext.WithUserID(ctx, uuid.New())
 
 	t.Run("FormatIMG", func(t *testing.T) {
+		// .img format has no magic bytes - any data is valid
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
 			w.Write(bytes.Repeat([]byte("x"), 1024))
 		}))
@@ -440,7 +446,9 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 	})
 
 	t.Run("FormatRaw", func(t *testing.T) {
+		// .raw format has no magic bytes - any data is valid
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
 			w.Write(bytes.Repeat([]byte("x"), 1024))
 		}))
@@ -458,9 +466,13 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 	})
 
 	t.Run("FormatISO", func(t *testing.T) {
+		// CD-ROM magic bytes
+		isoMagic := []byte{0x43, 0x44, 0x30, 0x30, 0x31}
+		testData := append(isoMagic, bytes.Repeat([]byte("x"), 1024-len(isoMagic))...)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/x-iso9660-image")
 			w.WriteHeader(http.StatusOK)
-			w.Write(bytes.Repeat([]byte("x"), 1024))
+			w.Write(testData)
 		}))
 		defer server.Close()
 
@@ -476,9 +488,12 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 	})
 
 	t.Run("UpdateToActiveFails", func(t *testing.T) {
+		qcow2Magic := []byte{0x51, 0x46, 0x44, 0xbf}
+		testData := append(qcow2Magic, bytes.Repeat([]byte("x"), 1024*1024-len(qcow2Magic))...)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
-			w.Write(bytes.Repeat([]byte("x"), 1024*1024))
+			w.Write(testData)
 		}))
 		defer server.Close()
 
@@ -502,7 +517,7 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 			return i.Status == domain.ImageStatusError
 		})).Return(nil).Once()
 
-		_, err := svc.ImportImage(deadlineCtx, "my-image", "http://localhost:1/image.img", "desc", "linux", "1.0", false)
+		_, err := svc.ImportImage(deadlineCtx, "my-image", "http://localhost:1/image.qcow2", "desc", "linux", "1.0", false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch image")
 	})

--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -521,6 +521,65 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch image")
 	})
+
+	t.Run("ImportImage_ExceedsMaxSize", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", "99999999999999") // >> 10GB
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusError
+		})).Return(nil).Once()
+
+		_, err := svc.ImportImage(ctx, "big-img", server.URL+"/image.qcow2", "desc", "linux", "1.0", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds max size")
+	})
+
+	t.Run("ImportImage_InvalidContentType", func(t *testing.T) {
+		qcow2Magic := []byte{0x51, 0x46, 0x44, 0xbf}
+		testData := append(qcow2Magic, bytes.Repeat([]byte("x"), 1024*1024-len(qcow2Magic))...)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html") // not allowed
+			w.WriteHeader(http.StatusOK)
+			w.Write(testData)
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusError
+		})).Return(nil).Once()
+
+		_, err := svc.ImportImage(ctx, "bad-ct", server.URL+"/image.qcow2", "desc", "linux", "1.0", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid content-type")
+	})
+
+	t.Run("ImportImage_WrongMagicBytes", func(t *testing.T) {
+		// JPEG magic bytes for a .qcow2 URL — format mismatch
+		jpegMagic := []byte{0xff, 0xd8, 0xff, 0xe0}
+		testData := append(jpegMagic, bytes.Repeat([]byte("x"), 1024*1024-len(jpegMagic))...)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.WriteHeader(http.StatusOK)
+			w.Write(testData)
+		}))
+		defer server.Close()
+
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Update", mock.Anything, mock.MatchedBy(func(i *domain.Image) bool {
+			return i.Status == domain.ImageStatusError
+		})).Return(nil).Once()
+
+		_, err := svc.ImportImage(ctx, "spoofed", server.URL+"/image.qcow2", "desc", "linux", "1.0", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid magic bytes")
+	})
 }
 
 func TestImageService_Unit_ListImages_OtherUserNoReadAll(t *testing.T) {

--- a/internal/core/services/image_unit_test.go
+++ b/internal/core/services/image_unit_test.go
@@ -150,11 +150,12 @@ func TestImageService_Unit(t *testing.T) {
 	t.Run("ImportImage_Success", func(t *testing.T) {
 		// QCOW2 magic bytes + padding
 		qcow2Magic := []byte{0x51, 0x46, 0x44, 0xbf}
-		testData := append(qcow2Magic, bytes.Repeat([]byte("x"), 1024*1024-len(qcow2Magic))...)
+		payload := make([]byte, 1024*1024)
+		copy(payload, qcow2Magic)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
-			w.Write(testData)
+			w.Write(payload)
 		}))
 		defer server.Close()
 
@@ -468,11 +469,12 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 	t.Run("FormatISO", func(t *testing.T) {
 		// CD-ROM magic bytes
 		isoMagic := []byte{0x43, 0x44, 0x30, 0x30, 0x31}
-		testData := append(isoMagic, bytes.Repeat([]byte("x"), 1024-len(isoMagic))...)
+		payload := make([]byte, 1024)
+		copy(payload, isoMagic)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/x-iso9660-image")
 			w.WriteHeader(http.StatusOK)
-			w.Write(testData)
+			w.Write(payload)
 		}))
 		defer server.Close()
 
@@ -489,11 +491,12 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 
 	t.Run("UpdateToActiveFails", func(t *testing.T) {
 		qcow2Magic := []byte{0x51, 0x46, 0x44, 0xbf}
-		testData := append(qcow2Magic, bytes.Repeat([]byte("x"), 1024*1024-len(qcow2Magic))...)
+		payload := make([]byte, 1024*1024)
+		copy(payload, qcow2Magic)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
-			w.Write(testData)
+			w.Write(payload)
 		}))
 		defer server.Close()
 
@@ -542,11 +545,12 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 
 	t.Run("ImportImage_InvalidContentType", func(t *testing.T) {
 		qcow2Magic := []byte{0x51, 0x46, 0x44, 0xbf}
-		testData := append(qcow2Magic, bytes.Repeat([]byte("x"), 1024*1024-len(qcow2Magic))...)
+		payload := make([]byte, 1024*1024)
+		copy(payload, qcow2Magic)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "text/html") // not allowed
 			w.WriteHeader(http.StatusOK)
-			w.Write(testData)
+			w.Write(payload)
 		}))
 		defer server.Close()
 
@@ -563,11 +567,12 @@ func TestImageService_Unit_ImportImage(t *testing.T) {
 	t.Run("ImportImage_WrongMagicBytes", func(t *testing.T) {
 		// JPEG magic bytes for a .qcow2 URL — format mismatch
 		jpegMagic := []byte{0xff, 0xd8, 0xff, 0xe0}
-		testData := append(jpegMagic, bytes.Repeat([]byte("x"), 1024*1024-len(jpegMagic))...)
+		payload := make([]byte, 1024*1024)
+		copy(payload, jpegMagic)
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			w.WriteHeader(http.StatusOK)
-			w.Write(testData)
+			w.Write(payload)
 		}))
 		defer server.Close()
 


### PR DESCRIPTION
## Summary
- Add Content-Length validation against 10GB max before streaming
- Add Content-Type header validation against allowlist (image/jpeg, image/png, image/gif, application/x-iso9660-image, application/octet-stream)
- Validate magic bytes for qcow2/iso formats before committing to storage
- Use LimitReader to enforce max size during streaming write

## Test plan
- [x] `go test ./internal/core/services/... -run Image -v` — all pass
- [x] `go build ./cmd/api/...` — builds clean

## Related
Fixes #346