### PR TITLE
fix: add i-- after stream splice in Coordinator.Write (#333)

### DIFF
--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -245,6 +245,7 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 				if errSend != nil {
 					// Remove failed stream
 					streams = append(streams[:i], streams[i+1:]...)
+					i--
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- : add missing  after  in the Write path
- Without this, when a stream send fails and the stream is removed, the next element is skipped during broadcast
- The  path at line 469 already had this correctly; only the Write path was broken

## Test plan
- [x] go build ./internal/storage/coordinator/...
- [x] go vet ./internal/storage/coordinator/...
- [x] go test -race ./internal/storage/coordinator/... -count=1

Fixes #333