### PR TITLE
fix: correct stream skip bug in Write and repairNodes send loops

### DIFF
--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -236,7 +236,7 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 			if totalSize > maxObjectSize {
 				return totalSize, fmt.Errorf("object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize)
 			}
-			// Broadcast chunk — compact live streams in place to avoid index skip bug
+			// Broadcast chunk — build live-streams slice excluding failed ones to avoid index skip bug
 			live := streams[:0]
 			for i := 0; i < len(streams); i++ {
 				errSend := streams[i].stream.Send(&pb.StoreRequest{

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -489,6 +489,7 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 					},
 				})
 				if errSend != nil {
+					streams[i].cancel()
 					_, _ = streams[i].stream.CloseAndRecv()
 					continue
 				}

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -480,7 +480,7 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 				}()
 				return
 			}
-			// Broadcast chunk to live streams — compact in place to avoid index skip bug
+			// Broadcast chunk to live streams — build live-streams slice excluding failed ones to avoid index skip bug
 			live := streams[:0]
 			for i := 0; i < len(streams); i++ {
 				errSend := streams[i].stream.Send(&pb.StoreRequest{

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -236,20 +236,21 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 			if totalSize > maxObjectSize {
 				return totalSize, fmt.Errorf("object exceeds max size: %d bytes (max %d)", totalSize, maxObjectSize)
 			}
-			// Broadcast chunk
-			for i := len(streams) - 1; i >= 0; i-- {
+			// Broadcast chunk — compact live streams in place to avoid index skip bug
+			live := streams[:0]
+			for i := 0; i < len(streams); i++ {
 				errSend := streams[i].stream.Send(&pb.StoreRequest{
 					Payload: &pb.StoreRequest_ChunkData{
 						ChunkData: buf[:n],
 					},
 				})
 				if errSend != nil {
-					// Close stream before removing to release resources
 					_, _ = streams[i].stream.CloseAndRecv()
-					streams = append(streams[:i], streams[i+1:]...)
-					i--
+					continue
 				}
+				live = append(live, streams[i])
 			}
+			streams = live
 		}
 		if errors.Is(err, io.EOF) {
 			break
@@ -479,6 +480,8 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 				}()
 				return
 			}
+			// Broadcast chunk to live streams — compact in place to avoid index skip bug
+			live := streams[:0]
 			for i := 0; i < len(streams); i++ {
 				errSend := streams[i].stream.Send(&pb.StoreRequest{
 					Payload: &pb.StoreRequest_ChunkData{
@@ -487,10 +490,11 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 				})
 				if errSend != nil {
 					_, _ = streams[i].stream.CloseAndRecv()
-					streams = append(streams[:i], streams[i+1:]...)
-					i--
+					continue
 				}
+				live = append(live, streams[i])
 			}
+			streams = live
 		}
 		if err != nil {
 			break

--- a/internal/storage/coordinator/service_test.go
+++ b/internal/storage/coordinator/service_test.go
@@ -291,7 +291,8 @@ func TestCoordinatorWriteStreamFailureMidChunk(t *testing.T) {
 
 	// Node A (node1): succeeds on all sends
 	sm1 := new(MockStoreClient)
-	sm1.On("Send", mock.Anything).Return(nil).Maybe()
+	sm1.On("Send", mock.Anything).Return(nil).Once() // metadata
+	sm1.On("Send", mock.Anything).Return(nil).Once() // chunk
 	sm1.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
 
 	// Node B (node2): fails on first chunk Send (after metadata Send succeeds)

--- a/internal/storage/coordinator/service_test.go
+++ b/internal/storage/coordinator/service_test.go
@@ -390,7 +390,7 @@ func TestCoordinatorRepairStreamFailureContinues(t *testing.T) {
 	data, err := io.ReadAll(r)
 	require.NoError(t, err)
 	assert.Equal(t, "newdata", string(data))
-	_ = r.Close()
+	require.NoError(t, r.Close())
 
 	// Wait for async repair goroutines
 	time.Sleep(200 * time.Millisecond)

--- a/internal/storage/coordinator/service_test.go
+++ b/internal/storage/coordinator/service_test.go
@@ -282,3 +282,123 @@ func TestCoordinatorGetClusterStatus(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, status)
 }
+
+func TestCoordinatorWriteStreamFailureMidChunk(t *testing.T) {
+	ring := NewConsistentHashRing(10)
+	ring.AddNode(node1)
+	ring.AddNode(node2)
+	ring.AddNode(node3)
+
+	// Node A (node1): succeeds on all sends
+	sm1 := new(MockStoreClient)
+	sm1.On("Send", mock.Anything).Return(nil).Maybe()
+	sm1.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	// Node B (node2): fails on first chunk Send (after metadata Send succeeds)
+	sm2 := new(MockStoreClient)
+	sm2.On("Send", mock.Anything).Return(nil).Once() // metadata succeeds
+	sm2.On("Send", mock.Anything).Return(errors.New("mid-stream failure")).Once()
+	sm2.On("CloseAndRecv").Return(&pb.StoreResponse{Success: false, Error: "stream error"}, nil)
+
+	// Node C (node3): succeeds on all sends
+	sm3 := new(MockStoreClient)
+	sm3.On("Send", mock.Anything).Return(nil).Maybe()
+	sm3.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	c1, c2, c3 := new(MockStorageNodeClient), new(MockStorageNodeClient), new(MockStorageNodeClient)
+	c1.On("Store", mock.Anything).Return(sm1, nil)
+	c2.On("Store", mock.Anything).Return(sm2, nil)
+	c3.On("Store", mock.Anything).Return(sm3, nil)
+
+	clients := map[string]pb.StorageNodeClient{node1: c1, node2: c2, node3: c3}
+	coord := NewCoordinator(context.Background(), ring, clients, 3)
+	defer coord.Stop()
+
+	// One chunk of data "hello" — 3 nodes, writeQuorum=2 (3/2+1), B fails mid-stream
+	n, err := coord.Write(context.Background(), "b", "k", bytes.NewReader([]byte("hello")))
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), n)
+
+	// B's stream had 1 successful Send (metadata) then 1 failing Send (chunk) — verified by mock
+	sm2.AssertNumberOfCalls(t, "Send", 2)
+
+	// A and C should have received the chunk (at least 2 Sends each: metadata + chunk)
+	sm1.AssertNumberOfCalls(t, "Send", 2)
+	sm3.AssertNumberOfCalls(t, "Send", 2)
+
+	// A and C must have called CloseAndRecv (stream stayed live)
+	sm1.AssertCalled(t, "CloseAndRecv")
+	sm3.AssertCalled(t, "CloseAndRecv")
+
+	// B's stream should also have called CloseAndRecv (to clean up the failed stream)
+	sm2.AssertCalled(t, "CloseAndRecv")
+}
+
+func TestCoordinatorRepairStreamFailureContinues(t *testing.T) {
+	ring := NewConsistentHashRing(10)
+	ring.AddNode(node1)
+	ring.AddNode(node2)
+	ring.AddNode(node3)
+
+	// Setup read: node1 is the winner (newest), node2 and node3 are stale
+	tsNew := time.Now().UnixNano()
+	tsOld := tsNew - 1000
+
+	rm1 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+		{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: tsNew}}},
+		{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("newdata")}},
+	}}
+	c1 := new(MockStorageNodeClient)
+	c1.On("Retrieve", mock.Anything, mock.Anything).Return(rm1, nil)
+
+	// node2: stale, repair will fail on first chunk
+	rm2 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+		{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: tsOld}}},
+		{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("olddata")}},
+	}}
+	c2 := new(MockStorageNodeClient)
+	c2.On("Retrieve", mock.Anything, mock.Anything).Return(rm2, nil)
+
+	// node3: stale, repair should succeed
+	rm3 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+		{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: tsOld}}},
+		{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("olddata")}},
+	}}
+	c3 := new(MockStorageNodeClient)
+	c3.On("Retrieve", mock.Anything, mock.Anything).Return(rm3, nil)
+
+	// Repair streams: node2 fails on first chunk, node3 succeeds
+	smRepair2 := new(MockStoreClient)
+	smRepair2.On("Send", mock.Anything).Return(nil).Once()  // metadata
+	smRepair2.On("Send", mock.Anything).Return(errors.New("repair node2 failure")).Once()
+	smRepair2.On("CloseAndRecv").Return(&pb.StoreResponse{Success: false, Error: "repair failed"}, nil)
+	c2.On("Store", mock.Anything).Return(smRepair2, nil)
+
+	smRepair3 := new(MockStoreClient)
+	smRepair3.On("Send", mock.Anything).Return(nil).Maybe()
+	smRepair3.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+	c3.On("Store", mock.Anything).Return(smRepair3, nil)
+
+	clients := map[string]pb.StorageNodeClient{node1: c1, node2: c2, node3: c3}
+	coord := NewCoordinator(context.Background(), ring, clients, 3)
+	defer coord.Stop()
+
+	r, err := coord.Read(context.Background(), "b", "k")
+	require.NoError(t, err)
+
+	data, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, "newdata", string(data))
+	_ = r.Close()
+
+	// Wait for async repair goroutines
+	time.Sleep(200 * time.Millisecond)
+
+	// node2: metadata succeeded, chunk failed, CloseAndRecv called to clean up
+	smRepair2.AssertNumberOfCalls(t, "Send", 2)
+	smRepair2.AssertCalled(t, "CloseAndRecv")
+
+	// node3: both metadata and chunk sent, CloseAndRecv called
+	smRepair3.AssertNumberOfCalls(t, "Send", 2)
+	smRepair3.AssertCalled(t, "CloseAndRecv")
+}


### PR DESCRIPTION
## Summary

Fixes the stream skip bug in `Coordinator.Write` and `repairNodes` send loops (issues #277, #199).

**Problem:** Both send loops used `append(streams[:i], streams[i+1:]...)` to remove a failed stream during iteration. This causes subsequent elements to shift left, but the loop index management (`i--`) resulted in elements being skipped after removal.

**Fix:** Use a compact pattern with forward iteration — build a new slice of live streams by copying only non-failed entries:

```go
live := streams[:0]
for i := 0; i < len(streams); i++ {
    errSend := streams[i].stream.Send(...)
    if errSend != nil {
        _, _ = streams[i].stream.CloseAndRecv()
        continue
    }
    live = append(live, streams[i])
}
streams = live
```

This ensures no elements are skipped regardless of removal order.

**Note:** Issues #228 (pipe reader not closed) and #229 (stream not closed before removal) were already fixed in PR #387 — `pr.Close()` is called via defer (line 314) and `CloseAndRecv()` is called before stream removal (lines 248, 489).

## Test plan

- [x] `go build ./internal/storage/coordinator/...` — ok
- [x] `go test -race ./internal/storage/coordinator/...` — ok

Fixes #277, #199.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of write and repair operations when stream failures occur during data transmission, ensuring operations complete successfully even when individual replicas encounter mid-stream errors.

* **Tests**
  * Added test coverage for write and repair scenarios with mid-stream failures to validate continued operation under adverse conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->