### PR TITLE
fix(#347): add origin allowlist for SSE endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ APP_ENV=development # development or production
 # credentialed dev endpoints.
 # WS_ALLOWED_ORIGINS=https://console.example.com,https://app.example.com
 
+# Dashboard SSE cross-origin control (default: deny all)
+# Comma-separated list of permitted Origin header values for SSE stream.
+# Empty = deny all cross-origin SSE. Use "*" for dev only.
+# DASHBOARD_ALLOWED_ORIGINS=https://console.example.com,https://app.example.com
+
 # Database Configuration
 DB_USER=cloud
 DB_PASSWORD=cloud

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -91,7 +91,7 @@ func InitHandlers(svcs *Services, cfg *platform.Config, logger *slog.Logger) *Ha
 		Event:         httphandlers.NewEventHandler(svcs.Event),
 		Volume:        httphandlers.NewVolumeHandler(svcs.Volume),
 		LB:            httphandlers.NewLBHandler(svcs.LB),
-		Dashboard:     httphandlers.NewDashboardHandler(svcs.Dashboard),
+		Dashboard:     httphandlers.NewDashboardHandler(svcs.Dashboard, logger, cfg.DashboardAllowedOrigins),
 		RBAC:          httphandlers.NewRBACHandler(svcs.RBAC),
 		Snapshot:      httphandlers.NewSnapshotHandler(svcs.Snapshot),
 		Stack:         httphandlers.NewStackHandler(svcs.Stack),

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
@@ -80,6 +81,7 @@ type Handlers struct {
 
 // InitHandlers constructs HTTP handlers and websocket hub.
 func InitHandlers(svcs *Services, cfg *platform.Config, logger *slog.Logger) *Handlers {
+	origins := strings.Split(cfg.DashboardAllowedOrigins, ",")
 	return &Handlers{
 		Audit:         httphandlers.NewAuditHandler(svcs.Audit),
 		Identity:      httphandlers.NewIdentityHandler(svcs.Identity),
@@ -91,7 +93,7 @@ func InitHandlers(svcs *Services, cfg *platform.Config, logger *slog.Logger) *Ha
 		Event:         httphandlers.NewEventHandler(svcs.Event),
 		Volume:        httphandlers.NewVolumeHandler(svcs.Volume),
 		LB:            httphandlers.NewLBHandler(svcs.LB),
-		Dashboard:     httphandlers.NewDashboardHandler(svcs.Dashboard, logger, cfg.DashboardAllowedOrigins),
+		Dashboard:     httphandlers.NewDashboardHandler(svcs.Dashboard, logger, origins...),
 		RBAC:          httphandlers.NewRBACHandler(svcs.RBAC),
 		Snapshot:      httphandlers.NewSnapshotHandler(svcs.Snapshot),
 		Stack:         httphandlers.NewStackHandler(svcs.Stack),

--- a/internal/handlers/dashboard_handler.go
+++ b/internal/handlers/dashboard_handler.go
@@ -2,8 +2,10 @@
 package httphandlers
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -13,12 +15,23 @@ import (
 
 // DashboardHandler handles dashboard API endpoints.
 type DashboardHandler struct {
-	svc ports.DashboardService
+	svc            ports.DashboardService
+	logger        *slog.Logger
+	allowedOrigins []string
 }
 
 // NewDashboardHandler creates a new dashboard handler.
-func NewDashboardHandler(svc ports.DashboardService) *DashboardHandler {
-	return &DashboardHandler{svc: svc}
+// allowedOrigins is an optional list of permitted Origin header values for SSE.
+// If empty, cross-origin SSE requests are denied.
+func NewDashboardHandler(svc ports.DashboardService, logger *slog.Logger, allowedOrigins ...string) *DashboardHandler {
+	cleaned := make([]string, 0, len(allowedOrigins))
+	for _, raw := range allowedOrigins {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	return &DashboardHandler{svc: svc, logger: logger, allowedOrigins: cleaned}
 }
 
 // GetSummary returns resource counts and overview metrics.
@@ -98,10 +111,16 @@ func (h *DashboardHandler) GetStats(c *gin.Context) {
 // @Security APIKeyAuth
 // @Router /api/dashboard/stream [get]
 func (h *DashboardHandler) StreamEvents(c *gin.Context) {
+	origin := c.Request.Header.Get("Origin")
+	if !h.isOriginAllowed(origin) {
+		c.AbortWithStatus(http.StatusForbidden)
+		return
+	}
+	c.Header("Access-Control-Allow-Origin", origin)
+
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")
 	c.Header("Connection", "keep-alive")
-	c.Header("Access-Control-Allow-Origin", "*")
 
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
@@ -126,4 +145,21 @@ func (h *DashboardHandler) StreamEvents(c *gin.Context) {
 			c.Writer.Flush()
 		}
 	}
+}
+
+// isOriginAllowed returns true if the given origin is permitted for SSE.
+// Empty allowlist means deny all. "*" in allowlist means allow any origin.
+func (h *DashboardHandler) isOriginAllowed(origin string) bool {
+	if len(h.allowedOrigins) == 0 {
+		return false // fail-closed by default
+	}
+	for _, allowed := range h.allowedOrigins {
+		if allowed == "*" {
+			return true
+		}
+		if allowed == origin {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/handlers/dashboard_handler.go
+++ b/internal/handlers/dashboard_handler.go
@@ -31,6 +31,10 @@ func NewDashboardHandler(svc ports.DashboardService, logger *slog.Logger, allowe
 			cleaned = append(cleaned, trimmed)
 		}
 	}
+	if len(cleaned) == 0 && logger != nil {
+		logger.Warn("DashboardHandler: cross-origin SSE is disabled (no allowed origins configured). " +
+			"Set DASHBOARD_ALLOWED_ORIGINS env var to enable.")
+	}
 	return &DashboardHandler{svc: svc, logger: logger, allowedOrigins: cleaned}
 }
 

--- a/internal/handlers/dashboard_handler.go
+++ b/internal/handlers/dashboard_handler.go
@@ -113,6 +113,11 @@ func (h *DashboardHandler) GetStats(c *gin.Context) {
 func (h *DashboardHandler) StreamEvents(c *gin.Context) {
 	origin := c.Request.Header.Get("Origin")
 	if !h.isOriginAllowed(origin) {
+		if origin != "" && h.logger != nil {
+			h.logger.Warn("SSE stream rejected: origin not in allowlist",
+				"origin", origin,
+				"path", c.Request.URL.Path)
+		}
 		c.AbortWithStatus(http.StatusForbidden)
 		return
 	}

--- a/internal/handlers/dashboard_handler_test.go
+++ b/internal/handlers/dashboard_handler_test.go
@@ -218,3 +218,135 @@ func TestDashboardHandlerErrors(t *testing.T) {
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
 }
+
+func TestDashboardHandlerStreamEvents_OriginNotAllowed(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	mockSvc := new(dashboardServiceMock)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Only "https://allowed.example.com" is allowed — anything else is rejected
+	handler := NewDashboardHandler(mockSvc, logger, "https://allowed.example.com")
+	r := gin.New()
+	r.GET("/stream", handler.StreamEvents)
+
+	summary := &domain.ResourceSummary{TotalInstances: 10}
+	mockSvc.On("GetSummary", mock.Anything).Return(summary, nil)
+
+	req, _ := http.NewRequest("GET", "/stream", nil)
+	req.Header.Set("Origin", "https://evil.example.com")
+	w := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	go r.ServeHTTP(w, req)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// Request should be rejected with 403 before SSE headers are sent
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestDashboardHandlerStreamEvents_OriginAllowed(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	mockSvc := new(dashboardServiceMock)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewDashboardHandler(mockSvc, logger, "https://app.example.com")
+	r := gin.New()
+	r.GET("/stream", handler.StreamEvents)
+
+	summary := &domain.ResourceSummary{TotalInstances: 10}
+	mockSvc.On("GetSummary", mock.Anything).Return(summary, nil)
+
+	req, _ := http.NewRequest("GET", "/stream", nil)
+	req.Header.Set("Origin", "https://app.example.com")
+	w := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	go r.ServeHTTP(w, req)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/event-stream")
+	assert.Contains(t, w.Body.String(), "event:summary")
+	assert.Equal(t, "https://app.example.com", w.Header().Get("Access-Control-Allow-Origin"))
+}
+
+func TestDashboardHandlerStreamEvents_WildcardAllowsAny(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	mockSvc := new(dashboardServiceMock)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewDashboardHandler(mockSvc, logger, "*")
+	r := gin.New()
+	r.GET("/stream", handler.StreamEvents)
+
+	summary := &domain.ResourceSummary{TotalInstances: 10}
+	mockSvc.On("GetSummary", mock.Anything).Return(summary, nil)
+
+	req, _ := http.NewRequest("GET", "/stream", nil)
+	req.Header.Set("Origin", "https://anything.com")
+	w := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	go r.ServeHTTP(w, req)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/event-stream")
+	assert.Contains(t, w.Body.String(), "event:summary")
+}
+
+func TestDashboardHandlerStreamEvents_EmptyAllowlistDenied(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	mockSvc := new(dashboardServiceMock)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Empty allowlist = fail-closed
+	handler := NewDashboardHandler(mockSvc, logger)
+	r := gin.New()
+	r.GET("/stream", handler.StreamEvents)
+
+	req, _ := http.NewRequest("GET", "/stream", nil)
+	req.Header.Set("Origin", "https://anything.com")
+	w := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	go r.ServeHTTP(w, req)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// Empty allowlist → deny all cross-origin → 403
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestDashboardHandlerStreamEvents_SameOriginNoHeader(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+	mockSvc := new(dashboardServiceMock)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// With wildcard, same-origin (no Origin header) should be allowed
+	handler := NewDashboardHandler(mockSvc, logger, "*")
+	r := gin.New()
+	r.GET("/stream", handler.StreamEvents)
+
+	summary := &domain.ResourceSummary{TotalInstances: 10}
+	mockSvc.On("GetSummary", mock.Anything).Return(summary, nil)
+
+	req, _ := http.NewRequest("GET", "/stream", nil)
+	// No Origin header set — same-origin request
+	w := httptest.NewRecorder()
+	ctx, cancel := context.WithCancel(context.Background())
+	req = req.WithContext(ctx)
+
+	go r.ServeHTTP(w, req)
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	// No Origin header = same-origin → allowed with wildcard
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/event-stream")
+	assert.Contains(t, w.Body.String(), "event:summary")
+}

--- a/internal/handlers/dashboard_handler_test.go
+++ b/internal/handlers/dashboard_handler_test.go
@@ -3,6 +3,8 @@ package httphandlers
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -52,7 +54,8 @@ func (m *dashboardServiceMock) GetStats(ctx context.Context) (*domain.DashboardS
 func setupDashboardHandlerTest(_ *testing.T) (*dashboardServiceMock, *DashboardHandler, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	mockSvc := new(dashboardServiceMock)
-	handler := NewDashboardHandler(mockSvc)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := NewDashboardHandler(mockSvc, logger, "*") // "*" for test allowlist
 	r := gin.New()
 	return mockSvc, handler, r
 }

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -31,6 +31,10 @@ type Config struct {
 	// permitted to open a WebSocket connection. Empty means deny all
 	// cross-origin upgrades. See #249.
 	WSAllowedOrigins     string
+	// DashboardAllowedOrigins is a comma-separated allowlist of Origin headers
+	// permitted for SSE connections. Empty means deny all cross-origin SSE.
+	// See #347.
+	DashboardAllowedOrigins string
 	LvmVgName            string
 	ObjectStorageMode    string
 	ObjectStorageNodes   string
@@ -71,6 +75,7 @@ func NewConfig() (*Config, error) {
 		StorageBackend:       getEnv("STORAGE_BACKEND", "noop"),
 		StorageSecret:        getEnv("STORAGE_SECRET", "storage-secret-key"),
 		WSAllowedOrigins:     os.Getenv("WS_ALLOWED_ORIGINS"),
+		DashboardAllowedOrigins: os.Getenv("DASHBOARD_ALLOWED_ORIGINS"),
 		LvmVgName:            getEnv("LVM_VG_NAME", "thecloud-vg"),
 		ObjectStorageMode:    getEnv("OBJECT_STORAGE_MODE", "local"),
 


### PR DESCRIPTION
## Summary

Replaces `Access-Control-Allow-Origin: *` on the dashboard SSE endpoint with origin validation that denies cross-origin SSE by default. The validated origin is echoed back instead of using a wildcard.

## Changes

- `DashboardHandler` now stores an `allowedOrigins` list and validates it in `StreamEvents` before streaming any data
- `StreamEvents` returns `403 Forbidden` if the requesting origin is not in the allowlist
- Empty allowlist = fail-closed (deny all cross-origin SSE)
- `*` in allowlist = allow any origin (development mode)
- `platform.Config.DashboardAllowedOrigins` loaded from `DASHBOARD_ALLOWED_ORIGINS` env var (following the same pattern as `WSAllowedOrigins`)
- `.env.example` updated with the new variable

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/handlers/... -run DashboardHandler` — all 7 tests pass
- [x] Existing `TestDashboardHandlerStreamEvents` uses `"*"` in allowlist so it continues to work

Fixes #347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced configurable CORS origin allowlist for dashboard Server-Sent Events (SSE)
  * Added `DASHBOARD_ALLOWED_ORIGINS` environment variable to control permitted cross-origin requests
  * Implemented origin validation with deny-by-default policy; requests from disallowed origins receive 403 status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->