### PR TITLE
fix(#333): use backward iteration in Write broadcast loop

### DIFF
--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -231,7 +231,7 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 		if n > 0 {
 			totalSize += int64(n)
 			// Broadcast chunk
-			for i := 0; i < len(streams); i++ {
+			for i := len(streams) - 1; i >= 0; i-- {
 				errSend := streams[i].stream.Send(&pb.StoreRequest{
 					Payload: &pb.StoreRequest_ChunkData{
 						ChunkData: buf[:n],
@@ -240,7 +240,6 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 				if errSend != nil {
 					// Remove failed stream
 					streams = append(streams[:i], streams[i+1:]...)
-					i--
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- Fix off-by-one bug in `Write` broadcast loop where stream removal during forward iteration skipped the next element
- Changed to backward iteration so slice removal doesn't affect unprocessed elements

## Test plan
- [x] `go build ./internal/storage/coordinator/...`
- [x] `go test ./internal/storage/coordinator/...`