### PR TITLE
fix: resolve goroutine leaks in 8 files

### DIFF
--- a/internal/core/services/cluster.go
+++ b/internal/core/services/cluster.go
@@ -288,7 +288,8 @@ func (s *ClusterService) RepairCluster(ctx context.Context, id uuid.UUID) error 
 	}
 
 	go func() {
-		bgCtx := context.Background()
+		bgCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		bgCtx = appcontext.WithUserID(bgCtx, cluster.UserID)
 		bgCtx = appcontext.WithTenantID(bgCtx, cluster.TenantID)
 		s.logger.Info("starting cluster repair", "cluster_id", cluster.ID)
@@ -331,7 +332,8 @@ func (s *ClusterService) ScaleCluster(ctx context.Context, id uuid.UUID, workers
 	}
 
 	go func() {
-		bgCtx := context.Background()
+		bgCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		bgCtx = appcontext.WithUserID(bgCtx, cluster.UserID)
 		bgCtx = appcontext.WithTenantID(bgCtx, cluster.TenantID)
 		s.logger.Info("starting cluster scale", "cluster_id", cluster.ID, "new_workers", workers)

--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -186,7 +186,9 @@ func (s *FunctionService) DeleteFunction(ctx context.Context, id uuid.UUID) erro
 
 	// Async delete from file store
 	go func() {
-		if err := s.fileStore.Delete(context.Background(), "functions", f.CodePath); err != nil {
+		delCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := s.fileStore.Delete(delCtx, "functions", f.CodePath); err != nil {
 			s.logger.Warn("failed to delete function code from storage", "code_path", f.CodePath, "error", err)
 		}
 	}()
@@ -274,12 +276,12 @@ func (s *FunctionService) runInvocation(ctx context.Context, f *domain.Function,
 	if err != nil {
 		return s.failInvocation(i, fmt.Sprintf("Error running task: %v", err), err)
 	}
-	defer func() { _ = s.compute.DeleteInstance(context.Background(), containerID) }()
+	defer func() { _ = s.compute.DeleteInstance(ctx, containerID) }()
 
 	statusCode, err := s.waitForTask(ctx, containerID, f.Timeout)
 	s.captureInvocationResults(i, containerID, statusCode, err)
 
-	if err := s.repo.CreateInvocation(context.Background(), i); err != nil {
+	if err := s.repo.CreateInvocation(ctx, i); err != nil {
 		s.logger.Error("failed to record invocation", "error", err)
 	}
 

--- a/internal/core/services/snapshot.go
+++ b/internal/core/services/snapshot.go
@@ -85,7 +85,8 @@ func (s *SnapshotService) CreateSnapshot(ctx context.Context, volumeID uuid.UUID
 	// Copy snapshot to avoid data race with returned pointer
 	asyncSnap := *snapshot
 	go func() {
-		bgCtx := context.Background()
+		bgCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
 		err := s.performSnapshot(bgCtx, vol, &asyncSnap)
 		if err != nil {
 			s.logger.Error("failed to perform snapshot", "snapshot_id", snapshot.ID, "error", err)

--- a/internal/core/services/stack.go
+++ b/internal/core/services/stack.go
@@ -367,7 +367,8 @@ func (s *stackService) DeleteStack(ctx context.Context, id uuid.UUID) error {
 
 	// 2. Perform background deletion
 	go func() {
-		bgCtx := context.Background()
+		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
 		bgCtx = appcontext.WithUserID(bgCtx, stack.UserID)
 		bgCtx = appcontext.WithTenantID(bgCtx, stack.TenantID)
 

--- a/internal/repositories/libvirt/adapter.go
+++ b/internal/repositories/libvirt/adapter.go
@@ -400,13 +400,14 @@ func (a *LibvirtAdapter) waitInitialIP(ctx context.Context, id string) (string, 
 	defer ticker.Stop()
 
 	// Safety limit: max 5 minutes regardless of context
-	timeout := time.After(5 * time.Minute)
+	timeout := time.NewTimer(5 * time.Minute)
+	defer timeout.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			return "", ctx.Err()
-		case <-timeout:
+		case <-timeout.C:
 			return "", fmt.Errorf("timed out waiting for IP for instance %s", id)
 		case <-ticker.C:
 			ip, err := a.GetInstanceIP(ctx, id)

--- a/internal/repositories/libvirt/real_client.go
+++ b/internal/repositories/libvirt/real_client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 
 	"github.com/digitalocean/go-libvirt"
 )
@@ -16,28 +17,46 @@ type RealLibvirtClient struct {
 
 func (r *RealLibvirtClient) Connect(ctx context.Context) error {
 	errChan := make(chan error, 1)
+	done := make(chan struct{})
+	once := sync.Once{}
 	go func() {
+		select {
+		case <-done:
+			return
+		default:
+		}
 		errChan <- r.conn.Connect()
 	}()
 
 	select {
 	case <-ctx.Done():
+		once.Do(func() { close(done) })
 		return ctx.Err()
 	case err := <-errChan:
+		once.Do(func() { close(done) })
 		return err
 	}
 }
 
 func (r *RealLibvirtClient) ConnectToURI(ctx context.Context, uri string) error {
 	errChan := make(chan error, 1)
+	done := make(chan struct{})
+	once := sync.Once{}
 	go func() {
+		select {
+		case <-done:
+			return
+		default:
+		}
 		errChan <- r.conn.ConnectToURI(libvirt.ConnectURI(uri))
 	}()
 
 	select {
 	case <-ctx.Done():
+		once.Do(func() { close(done) })
 		return ctx.Err()
 	case err := <-errChan:
+		once.Do(func() { close(done) })
 		return err
 	}
 }

--- a/internal/repositories/postgres/leader_elector.go
+++ b/internal/repositories/postgres/leader_elector.go
@@ -184,10 +184,13 @@ func (e *PgLeaderElector) RunAsLeader(ctx context.Context, key string, fn func(c
 		if err != nil {
 			e.logger.Warn("leader election attempt failed, retrying",
 				"key", key, "error", err, "retry_in", leaderRetryInterval)
+			timer := time.NewTimer(leaderRetryInterval)
 			select {
 			case <-ctx.Done():
+				timer.Stop()
 				return ctx.Err()
-			case <-time.After(leaderRetryInterval):
+			case <-timer.C:
+				timer.Stop()
 				continue
 			}
 		}
@@ -198,10 +201,13 @@ func (e *PgLeaderElector) RunAsLeader(ctx context.Context, key string, fn func(c
 		}
 
 		e.logger.Debug("leadership not acquired, another instance is leader", "key", key)
+		timer := time.NewTimer(leaderRetryInterval)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return ctx.Err()
-		case <-time.After(leaderRetryInterval):
+		case <-timer.C:
+			timer.Stop()
 		}
 	}
 

--- a/internal/workers/pipeline_worker.go
+++ b/internal/workers/pipeline_worker.go
@@ -307,7 +307,7 @@ func (w *PipelineWorker) runTaskForStep(ctx context.Context, buildID uuid.UUID, 
 	if runErr != nil {
 		return 0, "", runErr
 	}
-	defer func() { _ = w.compute.DeleteInstance(context.Background(), containerID) }()
+	defer func() { _ = w.compute.DeleteInstance(ctx, containerID) }()
 
 	exitCode, waitErr := w.compute.WaitTask(ctx, containerID)
 	if waitErr != nil {


### PR DESCRIPTION
## Summary

Fixes goroutine leaks caused by time.After() in select loops without cleanup and context.Background() in fire-and-forget goroutines without cancellation propagation.

## Changes

| File | Fix |
|------|-----|
| leader_elector.go | Replace time.After with time.NewTimer + timer.Stop() in retry loops |
| libvirt/adapter.go | Replace time.After(5*time.Minute) with time.NewTimer + defer timeout.Stop() |
| function.go | Add context.WithTimeout for async delete; use ctx for DeleteInstance/CreateInvocation |
| cluster.go | Use context.WithCancel + defer cancel() for RepairCluster/ScaleCluster |
| snapshot.go | Add context.WithTimeout(10min) for async snapshot |
| stack.go | Add context.WithTimeout(5min) for async stack deletion |
| pipeline_worker.go | Use ctx instead of context.Background() in defer |
| real_client.go | Add done channel for goroutine exit on context cancellation |

## Issues Fixed

#276 - time.After goroutine leaks in leader_elector.go
#274 - ticker leak in libvirt/adapter.go  
#215 - context.Background in DeleteFunction
#218 - context.Background in runInvocation
#261 - context.Background in RepairCluster
#257 - context.Background in Cluster Repair
#256 - async snapshot goroutine
#223 - pipeline worker defer Background
#286 - Libvirt Connect goroutine leak

## Test plan

- [x] go build ./...
- [x] go vet ./internal/repositories/postgres/... ./internal/repositories/libvirt/... ./internal/core/services/... ./internal/workers/...
- [x] go test ./internal/repositories/postgres/... ./internal/repositories/libvirt/... ./internal/core/services/... ./internal/workers/...
