### PR TITLE
fix: address 6 input validation issues

### DIFF
--- a/internal/adapters/dns/powerdns.go
+++ b/internal/adapters/dns/powerdns.go
@@ -64,7 +64,8 @@ func (b *PowerDNSBackend) CreateZone(ctx context.Context, zoneName string, names
 	}
 
 	// Add an initial SOA record to satisfy PowerDNS requirements for Native zones
-	soaContent := fmt.Sprintf("%s hostmaster.%s 1 10800 3600 604800 3600", nameservers[0], zoneName)
+	ns := nameservers[0] // validated above
+	soaContent := fmt.Sprintf("%s hostmaster.%s 1 10800 3600 604800 3600", ns, zoneName)
 	soaRecord := ports.RecordSet{
 		Name:    zoneName,
 		Type:    "SOA",

--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -1005,6 +1006,10 @@ func (s *InstanceService) completeResize(ctx context.Context, tenantID uuid.UUID
 
 	// 2. Compute resize (now that quota is settled)
 	newCpuNano := int64(newIT.VCPUs) * NanoCPUsPerVCPU
+	const maxMemoryMB = math.MaxInt64 / BytesPerMB
+	if int64(newIT.MemoryMB) > maxMemoryMB {
+		return fmt.Errorf("memory size overflows int64: %d MB", newIT.MemoryMB)
+	}
 	newMemoryBytes := int64(newIT.MemoryMB) * BytesPerMB
 	if err := s.compute.ResizeInstance(ctx, target, newCpuNano, newMemoryBytes); err != nil {
 		platform.InstanceOperationsTotal.WithLabelValues("resize", "failure").Inc()
@@ -1495,7 +1500,13 @@ func (s *InstanceService) findAvailableIP(ipNet *net.IPNet, usedIPs map[string]b
 	ip := make(net.IP, len(ipNet.IP))
 	copy(ip, ipNet.IP)
 
-	for {
+	ones, _ := ipNet.Mask.Size()
+	maxIPs := uint64(1) << (32 - ones)
+	if maxIPs > 1<<16 {
+		maxIPs = 1 << 16 // cap at 65536 to prevent unbounded iteration
+	}
+
+	for iterations := uint64(0); iterations < maxIPs; iterations++ {
 		// Increment IP
 		for i := len(ip) - 1; i >= 0; i-- {
 			ip[i]++
@@ -1517,7 +1528,7 @@ func (s *InstanceService) findAvailableIP(ipNet *net.IPNet, usedIPs map[string]b
 			return displayIP, nil
 		}
 	}
-	return "", fmt.Errorf("no available IPs in subnet")
+	return "", fmt.Errorf("no available IPs in subnet after %d attempts", maxIPs)
 }
 
 func (s *InstanceService) Exec(ctx context.Context, idOrName string, cmd []string) (string, error) {

--- a/internal/repositories/docker/snapshot_path.go
+++ b/internal/repositories/docker/snapshot_path.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -51,6 +52,11 @@ func validateSnapshotPath(p string) (string, error) {
 	cleaned := filepath.Clean(p)
 	if cleaned != p {
 		return "", fmt.Errorf("snapshot path is not canonical: %q (cleaned %q)", p, cleaned)
+	}
+
+	// Reject symlinks to prevent traversal through symlink-based escapes.
+	if info, err := os.Lstat(cleaned); err == nil && (info.Mode()&os.ModeSymlink) != 0 {
+		return "", fmt.Errorf("snapshot path is a symlink: %q", p)
 	}
 
 	// After Clean a leading `..` cannot survive on an absolute path, but reject

--- a/internal/repositories/ovs/adapter.go
+++ b/internal/repositories/ovs/adapter.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -145,6 +146,9 @@ func (a *OvsAdapter) CreateVXLANTunnel(ctx context.Context, bridge string, vni i
 	if !bridgeNameRegex.MatchString(bridge) {
 		return errors.New(errors.InvalidInput, invalidBridgeNameMsg)
 	}
+	if net.ParseIP(remoteIP) == nil {
+		return errors.New(errors.InvalidInput, "invalid remote IP address")
+	}
 
 	tunnelName := fmt.Sprintf("vxlan-%s", strings.ReplaceAll(remoteIP, ".", "-"))
 	cmd := a.exec.CommandContext(ctx, a.ovsPath,
@@ -163,6 +167,9 @@ func (a *OvsAdapter) CreateVXLANTunnel(ctx context.Context, bridge string, vni i
 }
 
 func (a *OvsAdapter) DeleteVXLANTunnel(ctx context.Context, bridge string, remoteIP string) error {
+	if net.ParseIP(remoteIP) == nil {
+		return errors.New(errors.InvalidInput, "invalid remote IP address")
+	}
 	tunnelName := fmt.Sprintf("vxlan-%s", strings.ReplaceAll(remoteIP, ".", "-"))
 	return a.DeletePort(ctx, bridge, tunnelName)
 }


### PR DESCRIPTION
## Summary
Fix 6 input validation issues across 4 files:

- **OVS adapter** (`repositories/ovs/adapter.go`): Validate `remoteIP` with `net.ParseIP` in `CreateVXLANTunnel` and `DeleteVXLANTunnel` — prevents command injection and malformed IP usage (#255)
- **Instance service** (`services/instance.go`): Add iteration limit to `findAvailableIP` — prevents infinite loop when all IPs in subnet are taken (#262)
- **Instance service** (`services/instance.go`): Add overflow check before memory calculation in resize path (#263)
- **PowerDNS** (`adapters/dns/powerdns.go`): Clarify nameserver access after empty check (#258)
- **Docker snapshot path** (`repositories/docker/snapshot_path.go`): Add symlink detection to path validation — prevents symlink-based traversal escapes (#239, #238)

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/repositories/ovs/... ./internal/core/services/... ./internal/adapters/dns/... ./internal/repositories/docker/... -count=1`