### PR TITLE
fix: add io.LimitReader on webhook payload to prevent unbounded read

### DIFF
--- a/internal/handlers/pipeline_handler.go
+++ b/internal/handlers/pipeline_handler.go
@@ -242,15 +242,15 @@ func (h *PipelineHandler) WebhookTrigger(c *gin.Context) {
 		return
 	}
 
-	payload, err := io.ReadAll(c.Request.Body)
+	payload, err := io.ReadAll(io.LimitReader(c.Request.Body, int64(maxPayloadSize)+1))
 	if err != nil {
 		httputil.Error(c, fmt.Errorf("failed to read payload: %w", err))
 		return
 	}
 	// Reject payloads that exceed the limit to prevent truncated bodies
 	// from causing signature validation failures or duplicate delivery issues.
-	if len(payload) >= maxPayloadSize {
-		httputil.Error(c, errors.New(errors.InvalidInput, "webhook payload exceeds maximum size"))
+	if len(payload) > maxPayloadSize {
+		httputil.Error(c, errors.New(errors.ObjectTooLarge, "webhook payload exceeds maximum size"))
 		return
 	}
 

--- a/internal/handlers/pipeline_handler.go
+++ b/internal/handlers/pipeline_handler.go
@@ -12,14 +12,17 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/poyrazk/thecloud/pkg/httputil"
 )
 
-// maxPayloadSize prevents memory exhaustion when reading webhook payloads.
-const maxPayloadSize = 10 * 1024 * 1024 // 10 MB, aligned with pipeline_worker.go
+// PipelineHandler handles CI/CD pipeline endpoints.
 type PipelineHandler struct {
 	svc ports.PipelineService
 }
+
+// maxPayloadSize prevents memory exhaustion when reading webhook payloads.
+const maxPayloadSize = 10 * 1024 * 1024 // 10 MB, aligned with pipeline_worker.go
 
 // NewPipelineHandler constructs a PipelineHandler.
 func NewPipelineHandler(svc ports.PipelineService) *PipelineHandler {
@@ -239,9 +242,15 @@ func (h *PipelineHandler) WebhookTrigger(c *gin.Context) {
 		return
 	}
 
-	payload, err := io.ReadAll(io.LimitReader(c.Request.Body, maxPayloadSize))
+	payload, err := io.ReadAll(c.Request.Body)
 	if err != nil {
 		httputil.Error(c, fmt.Errorf("failed to read payload: %w", err))
+		return
+	}
+	// Reject payloads that exceed the limit to prevent truncated bodies
+	// from causing signature validation failures or duplicate delivery issues.
+	if len(payload) >= maxPayloadSize {
+		httputil.Error(c, errors.New(errors.InvalidInput, "webhook payload exceeds maximum size"))
 		return
 	}
 

--- a/internal/handlers/pipeline_handler.go
+++ b/internal/handlers/pipeline_handler.go
@@ -15,7 +15,8 @@ import (
 	"github.com/poyrazk/thecloud/pkg/httputil"
 )
 
-// PipelineHandler handles CI/CD pipeline endpoints.
+// maxPayloadSize prevents memory exhaustion when reading webhook payloads.
+const maxPayloadSize = 10 * 1024 * 1024 // 10 MB, aligned with pipeline_worker.go
 type PipelineHandler struct {
 	svc ports.PipelineService
 }
@@ -238,7 +239,7 @@ func (h *PipelineHandler) WebhookTrigger(c *gin.Context) {
 		return
 	}
 
-	payload, err := io.ReadAll(c.Request.Body)
+	payload, err := io.ReadAll(io.LimitReader(c.Request.Body, maxPayloadSize))
 	if err != nil {
 		httputil.Error(c, fmt.Errorf("failed to read payload: %w", err))
 		return


### PR DESCRIPTION
## Summary
 in  used  with no size limit, allowing memory exhaustion via large webhook payloads. The fix:

- Reads with  — never allocates more than 10MB+1 bytes
- Explicitly checks  and returns HTTP 413 
- Aligns with 's existing  constant (10 MB)

## Test plan
- [x] go build ./internal/handlers/...
- [x] go vet ./internal/handlers/...
- [x] go test -race ./internal/handlers/... -count=1

Fixes #269