### PR TITLE
fix: address auth map growth, quota rollback, body close, and CSI shutdown

### DIFF
--- a/cmd/csi-driver/main.go
+++ b/cmd/csi-driver/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/poyrazk/thecloud/internal/csi"
 	"github.com/poyrazk/thecloud/pkg/sdk"
@@ -48,13 +49,22 @@ func main() {
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	done := make(chan struct{})
 	go func() {
 		<-c
 		d.Stop()
+		close(done)
 	}()
 
 	if err := d.Run(); err != nil {
 		fmt.Printf("Failed to run driver: %v\n", err)
 		os.Exit(1)
+	}
+
+	// Wait for signal handler to complete cleanup with timeout
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		fmt.Println("cleanup timed out after 5s, exiting anyway")
 	}
 }

--- a/internal/core/services/auth.go
+++ b/internal/core/services/auth.go
@@ -22,8 +22,12 @@ import (
 )
 
 const (
-	maxFailedAttempts = 5
+	lockoutThreshold  = 5
 	defaultLockout    = 15 * time.Minute
+	// Hard size limits prevent unbounded map growth under high failure traffic.
+	// The probabilistic purge (every ~10 calls) may not keep up with rapid failures.
+	maxFailedAttemptsMap = 1000
+	maxLockoutsMap       = 10000
 )
 
 // AuthService handles registration and authentication workflows.
@@ -202,13 +206,22 @@ func (s *AuthService) incrementFailure(email string) {
 	defer s.mu.Unlock()
 	s.failedAttempts[email]++
 	platform.AuthAttemptsTotal.WithLabelValues("failure_incorrect_password").Inc()
-	if s.failedAttempts[email] >= maxFailedAttempts {
+	if s.failedAttempts[email] >= lockoutThreshold {
 		s.lockouts[email] = time.Now().Add(s.lockoutDuration)
 		platform.AuthAttemptsTotal.WithLabelValues("failure_lockout").Inc()
 	}
 	// Probabilistically purge expired entries to prevent unbounded map growth.
 	// Every ~10 calls, scan and remove stale entries.
 	if len(s.lockouts) > 0 && time.Now().Nanosecond()%10 == 0 {
+		s.purgeExpiredLocked()
+	}
+	// Deterministic hard-limit eviction: if maps grow beyond maxSize, aggressively
+	// purge all expired entries. This prevents unbounded growth under high failure
+	// traffic before the probabilistic trigger can catch up.
+	if len(s.lockouts) > maxLockoutsMap {
+		s.purgeExpiredLocked()
+	}
+	if len(s.failedAttempts) > maxFailedAttemptsMap {
 		s.purgeExpiredLocked()
 	}
 }
@@ -227,7 +240,7 @@ func (s *AuthService) purgeExpiredLocked() {
 	// (these are users who failed but didn't reach lockout threshold)
 	for email, count := range s.failedAttempts {
 		// If count is suspiciously high, purge to prevent unbounded growth
-		if count > maxFailedAttempts*10 {
+		if count > lockoutThreshold*10 {
 			delete(s.failedAttempts, email)
 		}
 	}

--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -242,7 +242,9 @@ func (s *InstanceService) LaunchInstance(ctx context.Context, params ports.Launc
 	s.logger.Info("enqueueing provision job", "instance_id", inst.ID, "queue", "provision_queue", "tenant_id", inst.TenantID)
 	if err := s.taskQueue.Enqueue(ctx, "provision_queue", job); err != nil {
 		s.logger.Error("failed to enqueue provision job", "instance_id", inst.ID, "error", err)
-		// Return error on enqueue failure to maintain system reliability and state consistency.
+		// Rollback quota reservation on enqueue failure
+		_ = s.tenantSvc.DecrementUsage(ctx, tenantID, "vcpus", it.VCPUs)
+		_ = s.tenantSvc.DecrementUsage(ctx, tenantID, "memory", it.MemoryMB/1024)
 		return nil, errors.Wrap(errors.Internal, "failed to enqueue provisioning task", err)
 	}
 

--- a/tests/gateway_e2e_test.go
+++ b/tests/gateway_e2e_test.go
@@ -239,12 +239,14 @@ func TestGatewayE2E(t *testing.T) {
 			req, _ := http.NewRequest("GET", url, nil)
 			req.Header.Set(testutil.TestHeaderAPIKey, token)
 			resp, err := client.Do(req)
+			if resp != nil {
+				defer resp.Body.Close()
+			}
 			if err == nil && resp.StatusCode == http.StatusOK {
 				var res struct {
 					URL string `json:"url"`
 				}
 				_ = json.NewDecoder(resp.Body).Decode(&res)
-				resp.Body.Close()
 				if finalURL = res.URL; finalURL != "" && (finalURL == httpbinAnything+"/specific" || finalURL == httpbinAnything+"/general") {
 					if finalURL == httpbinAnything+"/specific" {
 						break


### PR DESCRIPTION
## Summary
- auth.go (#280): add hard size limits (maxFailedAttemptsMap=1000, maxLockoutsMap=10000) for deterministic eviction supplementing probabilistic purge
- instance.go (#297): rollback vCPU/memory quota when taskQueue.Enqueue fails after IncrementUsage
- gateway_e2e_test.go (#307): defer resp.Body.Close() covers all code paths, not just HTTP 200
- csi-driver/main.go (#283): wait for d.Stop() completion with 5s timeout before exiting

## Test plan
- [x] go build ./internal/core/services/... ./cmd/... ./tests/...
- [x] go vet ./internal/core/services/... ./cmd/...
- [x] go test -race ./internal/core/services/... -count=1

Fixes #280, #297, #307, #283