### PR TITLE
fix(workers): track provision goroutines with WaitGroup 

### DIFF
--- a/internal/workers/provision_worker.go
+++ b/internal/workers/provision_worker.go
@@ -74,9 +74,19 @@ func (w *ProvisionWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
 
 	sem := make(chan struct{}, provisionMaxWorkers)
 
+	// inFlight tracks every goroutine this worker spawns (the reclaim loop and
+	// each per-message processJob). Waiting on it before Run returns ensures
+	// shutdown drains in-flight work instead of leaking goroutines.
+	var inFlight sync.WaitGroup
+	defer inFlight.Wait()
+
 	// Start a background goroutine that periodically reclaims stale messages
 	// from crashed consumers.
-	go w.reclaimLoop(ctx, sem)
+	inFlight.Add(1)
+	go func() {
+		defer inFlight.Done()
+		w.reclaimLoop(ctx, sem, &inFlight)
+	}()
 
 	for {
 		select {
@@ -110,7 +120,9 @@ func (w *ProvisionWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
 			)
 
 			sem <- struct{}{} // acquire concurrency slot
+			inFlight.Add(1)
 			go func(m *ports.DurableMessage, j domain.ProvisionJob) {
+				defer inFlight.Done()
 				defer func() { <-sem }()
 				w.processJob(ctx, m, j)
 			}(msg, job)
@@ -191,8 +203,9 @@ func (w *ProvisionWorker) processJob(workerCtx context.Context, msg *ports.Durab
 }
 
 // reclaimLoop periodically reclaims messages stuck in the PEL from crashed
-// consumers and re-processes them.
-func (w *ProvisionWorker) reclaimLoop(ctx context.Context, sem chan struct{}) {
+// consumers and re-processes them. Spawned processJob goroutines are added to
+// inFlight so Run can wait for them on shutdown.
+func (w *ProvisionWorker) reclaimLoop(ctx context.Context, sem chan struct{}, inFlight *sync.WaitGroup) {
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 
@@ -219,7 +232,9 @@ func (w *ProvisionWorker) reclaimLoop(ctx context.Context, sem chan struct{}) {
 
 				m := m // capture loop variable
 				sem <- struct{}{}
+				inFlight.Add(1)
 				go func() {
+					defer inFlight.Done()
 					defer func() { <-sem }()
 					w.processJob(ctx, &m, job)
 				}()


### PR DESCRIPTION
Closes #298

The provision worker spawned per-message processJob goroutines and a reclaim loop without tracking them. Run() returned as soon as the receive loop exited, so wg.Done() fired to the supervisor while in-flight jobs were still running. Although the goroutines already inherited the worker context (so cancellation propagated), shutdown did not wait for them to drain, and acks/nacks could race past the worker's reported lifecycle.

Add a local sync.WaitGroup (inFlight) inside Run and:
- register the reclaim loop goroutine on it
- register every processJob goroutine spawned from the receive loop
- pass it into reclaimLoop so its own spawned processJob goroutines are tracked too
- defer inFlight.Wait() so Run blocks until every spawned goroutine exits before signalling Done() to the supervisor.

No behaviour change on the happy path; on shutdown the worker now drains in-flight provision work instead of leaking goroutines.