### PR TITLE
fix: add min/max validation to ScaleClusterRequest.Workers and CreateLBRequest.Port

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 
-version: 2
-
 run:
   timeout: 5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 
+version: 2
+
 run:
   timeout: 5m
 

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -10712,7 +10712,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "port": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 65535,
+                    "minimum": 1
                 },
                 "weight": {
                     "type": "integer"
@@ -10962,7 +10964,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "port": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 65535,
+                    "minimum": 1
                 },
                 "vpc_id": {
                     "type": "string"
@@ -11493,9 +11497,13 @@ const docTemplate = `{
         },
         "httphandlers.ScaleClusterRequest": {
             "type": "object",
+            "required": [
+                "workers"
+            ],
             "properties": {
                 "workers": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 }
             }
         },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -10704,7 +10704,9 @@
                     "type": "string"
                 },
                 "port": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 65535,
+                    "minimum": 1
                 },
                 "weight": {
                     "type": "integer"
@@ -10954,7 +10956,9 @@
                     "type": "string"
                 },
                 "port": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 65535,
+                    "minimum": 1
                 },
                 "vpc_id": {
                     "type": "string"
@@ -11485,9 +11489,13 @@
         },
         "httphandlers.ScaleClusterRequest": {
             "type": "object",
+            "required": [
+                "workers"
+            ],
             "properties": {
                 "workers": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 }
             }
         },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1883,6 +1883,8 @@ definitions:
       instance_id:
         type: string
       port:
+        maximum: 65535
+        minimum: 1
         type: integer
       weight:
         type: integer
@@ -2051,6 +2053,8 @@ definitions:
       name:
         type: string
       port:
+        maximum: 65535
+        minimum: 1
         type: integer
       vpc_id:
         type: string
@@ -2415,7 +2419,10 @@ definitions:
   httphandlers.ScaleClusterRequest:
     properties:
       workers:
+        minimum: 1
         type: integer
+    required:
+    - workers
     type: object
   httphandlers.ScaleDeploymentRequest:
     properties:

--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -41,7 +41,7 @@ func getServerSecret() string {
 // API keys are machine-generated 32-char hex strings (~128 bits of entropy),
 // but using HMAC adds an additional layer of protection.
 func computeKeyHash(key string) string {
-	//nolint:codeql // HMAC-SHA256 is used for key fingerprinting, not password hashing.
+	// HMAC-SHA256 is used for key fingerprinting, not password hashing.
 	h := hmac.New(sha256.New, []byte(serverSecret))
 	h.Write([]byte(key))
 	return hex.EncodeToString(h.Sum(nil))

--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -42,6 +42,7 @@ func getServerSecret() string {
 // but using HMAC adds an additional layer of protection.
 func computeKeyHash(key string) string {
 	// HMAC-SHA256 is used for key fingerprinting, not password hashing.
+	//nolint:codeql // HMAC-SHA256 is used for key fingerprinting, not password hashing.
 	h := hmac.New(sha256.New, []byte(serverSecret))
 	h.Write([]byte(key))
 	return hex.EncodeToString(h.Sum(nil))

--- a/internal/handlers/cluster_handler.go
+++ b/internal/handlers/cluster_handler.go
@@ -201,7 +201,7 @@ func (h *ClusterHandler) RepairCluster(c *gin.Context) {
 
 // ScaleClusterRequest is the payload for scaling workers.
 type ScaleClusterRequest struct {
-	Workers int `json:"workers"`
+	Workers int `json:"workers" binding:"required,min=1"`
 }
 
 // ScaleCluster godoc

--- a/internal/handlers/cluster_handler.go
+++ b/internal/handlers/cluster_handler.go
@@ -422,6 +422,9 @@ func (h *ClusterHandler) SetBackupPolicy(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, nil)
 }
 
+// isValidBackupSchedule validates a cron schedule string for backup timing.
+// Returns true for valid cron expressions or empty string.
+// Validates both standard cron format and @prefix shortcuts (e.g., @daily).
 func isValidBackupSchedule(schedule string) bool {
 	if schedule == "" {
 		return true

--- a/internal/handlers/cluster_handler_test.go
+++ b/internal/handlers/cluster_handler_test.go
@@ -425,6 +425,27 @@ func TestClusterHandlerScaleCluster(t *testing.T) {
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
+
+	// Table-driven validation subtests
+	t.Run("Validation_RejectsInvalidWorkers", func(t *testing.T) {
+		cases := []struct {
+			name    string
+			payload map[string]interface{}
+		}{
+			{"WorkersZero", map[string]interface{}{"workers": 0}},
+			{"WorkersNegative", map[string]interface{}{"workers": -1}},
+			{"WorkersMissing", map[string]interface{}{}},
+		}
+		for _, c := range cases {
+			t.Run(c.name, func(t *testing.T) {
+				body, _ := json.Marshal(c.payload)
+				w := httptest.NewRecorder()
+				req := httptest.NewRequest("PUT", clustersPrefix+clusterID.String()+scalePathSuffix, bytes.NewBuffer(body))
+				r.ServeHTTP(w, req)
+				assert.Equal(t, http.StatusBadRequest, w.Code)
+			})
+		}
+	})
 }
 
 func TestClusterHandlerGetClusterHealth(t *testing.T) {

--- a/internal/handlers/cluster_handler_test.go
+++ b/internal/handlers/cluster_handler_test.go
@@ -379,7 +379,7 @@ func TestClusterHandlerScaleCluster(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 	})
 
-	t.Run(msgInvalidID, func(t *testing.T) {
+	t.Run("InvalidID", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest("PUT", clustersPrefix+"invalid/scale", nil)
 		r.ServeHTTP(w, req)
@@ -400,6 +400,30 @@ func TestClusterHandlerScaleCluster(t *testing.T) {
 		req := httptest.NewRequest("PUT", clustersPrefix+clusterID.String()+scalePathSuffix, bytes.NewBuffer(body))
 		r.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("WorkersZero_Rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]interface{}{"workers": 0})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", clustersPrefix+clusterID.String()+scalePathSuffix, bytes.NewBuffer(body))
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("WorkersNegative_Rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]interface{}{"workers": -1})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", clustersPrefix+clusterID.String()+scalePathSuffix, bytes.NewBuffer(body))
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("WorkersMissing_Rejected", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]interface{}{})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", clustersPrefix+clusterID.String()+scalePathSuffix, bytes.NewBuffer(body))
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }
 

--- a/internal/handlers/lb_handler.go
+++ b/internal/handlers/lb_handler.go
@@ -34,7 +34,7 @@ type CreateLBRequest struct {
 // AddTargetRequest is the payload for adding a load balancer target.
 type AddTargetRequest struct {
 	InstanceID string `json:"instance_id" binding:"required"`
-	Port       int    `json:"port" binding:"required"`
+	Port       int    `json:"port" binding:"required,min=1,max=65535"`
 	Weight     int    `json:"weight"`
 }
 

--- a/internal/handlers/lb_handler.go
+++ b/internal/handlers/lb_handler.go
@@ -27,7 +27,7 @@ func NewLBHandler(svc ports.LBService) *LBHandler {
 type CreateLBRequest struct {
 	Name      string `json:"name" binding:"required"`
 	VpcID     string `json:"vpc_id" binding:"required"`
-	Port      int    `json:"port" binding:"required"`
+	Port      int    `json:"port" binding:"required,min=1,max=65535"`
 	Algorithm string `json:"algorithm"`
 }
 

--- a/internal/handlers/lb_handler_test.go
+++ b/internal/handlers/lb_handler_test.go
@@ -88,21 +88,80 @@ func TestLBHandlerCreate(t *testing.T) {
 
 	vpcID := uuid.New()
 	lb := &domain.LoadBalancer{ID: uuid.New(), Name: testLBName}
-	svc.On("Create", mock.Anything, testLBName, vpcID, 80, algoRoundRobin, "").Return(lb, nil)
 
-	body, err := json.Marshal(map[string]interface{}{
-		"name":      testLBName,
-		"vpc_id":    vpcID.String(),
-		"port":      80,
-		"algorithm": algoRoundRobin,
+	t.Run("Success", func(t *testing.T) {
+		svc.On("Create", mock.Anything, testLBName, vpcID, 80, algoRoundRobin, "").Return(lb, nil)
+		body, err := json.Marshal(map[string]interface{}{
+			"name":      testLBName,
+			"vpc_id":    vpcID.String(),
+			"port":      80,
+			"algorithm": algoRoundRobin,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath, bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusAccepted, w.Code)
 	})
-	require.NoError(t, err)
-	w := httptest.NewRecorder()
-	req, err := http.NewRequest("POST", lbPath, bytes.NewBuffer(body))
-	require.NoError(t, err)
-	r.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusAccepted, w.Code)
+	t.Run("PortZero_Rejected", func(t *testing.T) {
+		body, err := json.Marshal(map[string]interface{}{
+			"name":   testLBName,
+			"vpc_id": vpcID.String(),
+			"port":   0,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath, bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("PortNegative_Rejected", func(t *testing.T) {
+		body, err := json.Marshal(map[string]interface{}{
+			"name":   testLBName,
+			"vpc_id": vpcID.String(),
+			"port":   -1,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath, bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("PortExceedsMax_Rejected", func(t *testing.T) {
+		body, err := json.Marshal(map[string]interface{}{
+			"name":   testLBName,
+			"vpc_id": vpcID.String(),
+			"port":   65536,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath, bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("PortAtMax_IsValid", func(t *testing.T) {
+		svc.On("Create", mock.Anything, testLBName, vpcID, 65535, algoRoundRobin, "").Return(lb, nil)
+		body, err := json.Marshal(map[string]interface{}{
+			"name":      testLBName,
+			"vpc_id":    vpcID.String(),
+			"port":      65535,
+			"algorithm": algoRoundRobin,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath, bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusAccepted, w.Code)
+	})
 }
 
 func TestLBHandlerList(t *testing.T) {
@@ -169,20 +228,49 @@ func TestLBHandlerAddTarget(t *testing.T) {
 
 	lbID := uuid.New()
 	instID := uuid.New()
-	svc.On("AddTarget", mock.Anything, lbID, instID, 8080, 10).Return(nil)
 
-	body, err := json.Marshal(map[string]interface{}{
-		"instance_id": instID.String(),
-		"port":        8080,
-		"weight":      10,
+	t.Run("Success", func(t *testing.T) {
+		svc.On("AddTarget", mock.Anything, lbID, instID, 8080, 10).Return(nil)
+		body, err := json.Marshal(map[string]interface{}{
+			"instance_id": instID.String(),
+			"port":        8080,
+			"weight":      10,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath+"/"+lbID.String()+"/targets", bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusCreated, w.Code)
 	})
-	require.NoError(t, err)
-	w := httptest.NewRecorder()
-	req, err := http.NewRequest("POST", lbPath+"/"+lbID.String()+"/targets", bytes.NewBuffer(body))
-	require.NoError(t, err)
-	r.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusCreated, w.Code)
+	t.Run("PortZero_Rejected", func(t *testing.T) {
+		body, err := json.Marshal(map[string]interface{}{
+			"instance_id": instID.String(),
+			"port":        0,
+			"weight":      10,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath+"/"+lbID.String()+"/targets", bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("PortExceedsMax_Rejected", func(t *testing.T) {
+		body, err := json.Marshal(map[string]interface{}{
+			"instance_id": instID.String(),
+			"port":        65536,
+			"weight":      10,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath+"/"+lbID.String()+"/targets", bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
 }
 
 func TestLBHandlerRemoveTarget(t *testing.T) {

--- a/internal/handlers/lb_handler_test.go
+++ b/internal/handlers/lb_handler_test.go
@@ -258,6 +258,20 @@ func TestLBHandlerAddTarget(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 
+	t.Run("PortNegative_Rejected", func(t *testing.T) {
+		body, err := json.Marshal(map[string]interface{}{
+			"instance_id": instID.String(),
+			"port":        -1,
+			"weight":      10,
+		})
+		require.NoError(t, err)
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("POST", lbPath+"/"+lbID.String()+"/targets", bytes.NewBuffer(body))
+		require.NoError(t, err)
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
 	t.Run("PortExceedsMax_Rejected", func(t *testing.T) {
 		body, err := json.Marshal(map[string]interface{}{
 			"instance_id": instID.String(),


### PR DESCRIPTION
## Summary
- `ScaleClusterRequest.Workers`: add `binding:"required,min=1"` to reject 0/negative workers before reaching service layer
- `CreateLBRequest.Port`: add `binding:"required,min=1,max=65535"` to validate port is in valid range (1-65535)

Fixes #260, #259.

## Test plan
- [x] `go build ./internal/handlers/...`
- [x] `go vet ./internal/handlers/...`
- [x] `go test ./internal/handlers/... -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cluster scaling now requires at least 1 worker; load balancer ports are validated within 1–65535 and requests with missing/out-of-range values are rejected.
* **Tests**
  * Expanded test coverage for invalid, missing, and boundary worker/port inputs.
* **Documentation**
  * API docs/OpenAPI schemas updated to reflect the tighter request validation.
* **Chores**
  * Linter config version declared; minor comment cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->