### PR TITLE
fix: add size limits to repairNodes and pre-check Assemble parts

### DIFF
--- a/internal/repositories/filesystem/adapter.go
+++ b/internal/repositories/filesystem/adapter.go
@@ -135,7 +135,7 @@ func (s *LocalFileStore) Assemble(ctx context.Context, bucket, key string, parts
 		if totalSize+partSize > maxObjectSize {
 			_ = pf.Close()
 			_ = os.Remove(destPath)
-			return totalSize + partSize, fmt.Errorf("assembled object exceeds max size: %d bytes (max %d)", totalSize+partSize, maxObjectSize)
+			return totalSize + partSize, errors.New(errors.ObjectTooLarge, fmt.Sprintf("assembled object exceeds max size: %d bytes (max %d)", totalSize+partSize, maxObjectSize))
 		}
 		n, err := io.Copy(f, pf)
 		_ = pf.Close()
@@ -145,7 +145,7 @@ func (s *LocalFileStore) Assemble(ctx context.Context, bucket, key string, parts
 		totalSize += n
 		if totalSize > maxObjectSize {
 			_ = os.Remove(partPath)
-			return totalSize, fmt.Errorf("assembled object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize)
+			return totalSize, errors.New(errors.ObjectTooLarge, fmt.Sprintf("assembled object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize))
 		}
 		_ = os.Remove(partPath) // Cleanup part
 	}

--- a/internal/repositories/filesystem/adapter.go
+++ b/internal/repositories/filesystem/adapter.go
@@ -126,7 +126,17 @@ func (s *LocalFileStore) Assemble(ctx context.Context, bucket, key string, parts
 		if err != nil {
 			return 0, errors.Wrap(errors.Internal, "failed to open part file", err)
 		}
-
+		partInfo, err := pf.Stat()
+		if err != nil {
+			_ = pf.Close()
+			return 0, errors.Wrap(errors.Internal, "failed to stat part file", err)
+		}
+		partSize := partInfo.Size()
+		if totalSize+partSize > maxObjectSize {
+			_ = pf.Close()
+			_ = os.Remove(destPath)
+			return totalSize + partSize, fmt.Errorf("assembled object exceeds max size: %d bytes (max %d)", totalSize+partSize, maxObjectSize)
+		}
 		n, err := io.Copy(f, pf)
 		_ = pf.Close()
 		if err != nil {

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -429,12 +429,15 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 	type nodeStream struct {
 		id     string
 		stream pb.StorageNode_StoreClient
+		cancel context.CancelFunc
 	}
 	streams := make([]nodeStream, 0, len(nodes))
 	for _, nodeID := range nodes {
 		if client, ok := c.clients[nodeID]; ok {
-			st, err := client.Store(ctx)
+			streamCtx, cancel := context.WithCancel(ctx)
+			st, err := client.Store(streamCtx)
 			if err != nil {
+				cancel()
 				continue
 			}
 			err = st.Send(&pb.StoreRequest{
@@ -447,9 +450,10 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 				},
 			})
 			if err != nil {
+				cancel()
 				continue
 			}
-			streams = append(streams, nodeStream{id: nodeID, stream: st})
+			streams = append(streams, nodeStream{id: nodeID, stream: st, cancel: cancel})
 		}
 	}
 
@@ -464,10 +468,15 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 		if nr > 0 {
 			totalSize += int64(nr)
 			if totalSize > maxObjectSize {
-				// Close all open streams before returning
+				// Cancel all stream contexts so server-side handlers abort cleanly.
+				// Drain r to unblock the caller's io.TeeReader/io.Pipe so it can exit.
 				for _, ns := range streams {
+					ns.cancel()
 					_, _ = ns.stream.CloseAndRecv()
 				}
+				go func() {
+					_, _ = io.Copy(io.Discard, r)
+				}()
 				return
 			}
 			for i := 0; i < len(streams); i++ {

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -458,9 +458,18 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 	}
 
 	buf := make([]byte, chunkSize)
+	var totalSize int64
 	for {
 		nr, err := r.Read(buf)
 		if nr > 0 {
+			totalSize += int64(nr)
+			if totalSize > maxObjectSize {
+				// Close all open streams before returning
+				for _, ns := range streams {
+					_, _ = ns.stream.CloseAndRecv()
+				}
+				return
+			}
 			for i := 0; i < len(streams); i++ {
 				errSend := streams[i].stream.Send(&pb.StoreRequest{
 					Payload: &pb.StoreRequest_ChunkData{

--- a/internal/storage/node/store.go
+++ b/internal/storage/node/store.go
@@ -4,7 +4,7 @@ package node
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
+	stdlib_errors "errors"
 	"fmt"
 	"io"
 	"math"
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	apperrors "github.com/poyrazk/thecloud/internal/errors"
 )
 
 // LocalStore manages file storage on the local disk.
@@ -52,7 +54,7 @@ func (s *LocalStore) WriteStream(bucket, key string, r io.Reader, timestamp int6
 
 	n, copyErr := io.Copy(f, io.LimitReader(r, maxObjectSize))
 	closeErr := f.Close()
-	if copyErr != nil && !errors.Is(copyErr, io.EOF) {
+	if copyErr != nil && !stdlib_errors.Is(copyErr, io.EOF) {
 		_ = os.Remove(tmpPath)
 		return n, copyErr
 	}
@@ -203,7 +205,7 @@ func (s *LocalStore) Assemble(bucket, key string, parts []string) (int64, error)
 			_ = pf.Close()
 			_ = f.Close()
 			_ = os.Remove(tmpPath)
-			return totalSize, fmt.Errorf("assembled object exceeds max size: %d bytes (max %d)", totalSize+partSize, maxObjectSize)
+			return totalSize + partSize, apperrors.New(apperrors.ObjectTooLarge, fmt.Sprintf("assembled object exceeds max size: %d bytes (max %d)", totalSize+partSize, maxObjectSize))
 		}
 		n, err := io.Copy(f, pf)
 		_ = pf.Close()
@@ -215,7 +217,7 @@ func (s *LocalStore) Assemble(bucket, key string, parts []string) (int64, error)
 		if totalSize > maxObjectSize {
 			_ = f.Close()
 			_ = os.Remove(tmpPath)
-			return totalSize, fmt.Errorf("assembled object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize)
+			return totalSize, apperrors.New(apperrors.ObjectTooLarge, fmt.Sprintf("assembled object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize))
 		}
 	}
 

--- a/internal/storage/node/store.go
+++ b/internal/storage/node/store.go
@@ -192,6 +192,19 @@ func (s *LocalStore) Assemble(bucket, key string, parts []string) (int64, error)
 			assembleErr = err
 			break
 		}
+		partInfo, err := pf.Stat()
+		if err != nil {
+			_ = pf.Close()
+			assembleErr = err
+			break
+		}
+		partSize := partInfo.Size()
+		if totalSize+partSize > maxObjectSize {
+			_ = pf.Close()
+			_ = f.Close()
+			_ = os.Remove(tmpPath)
+			return totalSize, fmt.Errorf("assembled object exceeds max size: %d bytes (max %d)", totalSize+partSize, maxObjectSize)
+		}
 		n, err := io.Copy(f, pf)
 		_ = pf.Close()
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes remaining storage boundedness gaps:

- **coordinator/service.go `repairNodes`**: Added `totalSize` tracking with `maxObjectSize` check before reading, plus context cancellation to abort server-side handlers cleanly and drain the reader to unblock the caller's io.TeeReader. Prevents unbounded memory usage when repairing stale nodes.
- **node/store.go `Assemble`**: Pre-checks part file size via `Stat()` before `io.Copy` to avoid copying then rejecting oversized assemblies. Uses `errors.ObjectTooLarge` (HTTP 413) instead of `fmt.Errorf` (HTTP 500).
- **filesystem/adapter.go `Assemble`**: Same pre-check pattern as node/store.go.

Note: #305 (UploadPart) and #309 (PutObject) already had handler-level `io.LimitReader` limits in place. #304 coordinator Write already had `maxObjectSize` enforcement.

## Test plan

- [x] `go build ./internal/storage/coordinator/...` — ok
- [x] `go test -race ./internal/storage/node/...` — ok
- [x] `go test -race ./internal/repositories/filesystem/...` — ok

Fixes #304.