### PR TITLE
feat(instances): add Instance Tags API with dedicated endpoints and list filtering

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -189,6 +189,59 @@ Readiness probe. Checks connections to Database and Docker daemon.
 ### GET /instances
 List all instances owned by the authenticated user.
 
+**Query Parameters:**
+- `tag` (string, repeatable): Filter instances by label. Supports `key:value` format for exact match or bare key for existence check. Example: `?tag=env:prod&tag=team:backend`
+
+**Response:**
+```json
+{
+  "data": [
+    {
+      "id": "inst-uuid",
+      "name": "web-01",
+      "status": "RUNNING",
+      "labels": {
+        "env": "prod",
+        "team": "backend"
+      }
+    }
+  ]
+}
+```
+
+### GET /instances/:id/tags
+Get all labels for an instance.
+
+**Response:**
+```json
+{
+  "data": {
+    "env": "prod",
+    "team": "backend"
+  }
+}
+```
+
+### POST /instances/:id/tags
+Add or update one or more labels on an instance. Merges with existing labels.
+
+**Request:**
+```json
+{
+  "tags": {
+    "env": "prod",
+    "team": "backend"
+  }
+}
+```
+
+**Response:** Updated label map (same format as GET /instances/:id/tags).
+
+### DELETE /instances/:id/tags/:key
+Remove a label key from an instance.
+
+**Response:** `204 No Content`
+
 ### POST /instances
 Launch a new instance.
 ```json

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -4327,7 +4327,7 @@ const docTemplate = `{
                         "APIKeyAuth": []
                     }
                 ],
-                "description": "Merges the provided tags into the instance's label set. Existing keys are overwritten; keys with empty values are removed.",
+                "description": "Merges the provided tags into the instance's label set. Existing keys are overwritten.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -4276,6 +4276,152 @@ const docTemplate = `{
                 }
             }
         },
+        "/instances/{id}/tags": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Returns the label set (tags) assigned to an instance.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instances"
+                ],
+                "summary": "Get instance tags",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Merges the provided tags into the instance's label set. Existing keys are overwritten; keys with empty values are removed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instances"
+                ],
+                "summary": "Set instance tags",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/instances/{id}/tags/{key}": {
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Deletes the label with the given key from an instance.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instances"
+                ],
+                "summary": "Remove instance tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag key",
+                        "name": "key",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/internet-gateways": {
             "get": {
                 "security": [

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -4268,6 +4268,152 @@
                 }
             }
         },
+        "/instances/{id}/tags": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Returns the label set (tags) assigned to an instance.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instances"
+                ],
+                "summary": "Get instance tags",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Merges the provided tags into the instance's label set. Existing keys are overwritten; keys with empty values are removed.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instances"
+                ],
+                "summary": "Set instance tags",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/instances/{id}/tags/{key}": {
+            "delete": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Deletes the label with the given key from an instance.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "instances"
+                ],
+                "summary": "Remove instance tag",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Tag key",
+                        "name": "key",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/internet-gateways": {
             "get": {
                 "security": [

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -4319,7 +4319,7 @@
                         "APIKeyAuth": []
                     }
                 ],
-                "description": "Merges the provided tags into the instance's label set. Existing keys are overwritten; keys with empty values are removed.",
+                "description": "Merges the provided tags into the instance's label set. Existing keys are overwritten.",
                 "consumes": [
                     "application/json"
                 ],

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5259,7 +5259,7 @@ paths:
       consumes:
       - application/json
       description: Merges the provided tags into the instance's label set. Existing
-        keys are overwritten; keys with empty values are removed.
+        keys are overwritten.
       parameters:
       - description: Instance ID
         in: path

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -5226,6 +5226,100 @@ paths:
       summary: Stop an instance
       tags:
       - instances
+  /instances/{id}/tags:
+    get:
+      description: Returns the label set (tags) assigned to an instance.
+      parameters:
+      - description: Instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Get instance tags
+      tags:
+      - instances
+    post:
+      consumes:
+      - application/json
+      description: Merges the provided tags into the instance's label set. Existing
+        keys are overwritten; keys with empty values are removed.
+      parameters:
+      - description: Instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Set instance tags
+      tags:
+      - instances
+  /instances/{id}/tags/{key}:
+    delete:
+      description: Deletes the label with the given key from an instance.
+      parameters:
+      - description: Instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Tag key
+        in: path
+        name: key
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Remove instance tag
+      tags:
+      - instances
   /internet-gateways:
     get:
       produces:

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -278,6 +278,9 @@ func registerComputeRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		instanceGroup.GET("/:id/stats", httputil.Permission(svcs.RBAC, domain.PermissionInstanceRead), handlers.Instance.GetStats)
 		instanceGroup.GET("/:id/console", httputil.Permission(svcs.RBAC, domain.PermissionInstanceRead), handlers.Instance.GetConsole)
 		instanceGroup.PUT("/:id/metadata", httputil.Permission(svcs.RBAC, domain.PermissionInstanceUpdate), handlers.Instance.UpdateMetadata)
+		instanceGroup.GET("/:id/tags", httputil.Permission(svcs.RBAC, domain.PermissionInstanceRead), handlers.Instance.GetTags)
+		instanceGroup.POST("/:id/tags", httputil.Permission(svcs.RBAC, domain.PermissionInstanceUpdate), handlers.Instance.SetTags)
+		instanceGroup.DELETE("/:id/tags/:key", httputil.Permission(svcs.RBAC, domain.PermissionInstanceUpdate), handlers.Instance.RemoveTag)
 		instanceGroup.POST("/:id/resize", httputil.Permission(svcs.RBAC, domain.PermissionInstanceResize), handlers.Instance.ResizeInstance)
 		instanceGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionInstanceTerminate), handlers.Instance.Terminate)
 	}

--- a/internal/core/ports/instance.go
+++ b/internal/core/ports/instance.go
@@ -17,7 +17,9 @@ type InstanceRepository interface {
 	// GetByName retrieves an instance by its friendly name (typically scoped to owner).
 	GetByName(ctx context.Context, name string) (*domain.Instance, error)
 	// List returns instances authorized for the current operational context.
-	List(ctx context.Context) ([]*domain.Instance, error)
+	// tagFilter is an optional list of label constraints (e.g. ["env:prod", "team:backend"]);
+	// instances must match all listed constraints to be returned.
+	List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error)
 	// ListAll returns every instance in the system (for administrative or global tasks).
 	ListAll(ctx context.Context) ([]*domain.Instance, error)
 	// ListBySubnet returns all instances residing within a specific subnet.
@@ -63,7 +65,8 @@ type InstanceService interface {
 	// ResumeInstance resumes a paused instance back to running state.
 	ResumeInstance(ctx context.Context, idOrName string) error
 	// ListInstances returns a slice of all compute resources accessible to the caller.
-	ListInstances(ctx context.Context) ([]*domain.Instance, error)
+	// tagFilter optionally restricts results to instances matching all given label constraints.
+	ListInstances(ctx context.Context, tagFilter []string) ([]*domain.Instance, error)
 	// GetInstance retrieves detailed information about a specific compute resource.
 	GetInstance(ctx context.Context, idOrName string) (*domain.Instance, error)
 	// GetInstanceLogs retrieves recent console/system output from the instance.
@@ -80,4 +83,10 @@ type InstanceService interface {
 	UpdateInstanceMetadata(ctx context.Context, id uuid.UUID, metadata, labels map[string]string) error
 	// ResizeInstance changes the instance type (CPU/memory) of an existing instance.
 	ResizeInstance(ctx context.Context, idOrName, newInstanceType string) (*domain.Instance, error)
+	// GetTags returns the label set for an instance.
+	GetTags(ctx context.Context, id uuid.UUID) (map[string]string, error)
+	// SetTags replaces an instance's labels with the provided map (add/update).
+	SetTags(ctx context.Context, id uuid.UUID, labels map[string]string) error
+	// RemoveTag deletes a single label key from an instance.
+	RemoveTag(ctx context.Context, id uuid.UUID, key string) error
 }

--- a/internal/core/services/benchmarks_test.go
+++ b/internal/core/services/benchmarks_test.go
@@ -44,7 +44,7 @@ func BenchmarkInstanceServiceList(b *testing.B) {
 		b.Run(fmt.Sprintf("records=%d", size), func(b *testing.B) {
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				instances, _ := svc.ListInstances(ctx)
+				instances, _ := svc.ListInstances(ctx, nil)
 				if len(instances) != size {
 					b.Fatalf("expected %d instances, got %d", size, len(instances))
 				}
@@ -228,7 +228,7 @@ type benchInstanceRepository struct {
 	instances []*domain.Instance
 }
 
-func (r *benchInstanceRepository) List(ctx context.Context) ([]*domain.Instance, error) {
+func (r *benchInstanceRepository) List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
 	instances := make([]*domain.Instance, len(r.instances))
 	copy(instances, r.instances)
 	return instances, nil

--- a/internal/core/services/dashboard.go
+++ b/internal/core/services/dashboard.go
@@ -50,7 +50,7 @@ func (s *dashboardService) GetSummary(ctx context.Context) (*domain.ResourceSumm
 	summary := &domain.ResourceSummary{}
 
 	// Count instances
-	instances, err := s.instances.List(ctx)
+	instances, err := s.instances.List(ctx, nil)
 	if err != nil {
 		s.logger.Error("failed to list instances", slog.String("error", err.Error()))
 		return nil, err

--- a/internal/core/services/dashboard_test.go
+++ b/internal/core/services/dashboard_test.go
@@ -46,8 +46,8 @@ func (m *mockInstanceRepo) getList(args mock.Arguments) ([]*domain.Instance, err
 	return r0, args.Error(1)
 }
 
-func (m *mockInstanceRepo) List(ctx context.Context) ([]*domain.Instance, error) {
-	return m.getList(m.Called(ctx))
+func (m *mockInstanceRepo) List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	return m.getList(m.Called(ctx, tagFilter))
 }
 func (m *mockInstanceRepo) ListAll(ctx context.Context) ([]*domain.Instance, error) {
 	return m.getList(m.Called(ctx))
@@ -332,7 +332,7 @@ func TestDashboardServiceGetSummary(t *testing.T) {
 			defer volumeRepo.AssertExpectations(t)
 			defer vpcRepo.AssertExpectations(t)
 
-			instanceRepo.On("List", mock.Anything).Return(tt.instances, nil)
+			instanceRepo.On("List", mock.Anything, mock.Anything).Return(tt.instances, nil)
 			volumeRepo.On("List", mock.Anything).Return(tt.volumes, nil)
 			vpcRepo.On("List", mock.Anything).Return(tt.vpcs, nil)
 
@@ -372,7 +372,7 @@ func TestDashboardServiceGetStats(t *testing.T) {
 	defer vpcRepo.AssertExpectations(t)
 	defer eventRepo.AssertExpectations(t)
 
-	instanceRepo.On("List", mock.Anything).Return([]*domain.Instance{
+	instanceRepo.On("List", mock.Anything, mock.Anything).Return([]*domain.Instance{
 		{ID: uuid.New(), Status: domain.StatusRunning},
 	}, nil)
 	volumeRepo.On("List", mock.Anything).Return([]*domain.Volume{}, nil)

--- a/internal/core/services/dashboard_unit_test.go
+++ b/internal/core/services/dashboard_unit_test.go
@@ -45,7 +45,7 @@ func testDashboardServiceGetStats(t *testing.T) {
 		events := []*domain.Event{{ID: uuid.New(), Action: "test.action"}}
 
 		rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-		instRepo.On("List", ctx).Return(instances, nil).Once()
+		instRepo.On("List", ctx, []string(nil)).Return(instances, nil).Once()
 		volRepo.On("List", ctx).Return(volumes, nil).Once()
 		vpcRepo.On("List", ctx).Return(vpcs, nil).Once()
 		eventRepo.On("List", ctx, 10).Return(events, nil).Once()
@@ -65,7 +65,7 @@ func testDashboardServiceGetStats(t *testing.T) {
 	})
 
 	t.Run("RepoError", func(t *testing.T) {
-		instRepo.On("List", ctx).Return(nil, fmt.Errorf("db fail")).Once()
+		instRepo.On("List", ctx, []string(nil)).Return(nil, fmt.Errorf("db fail")).Once()
 
 		_, err := svc.GetStats(ctx)
 		require.Error(t, err)
@@ -98,7 +98,7 @@ func testDashboardServiceGetSummary(t *testing.T) {
 		}
 		vpcs := []*domain.VPC{{ID: uuid.New()}, {ID: uuid.New()}}
 
-		instRepo.On("List", ctx).Return(instances, nil).Once()
+		instRepo.On("List", ctx, []string(nil)).Return(instances, nil).Once()
 		volRepo.On("List", ctx).Return(volumes, nil).Once()
 		vpcRepo.On("List", ctx).Return(vpcs, nil).Once()
 
@@ -120,7 +120,7 @@ func testDashboardServiceGetSummary(t *testing.T) {
 		ctx = appcontext.WithTenantID(ctx, tenantID)
 		rbacSvc.On("Authorize", mock.Anything, userID, tenantID, domain.PermissionDashboardRead, "*").Return(nil)
 
-		instRepo.On("List", ctx).Return(nil, fmt.Errorf("db fail")).Once()
+		instRepo.On("List", ctx, []string(nil)).Return(nil, fmt.Errorf("db fail")).Once()
 
 		_, err := svc.GetSummary(ctx)
 		require.Error(t, err)

--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -761,7 +761,8 @@ func (s *InstanceService) ResumeInstance(ctx context.Context, idOrName string) e
 }
 
 // ListInstances returns all instances owned by the current user.
-func (s *InstanceService) ListInstances(ctx context.Context) ([]*domain.Instance, error) {
+// tagFilter optionally restricts results to instances matching all given label constraints.
+func (s *InstanceService) ListInstances(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
 	userID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)
 
@@ -769,7 +770,7 @@ func (s *InstanceService) ListInstances(ctx context.Context) ([]*domain.Instance
 		return nil, err
 	}
 
-	return s.repo.List(ctx)
+	return s.repo.List(ctx, tagFilter)
 }
 
 // GetInstance retrieves an instance by its UUID or name.
@@ -1649,6 +1650,67 @@ func (s *InstanceService) UpdateInstanceMetadata(ctx context.Context, id uuid.UU
 				inst.Labels[k] = v
 			}
 		}
+	}
+
+	return s.repo.Update(ctx, inst)
+}
+
+// GetTags returns the label set for an instance.
+func (s *InstanceService) GetTags(ctx context.Context, id uuid.UUID) (map[string]string, error) {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionInstanceRead, id.String()); err != nil {
+		return nil, err
+	}
+
+	inst, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	return inst.Labels, nil
+}
+
+// SetTags replaces an instance's labels with the provided map (add/update).
+func (s *InstanceService) SetTags(ctx context.Context, id uuid.UUID, labels map[string]string) error {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionInstanceUpdate, id.String()); err != nil {
+		return err
+	}
+
+	inst, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if inst.Labels == nil {
+		inst.Labels = make(map[string]string)
+	}
+	for k, v := range labels {
+		inst.Labels[k] = v
+	}
+
+	return s.repo.Update(ctx, inst)
+}
+
+// RemoveTag deletes a single label key from an instance.
+func (s *InstanceService) RemoveTag(ctx context.Context, id uuid.UUID, key string) error {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionInstanceUpdate, id.String()); err != nil {
+		return err
+	}
+
+	inst, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if inst.Labels != nil {
+		delete(inst.Labels, key)
 	}
 
 	return s.repo.Update(ctx, inst)

--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -1668,6 +1668,9 @@ func (s *InstanceService) GetTags(ctx context.Context, id uuid.UUID) (map[string
 	if err != nil {
 		return nil, err
 	}
+	if inst.Labels == nil {
+		return map[string]string{}, nil
+	}
 	return inst.Labels, nil
 }
 
@@ -1689,7 +1692,11 @@ func (s *InstanceService) SetTags(ctx context.Context, id uuid.UUID, labels map[
 		inst.Labels = make(map[string]string)
 	}
 	for k, v := range labels {
-		inst.Labels[k] = v
+		if v == "" {
+			delete(inst.Labels, k)
+		} else {
+			inst.Labels[k] = v
+		}
 	}
 
 	return s.repo.Update(ctx, inst)

--- a/internal/core/services/instance_unit_test.go
+++ b/internal/core/services/instance_unit_test.go
@@ -1305,7 +1305,7 @@ func testInstanceServiceUnitRbacErrors(t *testing.T) {
 			permission: domain.PermissionInstanceRead,
 			resourceID: "*",
 			invoke: func() error {
-				_, err := svc.ListInstances(ctx)
+				_, err := svc.ListInstances(ctx, nil)
 				return err
 			},
 		},
@@ -1448,9 +1448,9 @@ func testInstanceServiceUnitRepoErrors(t *testing.T) {
 	})
 
 	t.Run("ListInstances_RepoError", func(t *testing.T) {
-		repo.On("List", mock.Anything).Return(nil, fmt.Errorf("db error")).Once()
+		repo.On("List", mock.Anything, []string(nil)).Return(nil, fmt.Errorf("db error")).Once()
 
-		_, err := svc.ListInstances(ctx)
+		_, err := svc.ListInstances(ctx, nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "db error")
 	})

--- a/internal/core/services/lb_worker_test.go
+++ b/internal/core/services/lb_worker_test.go
@@ -131,8 +131,8 @@ func (m *mockInstRepo) GetByName(ctx context.Context, name string) (*domain.Inst
 	r0, _ := args.Get(0).(*domain.Instance)
 	return r0, args.Error(1)
 }
-func (m *mockInstRepo) List(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *mockInstRepo) List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	r0, _ := args.Get(0).([]*domain.Instance)
 	return r0, args.Error(1)
 }

--- a/internal/core/services/mock_compute_test.go
+++ b/internal/core/services/mock_compute_test.go
@@ -24,8 +24,8 @@ func (m *MockInstanceRepo) GetByID(ctx context.Context, id uuid.UUID) (*domain.I
 	}
 	return args.Get(0).(*domain.Instance), args.Error(1)
 }
-func (m *MockInstanceRepo) List(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *MockInstanceRepo) List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -91,8 +91,8 @@ func (m *MockInstanceService) PauseInstance(ctx context.Context, idOrName string
 func (m *MockInstanceService) ResumeInstance(ctx context.Context, idOrName string) error {
 	return m.Called(ctx, idOrName).Error(0)
 }
-func (m *MockInstanceService) ListInstances(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *MockInstanceService) ListInstances(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	r0, _ := args.Get(0).([]*domain.Instance)
 	return r0, args.Error(1)
 }
@@ -131,6 +131,17 @@ func (m *MockInstanceService) ResizeInstance(ctx context.Context, idOrName, newI
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*domain.Instance), args.Error(1)
+}
+func (m *MockInstanceService) GetTags(ctx context.Context, id uuid.UUID) (map[string]string, error) {
+	args := m.Called(ctx, id)
+	r0, _ := args.Get(0).(map[string]string)
+	return r0, args.Error(1)
+}
+func (m *MockInstanceService) SetTags(ctx context.Context, id uuid.UUID, labels map[string]string) error {
+	return m.Called(ctx, id, labels).Error(0)
+}
+func (m *MockInstanceService) RemoveTag(ctx context.Context, id uuid.UUID, key string) error {
+	return m.Called(ctx, id, key).Error(0)
 }
 func (m *MockInstanceService) Provision(ctx context.Context, job domain.ProvisionJob) error {
 	return m.Called(ctx, job).Error(0)

--- a/internal/handlers/instance_handler.go
+++ b/internal/handlers/instance_handler.go
@@ -504,7 +504,7 @@ type SetTagsRequest struct {
 
 // SetTags replaces an instance's labels with the provided map (add/update).
 // @Summary Set instance tags
-// @Description Merges the provided tags into the instance's label set. Existing keys are overwritten; keys with empty values are removed.
+// @Description Merges the provided tags into the instance's label set. Existing keys are overwritten.
 // @Tags instances
 // @Accept json
 // @Produce json

--- a/internal/handlers/instance_handler.go
+++ b/internal/handlers/instance_handler.go
@@ -209,7 +209,8 @@ func (h *InstanceHandler) mapLaunchRequest(req LaunchRequest) (*uuid.UUID, *uuid
 // @Failure 500 {object} httputil.Response
 // @Router /instances [get]
 func (h *InstanceHandler) List(c *gin.Context) {
-	instances, err := h.svc.ListInstances(c.Request.Context())
+	tags := c.QueryArray("tag")
+	instances, err := h.svc.ListInstances(c.Request.Context(), tags)
 	if err != nil {
 		httputil.Error(c, err)
 		return
@@ -469,6 +470,97 @@ func (h *InstanceHandler) UpdateMetadata(c *gin.Context) {
 	}
 
 	httputil.Success(c, http.StatusOK, gin.H{"message": "metadata updated"})
+}
+
+// GetTags returns the labels for an instance.
+// @Summary Get instance tags
+// @Description Returns the label set (tags) assigned to an instance.
+// @Tags instances
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Instance ID"
+// @Success 200 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /instances/{id}/tags [get]
+func (h *InstanceHandler) GetTags(c *gin.Context) {
+	id, ok := parseUUID(c)
+	if !ok {
+		return
+	}
+
+	labels, err := h.svc.GetTags(c.Request.Context(), *id)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, labels)
+}
+
+// SetTagsRequest is the payload for setting instance tags.
+type SetTagsRequest struct {
+	Tags map[string]string `json:"tags"`
+}
+
+// SetTags replaces an instance's labels with the provided map (add/update).
+// @Summary Set instance tags
+// @Description Merges the provided tags into the instance's label set. Existing keys are overwritten; keys with empty values are removed.
+// @Tags instances
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Instance ID"
+// @Success 200 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /instances/{id}/tags [post]
+func (h *InstanceHandler) SetTags(c *gin.Context) {
+	id, ok := parseUUID(c)
+	if !ok {
+		return
+	}
+
+	var req SetTagsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid request body"))
+		return
+	}
+
+	if err := h.svc.SetTags(c.Request.Context(), *id, req.Tags); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, gin.H{"message": "tags updated"})
+}
+
+// RemoveTag deletes a single label key from an instance.
+// @Summary Remove instance tag
+// @Description Deletes the label with the given key from an instance.
+// @Tags instances
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Instance ID"
+// @Param key path string true "Tag key"
+// @Success 200 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /instances/{id}/tags/{key} [delete]
+func (h *InstanceHandler) RemoveTag(c *gin.Context) {
+	id, ok := parseUUID(c)
+	if !ok {
+		return
+	}
+	key := c.Param("key")
+	if key == "" {
+		httputil.Error(c, errors.New(errors.InvalidInput, "key is required"))
+		return
+	}
+
+	if err := h.svc.RemoveTag(c.Request.Context(), *id, key); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, gin.H{"message": "tag removed"})
 }
 
 // ResizeInstanceRequest is the payload for resizing an instance.

--- a/internal/handlers/instance_handler_test.go
+++ b/internal/handlers/instance_handler_test.go
@@ -67,8 +67,8 @@ func (m *instanceServiceMock) ResumeInstance(ctx context.Context, idOrName strin
 	return m.Called(ctx, idOrName).Error(0)
 }
 
-func (m *instanceServiceMock) ListInstances(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *instanceServiceMock) ListInstances(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	r0, _ := args.Get(0).([]*domain.Instance)
 	return r0, args.Error(1)
 }
@@ -123,6 +123,20 @@ func (m *instanceServiceMock) ResizeInstance(ctx context.Context, idOrName, newI
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*domain.Instance), args.Error(1)
+}
+
+func (m *instanceServiceMock) GetTags(ctx context.Context, id uuid.UUID) (map[string]string, error) {
+	args := m.Called(ctx, id)
+	r0, _ := args.Get(0).(map[string]string)
+	return r0, args.Error(1)
+}
+
+func (m *instanceServiceMock) SetTags(ctx context.Context, id uuid.UUID, labels map[string]string) error {
+	return m.Called(ctx, id, labels).Error(0)
+}
+
+func (m *instanceServiceMock) RemoveTag(ctx context.Context, id uuid.UUID, key string) error {
+	return m.Called(ctx, id, key).Error(0)
 }
 
 func setupInstanceHandlerTest(_ *testing.T) (*instanceServiceMock, *InstanceHandler, *gin.Engine) {
@@ -237,7 +251,7 @@ func TestInstanceHandlerList(t *testing.T) {
 	r.GET(instancesPath, handler.List)
 
 	instances := []*domain.Instance{{ID: uuid.New(), Name: testInstanceName}}
-	mockSvc.On("ListInstances", mock.Anything).Return(instances, nil)
+	mockSvc.On("ListInstances", mock.Anything, []string(nil)).Return(instances, nil)
 
 	req := httptest.NewRequest(http.MethodGet, instancesPath, nil)
 	w := httptest.NewRecorder()

--- a/internal/repositories/docker/loadbalancer_test.go
+++ b/internal/repositories/docker/loadbalancer_test.go
@@ -38,8 +38,8 @@ func (m *mockInstanceRepo) GetByName(ctx context.Context, name string) (*domain.
 	return r0, args.Error(1)
 }
 
-func (m *mockInstanceRepo) List(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *mockInstanceRepo) List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/repositories/k8s/health_test.go
+++ b/internal/repositories/k8s/health_test.go
@@ -54,7 +54,7 @@ func TestKubeadmProvisionerGetHealthServiceExecutor(t *testing.T) {
 
 	repo.On("GetNodes", mock.Anything, clusterID).Return([]*domain.ClusterNode{{ID: uuid.New(), InstanceID: instanceID}}, nil)
 	instSvc.On("GetInstance", mock.Anything, instanceID.String()).Return(&domain.Instance{ID: instanceID, PrivateIP: masterIP}, nil)
-	instSvc.On("ListInstances", mock.Anything).Return([]*domain.Instance{{ID: instanceID, PrivateIP: masterIP}}, nil)
+	instSvc.On("ListInstances", mock.Anything, mock.Anything).Return([]*domain.Instance{{ID: instanceID, PrivateIP: masterIP}}, nil)
 	instSvc.On("Exec", mock.Anything, instanceID.String(), []string{kubeShell, "-c", kubectlBase + " get nodes"}).Return("", nil)
 	instSvc.On("Exec", mock.Anything, instanceID.String(), []string{kubeShell, "-c", kubectlBase + " get nodes --no-headers"}).Return("node-a Ready \nnode-b NotReady", nil)
 
@@ -79,7 +79,7 @@ func TestKubeadmProvisionerGetHealthAPIServerDown(t *testing.T) {
 
 	repo.On("GetNodes", mock.Anything, clusterID).Return([]*domain.ClusterNode{{ID: uuid.New(), InstanceID: instanceID}}, nil)
 	instSvc.On("GetInstance", mock.Anything, instanceID.String()).Return(&domain.Instance{ID: instanceID, PrivateIP: masterIP}, nil)
-	instSvc.On("ListInstances", mock.Anything).Return([]*domain.Instance{{ID: instanceID, PrivateIP: masterIP}}, nil)
+	instSvc.On("ListInstances", mock.Anything, mock.Anything).Return([]*domain.Instance{{ID: instanceID, PrivateIP: masterIP}}, nil)
 	instSvc.On("Exec", mock.Anything, instanceID.String(), []string{kubeShell, "-c", kubectlBase + " get nodes"}).Return("", errors.New("down"))
 	instSvc.On("Exec", mock.Anything, instanceID.String(), []string{kubeShell, "-c", kubectlBase + " get nodes --no-headers"}).Return("", io.EOF)
 

--- a/internal/repositories/k8s/kubeadm_provisioner_test.go
+++ b/internal/repositories/k8s/kubeadm_provisioner_test.go
@@ -55,8 +55,8 @@ func (m *MockInstanceService) PauseInstance(ctx context.Context, id string) erro
 func (m *MockInstanceService) ResumeInstance(ctx context.Context, id string) error {
 	return nil
 }
-func (m *MockInstanceService) ListInstances(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *MockInstanceService) ListInstances(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -86,6 +86,20 @@ func (m *MockInstanceService) ResizeInstance(ctx context.Context, idOrName, newI
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*domain.Instance), args.Error(1)
+}
+func (m *MockInstanceService) GetTags(ctx context.Context, id uuid.UUID) (map[string]string, error) {
+	args := m.Called(ctx, id)
+	var r0 map[string]string
+	if args.Get(0) != nil {
+		r0, _ = args.Get(0).(map[string]string)
+	}
+	return r0, args.Error(1)
+}
+func (m *MockInstanceService) SetTags(ctx context.Context, id uuid.UUID, labels map[string]string) error {
+	return m.Called(ctx, id, labels).Error(0)
+}
+func (m *MockInstanceService) RemoveTag(ctx context.Context, id uuid.UUID, key string) error {
+	return m.Called(ctx, id, key).Error(0)
 }
 
 type MockClusterRepo struct{ mock.Mock }
@@ -373,7 +387,7 @@ kubeadm join 10.0.0.100:6443 --token abc --discovery-token-ca-cert-hash sha256:1
 	}
 
 	instSvc.On("Exec", mock.Anything, mock.Anything, mock.Anything).Return(kubeadmOutput, nil).Maybe()
-	instSvc.On("ListInstances", mock.Anything).Return(instances, nil).Maybe()
+	instSvc.On("ListInstances", mock.Anything, mock.Anything).Return(instances, nil).Maybe()
 
 	err := p.Provision(ctx, cluster)
 

--- a/internal/repositories/k8s/mocks_test.go
+++ b/internal/repositories/k8s/mocks_test.go
@@ -34,8 +34,8 @@ func (m *mockInstanceService) StartInstance(ctx context.Context, idOrName string
 func (m *mockInstanceService) StopInstance(ctx context.Context, idOrName string) error  { return nil }
 func (m *mockInstanceService) PauseInstance(ctx context.Context, idOrName string) error   { return nil }
 func (m *mockInstanceService) ResumeInstance(ctx context.Context, idOrName string) error { return nil }
-func (m *mockInstanceService) ListInstances(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *mockInstanceService) ListInstances(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -86,6 +86,20 @@ func (m *mockInstanceService) ResizeInstance(ctx context.Context, idOrName, newI
 		r0, _ = args.Get(0).(*domain.Instance)
 	}
 	return r0, args.Error(1)
+}
+func (m *mockInstanceService) GetTags(ctx context.Context, id uuid.UUID) (map[string]string, error) {
+	args := m.Called(ctx, id)
+	var r0 map[string]string
+	if args.Get(0) != nil {
+		r0, _ = args.Get(0).(map[string]string)
+	}
+	return r0, args.Error(1)
+}
+func (m *mockInstanceService) SetTags(ctx context.Context, id uuid.UUID, labels map[string]string) error {
+	return m.Called(ctx, id, labels).Error(0)
+}
+func (m *mockInstanceService) RemoveTag(ctx context.Context, id uuid.UUID, key string) error {
+	return m.Called(ctx, id, key).Error(0)
 }
 
 type mockClusterRepo struct{ mock.Mock }

--- a/internal/repositories/k8s/provisioner.go
+++ b/internal/repositories/k8s/provisioner.go
@@ -401,7 +401,7 @@ func (p *KubeadmProvisioner) getExecutor(ctx context.Context, cluster *domain.Cl
 
 	// 1. Try to find instance by IP to use ServiceExecutor (preferred for Docker/Local/Managed)
 	// This avoids needing SSH access if we have direct control via the backend.
-	instances, err := p.instSvc.ListInstances(ctx)
+	instances, err := p.instSvc.ListInstances(ctx, nil)
 	if err == nil {
 		for _, inst := range instances {
 			if normalizeInstanceIP(inst.PrivateIP) == ip {

--- a/internal/repositories/k8s/provisioner_extra_test.go
+++ b/internal/repositories/k8s/provisioner_extra_test.go
@@ -186,7 +186,7 @@ func TestGetExecutor_FailPaths(t *testing.T) {
 		instSvc := new(mockInstanceService)
 		p := &KubeadmProvisioner{instSvc: instSvc}
 
-		instSvc.On("ListInstances", ctx).Return([]*domain.Instance{}, nil).Once()
+		instSvc.On("ListInstances", ctx, mock.Anything).Return([]*domain.Instance{}, nil).Once()
 
 		_, err := p.getExecutor(ctx, cluster, "10.0.0.1")
 		require.Error(t, err)

--- a/internal/repositories/k8s/provisioner_unit_test.go
+++ b/internal/repositories/k8s/provisioner_unit_test.go
@@ -188,7 +188,7 @@ func TestKubeadmProvisionerUpgrade(t *testing.T) {
 
 	mockRepo.On("GetNodes", ctx, cluster.ID).Return(nodes, nil).Once()
 	mockInst.On("GetInstance", ctx, nodes[0].InstanceID.String()).Return(inst, nil).Once()
-	mockInst.On("ListInstances", ctx).Return([]*domain.Instance{inst}, nil).Once()
+	mockInst.On("ListInstances", ctx, mock.Anything).Return([]*domain.Instance{inst}, nil).Once()
 	mockInst.On("Exec", ctx, inst.ID.String(), mock.Anything).Return("success", nil)
 
 	err := p.Upgrade(ctx, cluster, "v1.29.0")

--- a/internal/repositories/noop/adapters.go
+++ b/internal/repositories/noop/adapters.go
@@ -23,7 +23,7 @@ func (r *NoopInstanceRepository) GetByID(ctx context.Context, id uuid.UUID) (*do
 func (r *NoopInstanceRepository) GetByName(ctx context.Context, name string) (*domain.Instance, error) {
 	return &domain.Instance{ID: uuid.New(), Name: name}, nil
 }
-func (r *NoopInstanceRepository) List(ctx context.Context) ([]*domain.Instance, error) {
+func (r *NoopInstanceRepository) List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
 	return []*domain.Instance{}, nil
 }
 func (r *NoopInstanceRepository) ListAll(ctx context.Context) ([]*domain.Instance, error) {

--- a/internal/repositories/noop/repos_extra_test.go
+++ b/internal/repositories/noop/repos_extra_test.go
@@ -17,7 +17,7 @@ func TestNoopRepositoriesExtra(t *testing.T) {
 
 	t.Run("InstanceRepository", func(t *testing.T) {
 		repo := &NoopInstanceRepository{}
-		list, err := repo.List(ctx)
+		list, err := repo.List(ctx, nil)
 		require.NoError(t, err)
 		assert.Empty(t, list)
 

--- a/internal/repositories/postgres/instance_repo.go
+++ b/internal/repositories/postgres/instance_repo.go
@@ -3,7 +3,9 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	stdlib_errors "errors"
@@ -95,18 +97,31 @@ func (r *InstanceRepository) GetByName(ctx context.Context, name string) (*domai
 }
 
 // List returns all instances belonging to the authenticated user.
-func (r *InstanceRepository) List(ctx context.Context) ([]*domain.Instance, error) {
+func (r *InstanceRepository) List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	query := `
-		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), COALESCE(instance_type, ''), 
+		SELECT id, user_id, tenant_id, name, image, COALESCE(container_id, ''), status, COALESCE(ports, ''), vpc_id, subnet_id, COALESCE(private_ip::text, ''), COALESCE(ovs_port, ''), COALESCE(instance_type, ''),
 		       volume_binds, env, cmd, COALESCE(cpu_limit, 0), COALESCE(memory_limit, 0), COALESCE(disk_limit, 0),
 		       COALESCE(metadata, '{}'::jsonb), COALESCE(labels, '{}'::jsonb), ssh_key_id,
 		       version, created_at, updated_at
 		FROM instances
-		WHERE tenant_id = $1
-		ORDER BY created_at DESC
-	`
-	rows, err := r.db.Query(ctx, query, tenantID)
+		WHERE tenant_id = $1`
+	args := []interface{}{tenantID}
+	for i, tag := range tagFilter {
+		// tag format: "key:value" — use JSONB containment (@>) to match instances where labels contains this entry
+		query += fmt.Sprintf(" AND labels @> $%d", i+2)
+		parts := strings.SplitN(tag, ":", 2)
+		if len(parts) == 2 {
+			labelJSON, _ := json.Marshal(map[string]string{parts[0]: parts[1]})
+			args = append(args, string(labelJSON))
+		} else {
+			// bare key filter: labels ? key
+			query = strings.Replace(query, fmt.Sprintf(" AND labels @> $%d", i+2), fmt.Sprintf(" AND labels ? $%d", i+2), 1)
+			args = append(args, tag)
+		}
+	}
+	query += " ORDER BY created_at DESC"
+	rows, err := r.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, errors.Wrap(errors.Internal, "failed to list instances", err)
 	}

--- a/internal/repositories/postgres/instance_repo_integration_test.go
+++ b/internal/repositories/postgres/instance_repo_integration_test.go
@@ -56,7 +56,7 @@ func TestInstanceRepositoryIntegration(t *testing.T) {
 	})
 
 	t.Run("List", func(t *testing.T) {
-		list, err := repo.List(ctx)
+		list, err := repo.List(ctx, nil)
 		require.NoError(t, err)
 		assert.NotEmpty(t, list)
 	})

--- a/internal/repositories/postgres/instance_repo_test.go
+++ b/internal/repositories/postgres/instance_repo_test.go
@@ -193,7 +193,7 @@ func TestInstanceRepositoryList(t *testing.T) {
 			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "image", "container_id", "status", "ports", "vpc_id", "subnet_id", "private_ip", "ovs_port", "instance_type", "volume_binds", "env", "cmd", "cpu_limit", "memory_limit", "disk_limit", "metadata", "labels", "ssh_key_id", "version", "created_at", "updated_at"}).
 				AddRow(uuid.New(), userID, tenantID, testInstanceName, testInstanceImg, "cid-1", string(domain.StatusRunning), "80:80", nil, nil, testutil.TestIPHost, "ovs-1", testInstanceType, []string{}, []string{}, []string{}, int64(0), int64(0), int64(0), map[string]string{}, map[string]string{}, nil, 1, now, now))
 
-		list, err := repo.List(ctx)
+		list, err := repo.List(ctx, nil)
 		require.NoError(t, err)
 		assert.Len(t, list, 1)
 	})
@@ -212,7 +212,7 @@ func TestInstanceRepositoryList(t *testing.T) {
 			WithArgs(tenantID).
 			WillReturnError(errors.New(testDBError))
 
-		list, err := repo.List(ctx)
+		list, err := repo.List(ctx, nil)
 		require.Error(t, err)
 		assert.Nil(t, list)
 	})

--- a/internal/repositories/postgres/multitenancy_integration_test.go
+++ b/internal/repositories/postgres/multitenancy_integration_test.go
@@ -110,13 +110,13 @@ func TestMultiTenancy_TenantIsolation(t *testing.T) {
 		require.NoError(t, instRepo.Create(ctxB3, instB))
 
 		// Tenant A list
-		listA, err := instRepo.List(ctxA1)
+		listA, err := instRepo.List(ctxA1, nil)
 		require.NoError(t, err)
 		assert.Len(t, listA, 1)
 		assert.Equal(t, instA.ID, listA[0].ID)
 
 		// Tenant B list
-		listB, err := instRepo.List(ctxB3)
+		listB, err := instRepo.List(ctxB3, nil)
 		require.NoError(t, err)
 		assert.Len(t, listB, 1)
 		assert.Equal(t, instB.ID, listB[0].ID)

--- a/internal/workers/healing_worker_test.go
+++ b/internal/workers/healing_worker_test.go
@@ -38,8 +38,8 @@ func (m *mockInstanceRepo) GetByName(ctx context.Context, name string) (*domain.
 	r0, _ := args.Get(0).(*domain.Instance)
 	return r0, args.Error(1)
 }
-func (m *mockInstanceRepo) List(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *mockInstanceRepo) List(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -95,8 +95,8 @@ func (m *mockInstanceSvc) StartInstance(ctx context.Context, idOrName string) er
 func (m *mockInstanceSvc) StopInstance(ctx context.Context, idOrName string) error {
 	return m.Called(ctx, idOrName).Error(0)
 }
-func (m *mockInstanceSvc) ListInstances(ctx context.Context) ([]*domain.Instance, error) {
-	args := m.Called(ctx)
+func (m *mockInstanceSvc) ListInstances(ctx context.Context, tagFilter []string) ([]*domain.Instance, error) {
+	args := m.Called(ctx, tagFilter)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -149,6 +149,20 @@ func (m *mockInstanceSvc) PauseInstance(ctx context.Context, idOrName string) er
 }
 func (m *mockInstanceSvc) ResumeInstance(ctx context.Context, idOrName string) error {
 	return m.Called(ctx, idOrName).Error(0)
+}
+func (m *mockInstanceSvc) GetTags(ctx context.Context, id uuid.UUID) (map[string]string, error) {
+	args := m.Called(ctx, id)
+	var r0 map[string]string
+	if args.Get(0) != nil {
+		r0, _ = args.Get(0).(map[string]string)
+	}
+	return r0, args.Error(1)
+}
+func (m *mockInstanceSvc) SetTags(ctx context.Context, id uuid.UUID, labels map[string]string) error {
+	return m.Called(ctx, id, labels).Error(0)
+}
+func (m *mockInstanceSvc) RemoveTag(ctx context.Context, id uuid.UUID, key string) error {
+	return m.Called(ctx, id, key).Error(0)
 }
 
 func TestHealingWorker(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add dedicated tag CRUD endpoints: `GET /instances/:id/tags`, `POST /instances/:id/tags`, `DELETE /instances/:id/tags/:key`
- Add `?tag=` query parameter to `GET /instances` for filtering by label using PostgreSQL JSONB `@>` and `?` operators
- Add `GetTags`, `SetTags`, `RemoveTag` to `InstanceService` interface; propagate `tagFilter` through `InstanceRepository.List`
- Update all mock implementations across services, handlers, k8s, and worker packages
- Regenerate swagger docs and update API reference

## Test plan
- [x] `go build ./...`
- [x] `go test $(go list ./... | grep -v /tests$)` — all pass
- [x] `go vet ./...`
- [x] `make swagger` — schema updated

## Commits (6)
- `ac6e0146` feat(instances): add Instance Tags API with dedicated endpoints and list filtering
- `5941a4e1` test(services): update mocks and callers for InstanceRepository.List tagFilter
- `07c1634d` test: update mocks for InstanceService tag methods and ListInstances signature
- `3715beda` test(k8s): update mockInstanceService for tag methods and ListInstances signature
- `64962844` fix: update remaining repo mocks and call sites for tagFilter parameter
- `84e989c7` docs: regenerate swagger for Instance Tags API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added instance tagging functionality with support for creating, retrieving, and removing tags on compute instances
  * Instance listing now supports tag-based filtering via query parameter
  * New API endpoints: GET /instances/{id}/tags, POST /instances/{id}/tags, DELETE /instances/{id}/tags/{key}

<!-- end of auto-generated comment: release notes by coderabbit.ai -->