### PR TITLE
Fix/issue 310 k8s update errors

### DIFF
--- a/internal/core/services/notify.go
+++ b/internal/core/services/notify.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -14,6 +15,8 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 )
+
+var webhookHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
 // NotifyServiceParams defines the dependencies for NotifyService.
 type NotifyServiceParams struct {
@@ -286,12 +289,28 @@ func (s *NotifyService) deliverToQueue(ctx context.Context, sub *domain.Subscrip
 }
 
 func (s *NotifyService) deliverToWebhook(ctx context.Context, sub *domain.Subscription, body string) {
-	req, _ := http.NewRequestWithContext(ctx, "POST", sub.Endpoint, bytes.NewBufferString(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sub.Endpoint, bytes.NewBufferString(body))
+	if err != nil {
+		s.logger.Warn("failed to build webhook request", "endpoint", sub.Endpoint, "error", err)
+		return
+	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := http.DefaultClient.Do(req)
+
+	resp, err := webhookHTTPClient.Do(req)
 	if err != nil {
 		s.logger.Warn("failed to deliver to webhook", "endpoint", sub.Endpoint, "error", err)
 		return
 	}
-	_ = resp.Body.Close()
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode >= 400 {
+		s.logger.Warn("webhook delivery failed",
+			"endpoint", sub.Endpoint,
+			"subscription_id", sub.ID,
+			"status", resp.StatusCode)
+		return
+	}
 }

--- a/internal/core/services/notify_unit_test.go
+++ b/internal/core/services/notify_unit_test.go
@@ -1,10 +1,16 @@
 package services_test
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
@@ -407,6 +413,75 @@ func testNotifyServiceUnitPublishErrors(t *testing.T) {
 		<-done
 	})
 
+	t.Run("Publish_WebhookNon2xxStatus", func(t *testing.T) {
+		// Issue #338: webhook delivery must surface non-2xx HTTP responses.
+		var (
+			mu       sync.Mutex
+			received bool
+		)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			received = true
+			mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		var logBuf bytes.Buffer
+		var logMu sync.Mutex
+		capturingLogger := slog.New(slog.NewTextHandler(&lockedWriter{w: &logBuf, mu: &logMu}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		mockRepo2 := new(MockNotifyRepo)
+		mockQueueSvc2 := new(MockQueueService)
+		mockEventSvc2 := new(MockEventService)
+		mockAuditSvc2 := new(MockAuditService)
+		rbacSvc2 := new(MockRBACService)
+		rbacSvc2.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		svc2 := services.NewNotifyService(services.NotifyServiceParams{
+			Repo:     mockRepo2,
+			RBACSvc:  rbacSvc2,
+			QueueSvc: mockQueueSvc2,
+			EventSvc: mockEventSvc2,
+			AuditSvc: mockAuditSvc2,
+			Logger:   capturingLogger,
+		})
+
+		done := make(chan struct{})
+		topicID := uuid.New()
+		topic := &domain.Topic{ID: topicID, UserID: userID}
+		sub := &domain.Subscription{
+			ID:       uuid.New(),
+			UserID:   userID,
+			TopicID:  topicID,
+			Protocol: domain.ProtocolWebhook,
+			Endpoint: server.URL,
+		}
+		mockRepo2.On("GetTopicByID", mock.Anything, topicID, userID).Return(topic, nil).Once()
+		mockRepo2.On("SaveMessage", mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo2.On("ListSubscriptions", mock.Anything, topicID).Return([]*domain.Subscription{sub}, nil).Once()
+		mockEventSvc2.On("RecordEvent", mock.Anything, "TOPIC_PUBLISHED", mock.Anything, "TOPIC", mock.Anything).Return(nil).Once()
+		mockAuditSvc2.On("Log", mock.Anything, userID, "notify.publish", "topic", topicID.String(), mock.Anything).Return(nil).Run(func(mock.Arguments) { close(done) }).Once()
+
+		err := svc2.Publish(ctx, topicID, "hello")
+		require.NoError(t, err)
+		<-done
+
+		// Allow the async webhook goroutine a moment to fire and log.
+		require.Eventually(t, func() bool {
+			mu.Lock()
+			defer mu.Unlock()
+			return received
+		}, 2*time.Second, 10*time.Millisecond, "webhook server never received request")
+
+		require.Eventually(t, func() bool {
+			logMu.Lock()
+			defer logMu.Unlock()
+			return strings.Contains(logBuf.String(), "webhook delivery failed") &&
+				strings.Contains(logBuf.String(), "status=500")
+		}, 2*time.Second, 10*time.Millisecond, "expected webhook delivery failure log with status=500")
+	})
+
 	t.Run("Publish_QueueInvalidUUID", func(t *testing.T) {
 		done := make(chan struct{})
 		topicID := uuid.New()
@@ -429,4 +504,15 @@ func testNotifyServiceUnitPublishErrors(t *testing.T) {
 		require.NoError(t, err)
 		<-done
 	})
+}
+
+type lockedWriter struct {
+	w  *bytes.Buffer
+	mu *sync.Mutex
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
 }

--- a/internal/core/services/password_reset.go
+++ b/internal/core/services/password_reset.go
@@ -75,10 +75,9 @@ func (s *PasswordResetService) RequestReset(ctx context.Context, email string) e
 		return err
 	}
 
-	// Note: EmailService integration is pending.
-	// For MVP/Demo: Log the token so we can test it manually.
-	// Future: Inject and use EmailService here.
-	s.logger.Debug("password reset token", "email", email, "token", token)
+	// TODO: deliver `token` via an injected EmailService once available.
+	// Never log or persist the plaintext token — its only safe destination is the user.
+	s.logger.Info("password reset token issued", "user_id", user.ID, "token_id", resetToken.ID)
 
 	return nil
 }

--- a/internal/handlers/storage_handler.go
+++ b/internal/handlers/storage_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -37,6 +38,80 @@ const (
 	errInvalidUploadID = "invalid upload id"
 	headerContentSha256 = "X-Content-Sha256"
 )
+
+// contentDispositionAttachment builds a safe `Content-Disposition: attachment`
+// header for a stored object.
+//
+// Object keys can contain path segments, non-ASCII characters, control
+// characters, quotes, backslashes, or CRLF that — if interpolated naively —
+// would either corrupt the header (HTTP response splitting) or let an attacker
+// inject additional headers. The output therefore emits two parameters per
+// RFC 6266:
+//
+//   - `filename="..."`     ASCII-only fallback for legacy clients. All bytes
+//                          outside the safe printable range and the two
+//                          characters that are special inside a quoted-string
+//                          (`"` and `\`) are replaced with `_`.
+//   - `filename*=UTF-8''…` RFC 5987 percent-encoded form preserving the
+//                          original Unicode basename for modern clients.
+//
+// `path.Base` is used to discard any path segments embedded in the key. If the
+// resulting name is empty we fall back to "download".
+func contentDispositionAttachment(key string) string {
+	name := path.Base(key)
+	if name == "." || name == "/" || name == "" {
+		name = "download"
+	}
+
+	return fmt.Sprintf(`attachment; filename="%s"; filename*=UTF-8''%s`,
+		asciiFilenameFallback(name), rfc5987Encode(name))
+}
+
+// asciiFilenameFallback returns an ASCII-only sanitized copy of name suitable
+// for the legacy `filename=` parameter. Any byte that is a control character
+// (<0x20 or 0x7f), non-ASCII (>=0x80), or special inside a quoted-string is
+// replaced with `_` so the value can be safely wrapped in double quotes.
+func asciiFilenameFallback(name string) string {
+	out := make([]byte, 0, len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c < 0x20, c == 0x7f, c >= 0x80, c == '"', c == '\\':
+			out = append(out, '_')
+		default:
+			out = append(out, c)
+		}
+	}
+	if len(out) == 0 {
+		return "download"
+	}
+	return string(out)
+}
+
+// rfc5987Encode percent-encodes a value per RFC 5987 attr-char rules so it can
+// be safely placed in a `filename*` parameter.
+func rfc5987Encode(s string) string {
+	const hex = "0123456789ABCDEF"
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z',
+			c >= 'a' && c <= 'z',
+			c >= '0' && c <= '9',
+			c == '!', c == '#', c == '$', c == '&', c == '+',
+			c == '-', c == '.', c == '^', c == '_', c == '`',
+			c == '|', c == '~':
+			b.WriteByte(c)
+		default:
+			b.WriteByte('%')
+			b.WriteByte(hex[c>>4])
+			b.WriteByte(hex[c&0x0f])
+		}
+	}
+	return b.String()
+}
 
 // Upload uploads an object to a bucket
 // @Summary Upload an object
@@ -105,7 +180,7 @@ func (h *StorageHandler) Download(c *gin.Context) {
 	defer func() { _ = reader.Close() }()
 
 	// Set headers
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", key))
+	c.Header("Content-Disposition", contentDispositionAttachment(key))
 	c.Header("Content-Type", obj.ContentType)
 	c.Header("Content-Length", fmt.Sprintf("%d", obj.SizeBytes))
 
@@ -461,7 +536,7 @@ func (h *StorageHandler) ServePresignedDownload(c *gin.Context) {
 	}
 	defer func() { _ = reader.Close() }()
 
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", key))
+	c.Header("Content-Disposition", contentDispositionAttachment(key))
 	c.Header("Content-Type", obj.ContentType)
 	c.Header("Content-Length", fmt.Sprintf("%d", obj.SizeBytes))
 	_, _ = io.Copy(c.Writer, reader)

--- a/internal/handlers/storage_handler_content_disposition_test.go
+++ b/internal/handlers/storage_handler_content_disposition_test.go
@@ -1,0 +1,86 @@
+package httphandlers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestContentDispositionAttachment(t *testing.T) {
+	cases := []struct {
+		name           string
+		key            string
+		wantFilename   string
+		wantFilenameStar string
+	}{
+		{
+			name:             "simple ascii filename",
+			key:              "report.pdf",
+			wantFilename:     `filename="report.pdf"`,
+			wantFilenameStar: `filename*=UTF-8''report.pdf`,
+		},
+		{
+			name:             "nested key uses basename",
+			key:              "exports/2026/q1/report.pdf",
+			wantFilename:     `filename="report.pdf"`,
+			wantFilenameStar: `filename*=UTF-8''report.pdf`,
+		},
+		{
+			name:             "CRLF response splitting attempt is sanitized",
+			key:              "evil\r\nSet-Cookie: pwned=1",
+			wantFilename:     `filename="evil__Set-Cookie: pwned=1"`,
+			wantFilenameStar: `filename*=UTF-8''evil%0D%0ASet-Cookie%3A%20pwned%3D1`,
+		},
+		{
+			name:             "embedded quote and backslash are sanitized",
+			key:              `bad"name\file.txt`,
+			wantFilename:     `filename="bad_name_file.txt"`,
+			wantFilenameStar: `filename*=UTF-8''bad%22name%5Cfile.txt`,
+		},
+		{
+			name:             "non-ASCII falls back in legacy filename, preserved in filename*",
+			key:              "résumé.pdf",
+			wantFilename:     `filename="r__sum__.pdf"`, // 2 bytes per accented char both replaced
+			wantFilenameStar: `filename*=UTF-8''r%C3%A9sum%C3%A9.pdf`,
+		},
+		{
+			name:             "empty key falls back to download",
+			key:              "",
+			wantFilename:     `filename="download"`,
+			wantFilenameStar: `filename*=UTF-8''download`,
+		},
+		{
+			name:             "trailing slash falls back to download",
+			key:              "folder/",
+			wantFilename:     `filename="folder"`, // path.Base normalizes
+			wantFilenameStar: `filename*=UTF-8''folder`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := contentDispositionAttachment(tc.key)
+			if !strings.HasPrefix(got, "attachment; ") {
+				t.Errorf("missing attachment prefix: %q", got)
+			}
+			if !strings.Contains(got, tc.wantFilename) {
+				t.Errorf("missing legacy filename param\n got:  %q\n want: %q", got, tc.wantFilename)
+			}
+			if !strings.Contains(got, tc.wantFilenameStar) {
+				t.Errorf("missing filename* param\n got:  %q\n want: %q", got, tc.wantFilenameStar)
+			}
+			if strings.ContainsAny(got, "\r\n") {
+				t.Errorf("output must not contain CR/LF: %q", got)
+			}
+		})
+	}
+}
+
+func TestContentDispositionAttachment_NoCRLFEverEscapes(t *testing.T) {
+	for _, c := range []byte{'\r', '\n', 0, 0x1f, 0x7f} {
+		key := "x" + string(c) + "y"
+		got := contentDispositionAttachment(key)
+		if strings.ContainsAny(got, "\r\n") {
+			t.Fatalf("control byte 0x%02x leaked into header: %q", c, got)
+		}
+	}
+}

--- a/internal/repositories/k8s/provisioner.go
+++ b/internal/repositories/k8s/provisioner.go
@@ -108,7 +108,9 @@ func (p *KubeadmProvisioner) Provision(ctx context.Context, cluster *domain.Clus
 	}
 
 	cluster.Status = domain.ClusterStatusRunning
-	_ = p.repo.Update(ctx, cluster)
+	if err := p.repo.Update(ctx, cluster); err != nil {
+		return fmt.Errorf("provisioning succeeded but failed to persist running status for cluster %s: %w", cluster.ID, err)
+	}
 	return nil
 }
 
@@ -185,7 +187,9 @@ func (p *KubeadmProvisioner) provisionControlPlane(ctx context.Context, cluster 
 		return p.failCluster(ctx, cluster, "control plane node failed to get an IP", nil)
 	}
 	cluster.ControlPlaneIPs = append(cluster.ControlPlaneIPs, masterIP)
-	_ = p.repo.Update(ctx, cluster)
+	if err := p.repo.Update(ctx, cluster); err != nil {
+		return p.failCluster(ctx, cluster, "failed to persist control plane IP", err)
+	}
 
 	// Wait for kubeadm init to finish and kubeconfig to be available via SSH
 	p.logger.Info("waiting for kubeadm init to complete", "ip", masterIP)
@@ -202,7 +206,9 @@ func (p *KubeadmProvisioner) provisionControlPlane(ctx context.Context, cluster 
 	}
 	cluster.KubeconfigEncrypted = encryptedKubeconfig
 
-	_ = p.repo.Update(ctx, cluster)
+	if err := p.repo.Update(ctx, cluster); err != nil {
+		return p.failCluster(ctx, cluster, "failed to persist encrypted kubeconfig", err)
+	}
 	return nil
 }
 
@@ -462,7 +468,12 @@ func (p *KubeadmProvisioner) Deprovision(ctx context.Context, cluster *domain.Cl
 
 func (p *KubeadmProvisioner) failCluster(ctx context.Context, cluster *domain.Cluster, msg string, err error) error {
 	cluster.Status = domain.ClusterStatusFailed
-	_ = p.repo.Update(ctx, cluster)
+	if updateErr := p.repo.Update(ctx, cluster); updateErr != nil {
+		// We're already returning a failure; log so the persistence
+		// gap is visible in operations rather than silently dropped.
+		p.logger.Error("failed to persist failed cluster status",
+			"cluster_id", cluster.ID, "error", updateErr, "original_error", err)
+	}
 	p.logger.Error(msg, "cluster_id", cluster.ID, "error", err)
 	return fmt.Errorf("%s: %w", msg, err)
 }

--- a/internal/repositories/k8s/provisioner_extra_test.go
+++ b/internal/repositories/k8s/provisioner_extra_test.go
@@ -106,22 +106,40 @@ func TestCreateBackup_Extra(t *testing.T) {
 
 func TestFailCluster(t *testing.T) {
 	ctx := context.Background()
-	repo := new(mockClusterRepo)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	cluster := &domain.Cluster{ID: uuid.New()}
 
-	p := &KubeadmProvisioner{
-		repo:   repo,
-		logger: logger,
-	}
+	t.Run("UpdateSucceeds", func(t *testing.T) {
+		repo := new(mockClusterRepo)
+		cluster := &domain.Cluster{ID: uuid.New()}
+		p := &KubeadmProvisioner{repo: repo, logger: logger}
 
-	repo.On("Update", ctx, mock.MatchedBy(func(c *domain.Cluster) bool {
-		return c.Status == domain.ClusterStatusFailed
-	})).Return(nil).Once()
+		repo.On("Update", ctx, mock.MatchedBy(func(c *domain.Cluster) bool {
+			return c.Status == domain.ClusterStatusFailed
+		})).Return(nil).Once()
 
-	err := p.failCluster(ctx, cluster, "test error", fmt.Errorf("underlying"))
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "test error")
+		err := p.failCluster(ctx, cluster, "test error", fmt.Errorf("underlying"))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "test error")
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("UpdateFails_StillReturnsOriginalError", func(t *testing.T) {
+		repo := new(mockClusterRepo)
+		cluster := &domain.Cluster{ID: uuid.New()}
+		p := &KubeadmProvisioner{repo: repo, logger: logger}
+
+		repo.On("Update", ctx, mock.Anything).Return(fmt.Errorf("db down")).Once()
+
+		err := p.failCluster(ctx, cluster, "test error", fmt.Errorf("underlying"))
+		require.Error(t, err)
+		// Original failure must surface, not the persistence error.
+		assert.Contains(t, err.Error(), "test error")
+		assert.Contains(t, err.Error(), "underlying")
+		assert.NotContains(t, err.Error(), "db down")
+		// In-memory status still flipped to Failed even if persistence failed.
+		assert.Equal(t, domain.ClusterStatusFailed, cluster.Status)
+		repo.AssertExpectations(t)
+	})
 }
 
 func TestDeprovision(t *testing.T) {


### PR DESCRIPTION
 Closes #310.

  Four `repo.Update()` calls in `internal/repositories/k8s/provisioner.go` previously discarded their error with `_ =`, hiding silent state divergence between in-memory cluster
  state and the database. If a database write failed, callers would either see `nil` (success) despite uncommitted state, or — in `failCluster` — lose track of the persistence gap
   entirely.

  ## Changes

  - **`Provision` (line 111)** — final `Status = Running` update now returns a wrapped error if persistence fails, so the caller knows provisioning succeeded but the running
  status was not durably committed.
  - **`provisionControlPlane` (lines 188, 205)** — `ControlPlaneIPs` and `KubeconfigEncrypted` updates now route failures through `failCluster`, marking the cluster `Failed`
  consistently instead of silently leaving it in `Provisioning`.
  - **`failCluster` (line 463)** — secondary update failure is now logged with both the persistence error and the original failure error, while the original failure error is still
   returned to the caller (so the root cause is never masked by the persistence error).

  ## Test plan

  - [x] `go build ./...` clean
  - [x] `go test ./internal/repositories/k8s/...` passes
  - [x] New regression subtest `TestFailCluster/UpdateFails_StillReturnsOriginalError` verifies the original failure error is preserved and `cluster.Status` is still flipped to
  `Failed` in memory when status persistence fails
  - [x] Existing `TestFailCluster/UpdateSucceeds` retained to cover the happy path