### PR TITLE
fix(security): bound log handler pagination to prevent DoS

### DIFF
--- a/internal/handlers/log_handler.go
+++ b/internal/handlers/log_handler.go
@@ -13,9 +13,27 @@ import (
 	"github.com/poyrazk/thecloud/pkg/httputil"
 )
 
+const (
+	defaultLogLimit = 100
+	maxLogLimit     = 1000
+	maxLogOffset    = 1_000_000
+)
+
 // LogHandler handles log-related requests.
 type LogHandler struct {
 	svc ports.LogService
+}
+
+// clampLogLimit bounds a user-supplied limit to a safe range. Values <= 0 fall
+// back to the default; values above maxLogLimit are capped.
+func clampLogLimit(limit int) int {
+	if limit <= 0 {
+		return defaultLogLimit
+	}
+	if limit > maxLogLimit {
+		return maxLogLimit
+	}
+	return limit
 }
 
 // NewLogHandler creates a new LogHandler.
@@ -68,7 +86,7 @@ func (h *LogHandler) Search(c *gin.Context) {
 	}
 
 	// Pagination
-	limitStr := c.DefaultQuery("limit", "100")
+	limitStr := c.DefaultQuery("limit", strconv.Itoa(defaultLogLimit))
 	limit, err := strconv.Atoi(limitStr)
 	if err != nil {
 		httputil.Error(c, errors.New(errors.InvalidInput, "invalid limit; must be a number"))
@@ -81,8 +99,15 @@ func (h *LogHandler) Search(c *gin.Context) {
 		httputil.Error(c, errors.New(errors.InvalidInput, "invalid offset; must be a number"))
 		return
 	}
+	if offset < 0 {
+		offset = 0
+	}
+	if offset > maxLogOffset {
+		httputil.Error(c, errors.New(errors.InvalidInput, "offset too large"))
+		return
+	}
 
-	query.Limit = limit
+	query.Limit = clampLogLimit(limit)
 	query.Offset = offset
 
 	entries, total, err := h.svc.SearchLogs(c.Request.Context(), query)
@@ -113,11 +138,11 @@ func (h *LogHandler) GetByResource(c *gin.Context) {
 	id := c.Param("id")
 	tenantID := appcontext.TenantIDFromContext(c.Request.Context())
 
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "100"))
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", strconv.Itoa(defaultLogLimit)))
 	query := domain.LogQuery{
 		TenantID:   tenantID,
 		ResourceID: id,
-		Limit:      limit,
+		Limit:      clampLogLimit(limit),
 	}
 
 	entries, total, err := h.svc.SearchLogs(c.Request.Context(), query)

--- a/internal/handlers/log_handler_test.go
+++ b/internal/handlers/log_handler_test.go
@@ -100,6 +100,76 @@ func TestLogHandlerSearch(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
+
+	t.Run("limit clamped to max", func(t *testing.T) {
+		mockSvc, handler, r := setupLogHandlerTest()
+		r.GET("/logs", handler.Search)
+
+		mockSvc.On("SearchLogs", mock.Anything, mock.MatchedBy(func(q domain.LogQuery) bool {
+			return q.Limit == maxLogLimit
+		})).Return([]*domain.LogEntry{}, 0, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/logs?limit=1000000", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("non-positive limit uses default", func(t *testing.T) {
+		mockSvc, handler, r := setupLogHandlerTest()
+		r.GET("/logs", handler.Search)
+
+		mockSvc.On("SearchLogs", mock.Anything, mock.MatchedBy(func(q domain.LogQuery) bool {
+			return q.Limit == defaultLogLimit
+		})).Return([]*domain.LogEntry{}, 0, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/logs?limit=-5", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("negative offset normalized to zero", func(t *testing.T) {
+		mockSvc, handler, r := setupLogHandlerTest()
+		r.GET("/logs", handler.Search)
+
+		mockSvc.On("SearchLogs", mock.Anything, mock.MatchedBy(func(q domain.LogQuery) bool {
+			return q.Offset == 0
+		})).Return([]*domain.LogEntry{}, 0, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/logs?offset=-10", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		mockSvc.AssertExpectations(t)
+	})
+
+	t.Run("offset above max rejected", func(t *testing.T) {
+		_, handler, r := setupLogHandlerTest()
+		r.GET("/logs", handler.Search)
+
+		req := httptest.NewRequest(http.MethodGet, "/logs?offset=2000000", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("non-numeric limit rejected", func(t *testing.T) {
+		_, handler, r := setupLogHandlerTest()
+		r.GET("/logs", handler.Search)
+
+		req := httptest.NewRequest(http.MethodGet, "/logs?limit=abc", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }
 
 func TestLogHandlerGetByResource(t *testing.T) {
@@ -134,5 +204,21 @@ func TestLogHandlerGetByResource(t *testing.T) {
 		r.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("limit clamped to max", func(t *testing.T) {
+		mockSvc, handler, r := setupLogHandlerTest()
+		r.GET("/logs/:id", handler.GetByResource)
+
+		mockSvc.On("SearchLogs", mock.Anything, mock.MatchedBy(func(q domain.LogQuery) bool {
+			return q.Limit == maxLogLimit
+		})).Return([]*domain.LogEntry{}, 0, nil)
+
+		req := httptest.NewRequest(http.MethodGet, "/logs/res-1?limit=1000000", nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		mockSvc.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
## Summary
  - Clamp `limit` (max 1000, default 100) and `offset` (rejected above 1,000,000, normalized to 0 if negative) on `GET /logs` so a malicious caller cannot request millions of rows
   in a single query.
  - Apply the same `limit` clamp to `GET /logs/:id` (`GetByResource`).
  - Add subtests covering: clamp-to-max, non-positive limit falls back to default, negative offset normalized, offset above max rejected with 400, non-numeric limit still
  rejected, and `GetByResource` clamp.

  Closes #336.

  ## Test plan
  - [x] `go build ./...`
  - [x] `go test ./internal/handlers/...`

  ## Out of scope / follow-ups
  `audit_handler.go`, `event_handler.go`, and `dashboard_handler.go` use the same unbounded `DefaultQuery("limit", ...)` pattern with smaller defaults. They are not addressed here
   — separate issues should be filed if reviewers want them tightened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log search pagination validation: invalid `limit` and `offset` values now return proper 400 Bad Request responses.
  * Negative offsets are automatically normalized to 0.
  * Query limits are now capped and use consistent defaults.

* **Tests**
  * Added comprehensive test coverage for log search and resource lookup pagination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->