### PR TITLE
fix(notify): surface non-2xx webhook delivery responses

### DIFF
--- a/internal/core/services/notify.go
+++ b/internal/core/services/notify.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -14,6 +15,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 )
+
+var webhookHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
 // NotifyServiceParams defines the dependencies for NotifyService.
 type NotifyServiceParams struct {
@@ -286,12 +289,28 @@ func (s *NotifyService) deliverToQueue(ctx context.Context, sub *domain.Subscrip
 }
 
 func (s *NotifyService) deliverToWebhook(ctx context.Context, sub *domain.Subscription, body string) {
-	req, _ := http.NewRequestWithContext(ctx, "POST", sub.Endpoint, bytes.NewBufferString(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sub.Endpoint, bytes.NewBufferString(body))
+	if err != nil {
+		s.logger.Warn("failed to build webhook request", "endpoint", sub.Endpoint, "error", err)
+		return
+	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+
+	resp, err := webhookHTTPClient.Do(req)
 	if err != nil {
 		s.logger.Warn("failed to deliver to webhook", "endpoint", sub.Endpoint, "error", err)
 		return
 	}
-	_ = resp.Body.Close()
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 400 {
+		s.logger.Warn("webhook delivery failed",
+			"endpoint", sub.Endpoint,
+			"subscription_id", sub.ID,
+			"status", resp.StatusCode)
+		return
+	}
 }

--- a/internal/core/services/notify_unit_test.go
+++ b/internal/core/services/notify_unit_test.go
@@ -1,10 +1,16 @@
 package services_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
@@ -407,6 +413,74 @@ func testNotifyServiceUnitPublishErrors(t *testing.T) {
 		<-done
 	})
 
+	t.Run("Publish_WebhookNon2xxStatus", func(t *testing.T) {
+		// Issue #338: webhook delivery must surface non-2xx HTTP responses.
+		var (
+			mu       sync.Mutex
+			received bool
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			received = true
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		var logBuf bytes.Buffer
+		var logMu sync.Mutex
+		capturingLogger := slog.New(slog.NewTextHandler(&lockedWriter{w: &logBuf, mu: &logMu}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		mockRepo2 := new(MockNotifyRepo)
+		mockQueueSvc2 := new(MockQueueService)
+		mockEventSvc2 := new(MockEventService)
+		mockAuditSvc2 := new(MockAuditService)
+		rbacSvc2 := new(MockRBACService)
+		rbacSvc2.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		svc2 := services.NewNotifyService(services.NotifyServiceParams{
+			Repo:     mockRepo2,
+			RBACSvc:  rbacSvc2,
+			QueueSvc: mockQueueSvc2,
+			EventSvc: mockEventSvc2,
+			AuditSvc: mockAuditSvc2,
+			Logger:   capturingLogger,
+		})
+
+		done := make(chan struct{})
+		topicID := uuid.New()
+		topic := &domain.Topic{ID: topicID, UserID: userID}
+		sub := &domain.Subscription{
+			ID:       uuid.New(),
+			UserID:   userID,
+			TopicID:  topicID,
+			Protocol: domain.ProtocolWebhook,
+			Endpoint: server.URL,
+		}
+		mockRepo2.On("GetTopicByID", mock.Anything, topicID, userID).Return(topic, nil).Once()
+		mockRepo2.On("SaveMessage", mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo2.On("ListSubscriptions", mock.Anything, topicID).Return([]*domain.Subscription{sub}, nil).Once()
+		mockEventSvc2.On("RecordEvent", mock.Anything, "TOPIC_PUBLISHED", mock.Anything, "TOPIC", mock.Anything).Return(nil).Once()
+		mockAuditSvc2.On("Log", mock.Anything, userID, "notify.publish", "topic", topicID.String(), mock.Anything).Return(nil).Run(func(mock.Arguments) { close(done) }).Once()
+
+		err := svc2.Publish(ctx, topicID, "hello")
+		require.NoError(t, err)
+		<-done
+
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return received
+		}, 2*time.Second, 10*time.Millisecond, "webhook server never received request")
+
+		require.Eventually(t, func() bool {
+			logMu.Lock()
+			defer logMu.Unlock()
+			return strings.Contains(logBuf.String(), "webhook delivery failed") &&
+				strings.Contains(logBuf.String(), "status=500")
+		}, 2*time.Second, 10*time.Millisecond, "expected webhook delivery failure log with status=500")
+	})
+
 	t.Run("Publish_QueueInvalidUUID", func(t *testing.T) {
 		done := make(chan struct{})
 		topicID := uuid.New()
@@ -429,4 +503,15 @@ func testNotifyServiceUnitPublishErrors(t *testing.T) {
 		require.NoError(t, err)
 		<-done
 	})
+}
+
+type lockedWriter struct {
+	w  *bytes.Buffer
+	mu *sync.Mutex
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
 }


### PR DESCRIPTION
 ## Summary
  - Webhook delivery in `NotifyService.deliverToWebhook` only inspected transport errors and silently treated 4xx/5xx responses as successful, dropping messages for any subscriber
   whose endpoint returned a failure.
  - Now check `resp.StatusCode` and emit a structured warn log on `>= 400` (with `endpoint`, `subscription_id`, `status`).
  - Replaced `http.DefaultClient` with a dedicated `http.Client` carrying a 15s timeout so a slow/hanging webhook can no longer pin the delivery goroutine indefinitely.
  - Drained the response body before close (connection reuse hygiene) and stopped discarding the error from `http.NewRequestWithContext` (a malformed `sub.Endpoint` would have
  nil-panicked on the next line).

  Closes #338

  ## Test plan
  - [x] New unit test `Publish_WebhookNon2xxStatus` spins up an `httptest` server returning 500, captures slog output, and asserts the warn log contains `webhook delivery failed`
  and `status=500`.
  - [x] `go test -run TestNotifyServiceUnit -count=1 ./internal/core/services/...` passes.
  - [x] `go vet ./internal/core/services/...` clean.

  ## Out of scope (follow-up)
  The issue notes that subscribers returning failures "will never have their messages retried." This PR makes failures observable but does not add retry/backoff or a
  delivery-failure metric — those touch the broader notification subsystem (dead-letter strategy, per-subscription failure counters) and belong in a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook delivery reliability with enhanced error handling and request timeout management.
  * Webhook deliveries returning HTTP error status codes (4xx/5xx) are now properly handled as failures with detailed logging.
  * Response bodies are now properly drained to prevent resource leaks during webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->