### PR TITLE
fix: close failed gRPC streams, fix libvirt goroutine leak, add io.LimitReader

### DIFF
--- a/internal/handlers/function_handler.go
+++ b/internal/handlers/function_handler.go
@@ -13,7 +13,13 @@ import (
 	"github.com/poyrazk/thecloud/pkg/httputil"
 )
 
-const invalidFunctionIDMsg = "invalid function id"
+const (
+	invalidFunctionIDMsg = "invalid function id"
+	// maxFunctionCodeSize prevents memory exhaustion when reading function code uploads.
+	maxFunctionCodeSize = 10 * 1024 * 1024 // 10 MB
+	// maxInvokePayloadSize prevents memory exhaustion on function invocation payloads.
+	maxInvokePayloadSize = 1 * 1024 * 1024 // 1 MB
+)
 
 // FunctionHandler handles serverless function HTTP endpoints.
 type FunctionHandler struct {
@@ -61,7 +67,7 @@ func (h *FunctionHandler) Create(c *gin.Context) {
 	}
 	defer func() { _ = f.Close() }()
 
-	code, err := io.ReadAll(f)
+	code, err := io.ReadAll(io.LimitReader(f, maxFunctionCodeSize))
 	if err != nil {
 		httputil.Error(c, errors.Wrap(errors.Internal, "failed to read code file", err))
 		return
@@ -148,7 +154,7 @@ func (h *FunctionHandler) Invoke(c *gin.Context) {
 		return
 	}
 
-	payload, err := io.ReadAll(c.Request.Body)
+	payload, err := io.ReadAll(io.LimitReader(c.Request.Body, maxInvokePayloadSize))
 	if err != nil {
 		httputil.Error(c, errors.Wrap(errors.InvalidInput, "failed to read payload", err))
 		return

--- a/internal/repositories/libvirt/real_client.go
+++ b/internal/repositories/libvirt/real_client.go
@@ -25,7 +25,12 @@ func (r *RealLibvirtClient) Connect(ctx context.Context) error {
 			return
 		default:
 		}
-		errChan <- r.conn.Connect()
+		err := r.conn.Connect()
+		select {
+		case errChan <- err:
+		case <-done:
+		case <-ctx.Done():
+		}
 	}()
 
 	select {
@@ -48,7 +53,12 @@ func (r *RealLibvirtClient) ConnectToURI(ctx context.Context, uri string) error 
 			return
 		default:
 		}
-		errChan <- r.conn.ConnectToURI(libvirt.ConnectURI(uri))
+		err := r.conn.ConnectToURI(libvirt.ConnectURI(uri))
+		select {
+		case errChan <- err:
+		case <-done:
+		case <-ctx.Done():
+		}
 	}()
 
 	select {

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -243,7 +243,8 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 					},
 				})
 				if errSend != nil {
-					// Remove failed stream
+					// Close stream before removing to release resources
+					_, _ = streams[i].stream.CloseAndRecv()
 					streams = append(streams[:i], streams[i+1:]...)
 				}
 			}
@@ -465,6 +466,7 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 					},
 				})
 				if errSend != nil {
+					_, _ = streams[i].stream.CloseAndRecv()
 					streams = append(streams[:i], streams[i+1:]...)
 					i--
 				}


### PR DESCRIPTION
## Summary

Three independent bug fixes:

### Fix 1: gRPC stream resource leak on send failure (#330)
**File:** `internal/storage/coordinator/service.go`

When `streams[i].stream.Send()` fails during broadcast in `Write` and `repairNodes`, the stream was removed from the slice but `CloseAndRecv()` was never called to release its resources.

- Write path (line 247): Added `_, _ = streams[i].stream.CloseAndRecv()` before the splice
- repairNodes path (line 472): Same fix

### Fix 2: Libvirt goroutine blocks forever on context cancellation (#286)
**File:** `internal/repositories/libvirt/real_client.go`

In `Connect()` and `ConnectToURI()`, the goroutine sends to `errChan` with a blocking call. If the context is cancelled before the send completes, the goroutine blocks forever.

- `Connect()` (line 28): Changed `errChan <- r.conn.Connect()` to a select that checks `ctx.Done()` and `done`
- `ConnectToURI()` (line 51): Same pattern

### Fix 3: Unbounded io.ReadAll in function handler (#302)
**File:** `internal/handlers/function_handler.go`

`io.ReadAll` on request body with no size limit allows memory exhaustion via large payloads.

- `CreateFunction` (line 64): `io.ReadAll(io.LimitReader(f, maxFunctionCodeSize))` -- 10 MB limit
- `InvokeFunction` (line 151): `io.ReadAll(io.LimitReader(c.Request.Body, maxInvokePayloadSize))` -- 1 MB limit

## Test plan
- [x] go build ./internal/storage/coordinator/... ./internal/repositories/libvirt/... ./internal/handlers/...
- [x] go vet ./internal/storage/coordinator/... ./internal/repositories/libvirt/... ./internal/handlers/...
- [x] go test -race ./internal/storage/coordinator/... -count=1

Fixes #330, #286, #302