### PR TITLE
fix(e2e): retry with exponential backoff on docker compose pull failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,9 +36,34 @@ jobs:
           JWT_SECRET: e2e-test-secret-key-that-is-long-enough-for-32-chars
           DATABASE_READ_URL: postgres://cloud:cloud@postgres:5432/cloud?sslmode=disable
         run: |
-          # Start internal dependencies
-          docker compose up -d postgres redis jaeger
-          
+          # Retry loop for Docker Hub transient 500 errors.
+          # Uses exponential backoff to avoid hammering the registry.
+          max_retries=5
+          retry_delay=10
+          attempt=1
+
+          while true; do
+            echo "Attempt $attempt/$max_retries: pulling images..."
+            if docker compose up -d --pull always postgres redis jaeger 2>&1; then
+              echo "Infrastructure started successfully."
+              break
+            fi
+
+            echo "docker compose failed (attempt $attempt/$max_retries)"
+            if [ $attempt -ge $max_retries ]; then
+              echo "Max retries reached. Infrastructure failed to start."
+              docker compose logs --tail=50
+              exit 1
+            fi
+
+            echo "Retrying in ${retry_delay}s..."
+            sleep $retry_delay
+            attempt=$((attempt + 1))
+            # Exponential backoff: double delay each retry (capped at 60s)
+            retry_delay=$((retry_delay * 2))
+            [ $retry_delay -gt 60 ] && retry_delay=60
+          done
+
           # Wait for Postgres to be healthy
           until docker compose exec -T postgres pg_isready -U cloud; do
             echo "Waiting for postgres..."


### PR DESCRIPTION
## Summary

- Add retry loop to E2E Setup Infrastructure step to handle transient Docker Hub 500 errors when pulling `jaegertracing/all-in-one:1.54`
- Uses `--pull always` to retry image pulls on each attempt
- Exponential backoff: 10s → 20s → 40s → 60s (capped) over 5 attempts max
- Dumps container logs on final failure for debugging

Fixes #400