### PR TITLE
fix: add size limits to prevent unbounded resource exhaustion

### DIFF
--- a/internal/core/services/auth.go
+++ b/internal/core/services/auth.go
@@ -206,6 +206,31 @@ func (s *AuthService) incrementFailure(email string) {
 		s.lockouts[email] = time.Now().Add(s.lockoutDuration)
 		platform.AuthAttemptsTotal.WithLabelValues("failure_lockout").Inc()
 	}
+	// Probabilistically purge expired entries to prevent unbounded map growth.
+	// Every ~10 calls, scan and remove stale entries.
+	if len(s.lockouts) > 0 && time.Now().Nanosecond()%10 == 0 {
+		s.purgeExpiredLocked()
+	}
+}
+
+// purgeExpiredLocked removes expired lockouts and stale failure records.
+// Caller must hold s.mu.
+func (s *AuthService) purgeExpiredLocked() {
+	now := time.Now()
+	for email, lockoutTime := range s.lockouts {
+		if now.After(lockoutTime) {
+			delete(s.lockouts, email)
+			delete(s.failedAttempts, email)
+		}
+	}
+	// Also purge failure-only entries that have no lockout and are very old
+	// (these are users who failed but didn't reach lockout threshold)
+	for email, count := range s.failedAttempts {
+		// If count is suspiciously high, purge to prevent unbounded growth
+		if count > maxFailedAttempts*10 {
+			delete(s.failedAttempts, email)
+		}
+	}
 }
 
 func (s *AuthService) GetUserByID(ctx context.Context, userID uuid.UUID) (*domain.User, error) {

--- a/internal/core/services/cache.go
+++ b/internal/core/services/cache.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"strconv"
@@ -22,6 +23,8 @@ import (
 
 const (
 	defaultRedisPort = "6379"
+	// maxCacheStatsSize bounds cache stats JSON decoding to prevent memory exhaustion.
+	maxCacheStatsSize = 1 * 1024 * 1024 // 1 MB
 )
 
 // CacheService manages cache clusters and their lifecycle.
@@ -365,7 +368,7 @@ func (s *CacheService) GetCacheStats(ctx context.Context, idOrName string) (*por
 			Limit uint64 `json:"limit"`
 		} `json:"memory_stats"`
 	}
-	if err := json.NewDecoder(stream).Decode(&dockerStats); err != nil {
+	if err := json.NewDecoder(io.LimitReader(stream, maxCacheStatsSize)).Decode(&dockerStats); err != nil {
 		return nil, errors.Wrap(errors.Internal, "failed to decode stats", err)
 	}
 

--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -23,6 +23,11 @@ import (
 	"github.com/poyrazk/thecloud/internal/errors"
 )
 
+const (
+	// maxLogSize bounds log reading in captureInvocationResults to prevent memory exhaustion.
+	maxLogSize = 1 * 1024 * 1024 // 1 MB
+)
+
 // RuntimeConfig describes how a function runtime is executed.
 type RuntimeConfig struct {
 	Image      string
@@ -356,7 +361,7 @@ func (s *FunctionService) waitForTask(ctx context.Context, containerID string, t
 func (s *FunctionService) captureInvocationResults(i *domain.Invocation, containerID string, statusCode int64, waitErr error) {
 	logsReader, _ := s.compute.GetInstanceLogs(context.Background(), containerID)
 	if logsReader != nil {
-		logBytes, _ := io.ReadAll(logsReader)
+		logBytes, _ := io.ReadAll(io.LimitReader(logsReader, maxLogSize))
 		// Sanitize logs to prevent log injection (strip control characters)
 		re := regexp.MustCompile(`[^[:print:][:space:]]`)
 		i.Logs = re.ReplaceAllString(string(logBytes), "?")

--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -34,6 +34,8 @@ const (
 	NanoCPUsPerVCPU = int64(1e9)
 	// BytesPerMB is the number of bytes per megabyte.
 	BytesPerMB = int64(1024 * 1024)
+	// maxStatsSize bounds instance stats JSON decoding to prevent memory exhaustion.
+	maxStatsSize = 1 * 1024 * 1024 // 1 MB
 )
 type InstanceService struct {
 	repo             ports.InstanceRepository
@@ -1112,7 +1114,7 @@ func (s *InstanceService) GetInstanceStats(ctx context.Context, idOrName string)
 	defer func() { _ = stream.Close() }()
 
 	var stats domain.RawDockerStats
-	if err := json.NewDecoder(stream).Decode(&stats); err != nil {
+	if err := json.NewDecoder(io.LimitReader(stream, maxStatsSize)).Decode(&stats); err != nil {
 		return nil, errors.Wrap(errors.Internal, "failed to decode stats", err)
 	}
 

--- a/internal/core/services/storage.go
+++ b/internal/core/services/storage.go
@@ -30,6 +30,7 @@ const (
 	versionQueryFormat   = "%s?versionId=%s"
 	versionEpochBit      = 1 << 62
 	sniffLen             = 512
+	maxPartSize          = 5 * 1024 * 1024 * 1024 // 5 GB per part
 )
 
 // generateVersionID generates a timestamp-based version ID (reverse chronological).
@@ -603,7 +604,7 @@ func (s *StorageService) UploadPart(ctx context.Context, uploadID uuid.UUID, par
 
 	// 3. Write to store (use temporary location)
 	partKey := fmt.Sprintf(partPathFormat, upload.ID.String(), partNumber)
-	size, err := s.store.Write(ctx, upload.Bucket, partKey, teeReader)
+	size, err := s.store.Write(ctx, upload.Bucket, partKey, io.LimitReader(teeReader, maxPartSize))
 	if err != nil {
 		return nil, errors.Wrap(errors.Internal, "failed to write part", err)
 	}

--- a/internal/handlers/storage_handler.go
+++ b/internal/handlers/storage_handler.go
@@ -34,8 +34,9 @@ func NewStorageHandler(svc ports.StorageService, cfg *platform.Config) *StorageH
 }
 
 const (
-	errInvalidUploadID = "invalid upload id"
+	errInvalidUploadID  = "invalid upload id"
 	headerContentSha256 = "X-Content-Sha256"
+	maxUploadSize       = 5 * 1024 * 1024 * 1024 // 5 GB
 )
 
 // Upload uploads an object to a bucket
@@ -61,7 +62,7 @@ func (h *StorageHandler) Upload(c *gin.Context) {
 	providedChecksum := c.GetHeader(headerContentSha256)
 
 	// Read from request body (stream)
-	obj, err := h.svc.Upload(c.Request.Context(), bucket, key, c.Request.Body, providedChecksum)
+	obj, err := h.svc.Upload(c.Request.Context(), bucket, key, io.LimitReader(c.Request.Body, maxUploadSize), providedChecksum)
 	if err != nil {
 		httputil.Error(c, err)
 		return
@@ -318,7 +319,7 @@ func (h *StorageHandler) UploadPart(c *gin.Context) {
 
 	providedChecksum := c.GetHeader(headerContentSha256)
 
-	part, err := h.svc.UploadPart(c.Request.Context(), uploadID, partNumber, c.Request.Body, providedChecksum)
+	part, err := h.svc.UploadPart(c.Request.Context(), uploadID, partNumber, io.LimitReader(c.Request.Body, maxUploadSize), providedChecksum)
 	if err != nil {
 		httputil.Error(c, err)
 		return
@@ -501,7 +502,7 @@ func (h *StorageHandler) ServePresignedUpload(c *gin.Context) {
 	// The Repository `SaveMeta` saves this UserID. It's valid to have Nil (0000...) for system/anon uploads?
 	// It's acceptable for this feature.
 
-	obj, err := h.svc.Upload(c.Request.Context(), bucket, key, c.Request.Body, "")
+	obj, err := h.svc.Upload(c.Request.Context(), bucket, key, io.LimitReader(c.Request.Body, maxUploadSize), "")
 	if err != nil {
 		httputil.Error(c, err)
 		return

--- a/internal/repositories/filesystem/adapter.go
+++ b/internal/repositories/filesystem/adapter.go
@@ -26,7 +26,10 @@ func NewLocalFileStore(basePath string) (*LocalFileStore, error) {
 	return &LocalFileStore{basePath: basePath}, nil
 }
 
-const errTraversal = "invalid path: traversal detected"
+const (
+	errTraversal   = "invalid path: traversal detected"
+	maxObjectSize   = 5 * 1024 * 1024 * 1024 // 5 GB - prevents memory exhaustion during writes
+)
 
 func (s *LocalFileStore) Write(ctx context.Context, bucket, key string, r io.Reader) (int64, error) {
 	bucketPath := filepath.Join(s.basePath, filepath.Clean(bucket))
@@ -46,7 +49,7 @@ func (s *LocalFileStore) Write(ctx context.Context, bucket, key string, r io.Rea
 	}
 	defer func() { _ = f.Close() }()
 
-	n, err := io.Copy(f, r)
+	n, err := io.Copy(f, io.LimitReader(r, maxObjectSize))
 	if err != nil {
 		return 0, errors.Wrap(errors.Internal, "failed to write file", err)
 	}
@@ -130,6 +133,10 @@ func (s *LocalFileStore) Assemble(ctx context.Context, bucket, key string, parts
 			return 0, errors.Wrap(errors.Internal, "failed to copy part", err)
 		}
 		totalSize += n
+		if totalSize > maxObjectSize {
+			_ = os.Remove(partPath)
+			return totalSize, fmt.Errorf("assembled object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize)
+		}
 		_ = os.Remove(partPath) // Cleanup part
 	}
 

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -231,7 +231,7 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 		if n > 0 {
 			totalSize += int64(n)
 			// Broadcast chunk
-			for i := 0; i < len(streams); i++ {
+			for i := len(streams) - 1; i >= 0; i-- {
 				errSend := streams[i].stream.Send(&pb.StoreRequest{
 					Payload: &pb.StoreRequest_ChunkData{
 						ChunkData: buf[:n],
@@ -240,7 +240,6 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 				if errSend != nil {
 					// Remove failed stream
 					streams = append(streams[:i], streams[i+1:]...)
-					i--
 				}
 			}
 		}

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -21,6 +21,8 @@ const (
 	errNoNodesAvailable = "no storage nodes available"
 	chunkSize           = 1024 * 1024 // 1MB chunks
 	repairTimeout       = 30 * time.Second
+	// maxObjectSize prevents memory exhaustion when writing large objects.
+	maxObjectSize = 5 * 1024 * 1024 * 1024 // 5 GB
 )
 
 // Coordinator implements ports.FileStore to manage distributed storage.
@@ -230,6 +232,9 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 		n, err := r.Read(buf)
 		if n > 0 {
 			totalSize += int64(n)
+			if totalSize > maxObjectSize {
+				return totalSize, fmt.Errorf("object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize)
+			}
 			// Broadcast chunk
 			for i := len(streams) - 1; i >= 0; i-- {
 				errSend := streams[i].stream.Send(&pb.StoreRequest{

--- a/internal/storage/node/store.go
+++ b/internal/storage/node/store.go
@@ -4,6 +4,8 @@ package node
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
@@ -17,6 +19,8 @@ type LocalStore struct {
 	rootDir string
 	mu      sync.RWMutex
 }
+
+const maxObjectSize = 5 * 1024 * 1024 * 1024 // 5 GB
 
 // NewLocalStore initializes a new local storage backend.
 func NewLocalStore(dataDir string) (*LocalStore, error) {
@@ -46,9 +50,9 @@ func (s *LocalStore) WriteStream(bucket, key string, r io.Reader, timestamp int6
 		return 0, err
 	}
 
-	n, copyErr := io.Copy(f, r)
+	n, copyErr := io.Copy(f, io.LimitReader(r, maxObjectSize))
 	closeErr := f.Close()
-	if copyErr != nil {
+	if copyErr != nil && !errors.Is(copyErr, io.EOF) {
 		_ = os.Remove(tmpPath)
 		return n, copyErr
 	}
@@ -195,6 +199,11 @@ func (s *LocalStore) Assemble(bucket, key string, parts []string) (int64, error)
 			break
 		}
 		totalSize += n
+		if totalSize > maxObjectSize {
+			_ = f.Close()
+			_ = os.Remove(tmpPath)
+			return totalSize, fmt.Errorf("assembled object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize)
+		}
 	}
 
 	closeErr := f.Close()

--- a/internal/workers/pipeline_worker.go
+++ b/internal/workers/pipeline_worker.go
@@ -30,6 +30,7 @@ const (
 	// Stale threshold for idempotency ledger: builds can take up to 30 min,
 	// so a "running" entry older than this is considered abandoned.
 	pipelineStaleThreshold = 35 * time.Minute
+	maxPayloadSize         = 10 * 1024 * 1024 // 10 MB max pipeline job payload
 )
 
 // PipelineWorker processes queued pipeline builds.
@@ -92,6 +93,11 @@ func (w *PipelineWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
 			}
 
 			var job domain.BuildJob
+			if len(msg.Payload) > maxPayloadSize {
+				w.logger.Error("pipeline job payload too large", "msg_id", msg.ID, "size", len(msg.Payload))
+				w.ackWithLog(ctx, msg.ID, "pipeline payload too large")
+				continue
+			}
 			if err := json.Unmarshal([]byte(msg.Payload), &job); err != nil {
 				w.logger.Error("failed to unmarshal build job",
 					"error", err, "msg_id", msg.ID)
@@ -420,6 +426,11 @@ func (w *PipelineWorker) reclaimLoop(ctx context.Context, sem chan struct{}) {
 			}
 			for _, m := range msgs {
 				var job domain.BuildJob
+				if len(m.Payload) > maxPayloadSize {
+					w.logger.Error("reclaimed pipeline job payload too large", "msg_id", m.ID, "size", len(m.Payload))
+					w.ackWithLog(ctx, m.ID, "pipeline payload too large")
+					continue
+				}
 				if err := json.Unmarshal([]byte(m.Payload), &job); err != nil {
 					w.logger.Error("failed to unmarshal reclaimed pipeline job",
 						"msg_id", m.ID, "error", err)


### PR DESCRIPTION
## Summary

Addresses multiple DoS vectors from unbounded `io` operations and growing maps across the codebase.

## Changes

| File | Fix |
|------|-----|
| `handlers/storage_handler.go` | `io.LimitReader(body, 5GB)` on Upload, UploadPart, ServePresignedUpload |
| `core/services/storage.go` | `io.LimitReader(teeReader, 5GB)` on UploadPart |
| `workers/pipeline_worker.go` | Reject payloads >10MB before `json.Unmarshal` |
| `core/services/instance.go` | `io.LimitReader(stream, 1MB)` on GetInstanceStats JSON decode |
| `core/services/cache.go` | `io.LimitReader(stream, 1MB)` on cache stats JSON decode |
| `core/services/function.go` | `io.LimitReader(logsReader, 1MB)` on log capture |
| `core/services/auth.go` | Probabilistic purge of expired lockout/failure map entries |
| `storage/coordinator/service.go` | Track totalSize and reject if >5GB in Write |
| `storage/node/store.go` | `io.LimitReader` + Assemble size check |
| `repositories/filesystem/adapter.go` | `io.LimitReader(r, 5GB)` on Write |

## Issues Fixed

- #309: PutObject no size limit
- #305: Multipart upload parts no size limit
- #302: `io.ReadAll` without limit (pipeline worker)
- #268: Instance stats JSON decode no size limit
- #267: Pipeline worker JSON unmarshal no payload size limit
- #244: Unbounded auth lockout/failure maps
- #304: Storage write path no size limit

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/handlers/... ./internal/core/services/... ./internal/workers/... ./internal/storage/... ./internal/repositories/...`