### PR TITLE
fix: reduce E2E flakiness in termination and kubeconfig tests

### DIFF
--- a/tests/instance_types_e2e_test.go
+++ b/tests/instance_types_e2e_test.go
@@ -84,12 +84,16 @@ func TestInstanceTypesE2E(t *testing.T) {
 	})
 
 	// 4. Terminate Instance
+	const (
+		maxRetries   = 3
+		retryDelayMs = 500 // milliseconds between retry attempts
+	)
 	t.Run("TerminateInstance", func(t *testing.T) {
 		var resp *http.Response
-		for attempt := 0; attempt < 3; attempt++ {
+		for attempt := 0; attempt < maxRetries; attempt++ {
 			// resp is always closed before the next iteration or early return
 			if attempt > 0 {
-				time.Sleep(time.Duration(attempt*500) * time.Millisecond)
+				time.Sleep(time.Duration(attempt*retryDelayMs) * time.Millisecond)
 			}
 			resp = deleteRequest(t, client, fmt.Sprintf(testutil.TestRouteFormat, testutil.TestBaseURL, testutil.TestRouteInstances, instanceID), token)
 			if resp.StatusCode == http.StatusOK {
@@ -108,6 +112,9 @@ func TestInstanceTypesE2E(t *testing.T) {
 				return
 			}
 			resp.Body.Close()
+		}
+		if resp != nil {
+			t.Logf("Instance still exists after %d attempts", maxRetries)
 		}
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})

--- a/tests/instance_types_e2e_test.go
+++ b/tests/instance_types_e2e_test.go
@@ -87,6 +87,7 @@ func TestInstanceTypesE2E(t *testing.T) {
 	t.Run("TerminateInstance", func(t *testing.T) {
 		var resp *http.Response
 		for attempt := 0; attempt < 3; attempt++ {
+			// resp is always closed before the next iteration or early return
 			if attempt > 0 {
 				time.Sleep(time.Duration(attempt*500) * time.Millisecond)
 			}

--- a/tests/instance_types_e2e_test.go
+++ b/tests/instance_types_e2e_test.go
@@ -115,7 +115,7 @@ func TestInstanceTypesE2E(t *testing.T) {
 		}
 		if resp != nil {
 			t.Logf("Instance still exists after %d attempts", maxRetries)
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
 		}
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }

--- a/tests/instance_types_e2e_test.go
+++ b/tests/instance_types_e2e_test.go
@@ -85,21 +85,28 @@ func TestInstanceTypesE2E(t *testing.T) {
 
 	// 4. Terminate Instance
 	t.Run("TerminateInstance", func(t *testing.T) {
-		resp := deleteRequest(t, client, fmt.Sprintf(testutil.TestRouteFormat, testutil.TestBaseURL, testutil.TestRouteInstances, instanceID), token)
-		defer func() { _ = resp.Body.Close() }()
-
-		// 500 may occur if chaos tests restarted the API between test runs
-		// In that case, the instance may have been deleted by the API restart cleanup
-		if resp.StatusCode == http.StatusInternalServerError {
-			// Check if instance was already deleted (not found)
-			checkResp := getRequest(t, client, fmt.Sprintf(testutil.TestRouteFormat, testutil.TestBaseURL, testutil.TestRouteInstances, instanceID), token)
-			defer func() { _ = checkResp.Body.Close() }()
-			if checkResp.StatusCode == http.StatusNotFound {
-				t.Log("Instance already deleted (likely by API restart cleanup during chaos tests)")
+		var resp *http.Response
+		for attempt := 0; attempt < 3; attempt++ {
+			if attempt > 0 {
+				time.Sleep(time.Duration(attempt*500) * time.Millisecond)
+			}
+			resp = deleteRequest(t, client, fmt.Sprintf(testutil.TestRouteFormat, testutil.TestBaseURL, testutil.TestRouteInstances, instanceID), token)
+			if resp.StatusCode == http.StatusOK {
+				resp.Body.Close()
 				return
 			}
-			// Instance exists but delete failed - this is a real error
-			t.Fatalf("Instance termination failed with 500 but instance still exists at %s", instanceID)
+			if resp.StatusCode != http.StatusInternalServerError {
+				break
+			}
+			// 500 — check if instance was already deleted by API restart cleanup
+			checkResp := getRequest(t, client, fmt.Sprintf(testutil.TestRouteFormat, testutil.TestBaseURL, testutil.TestRouteInstances, instanceID), token)
+			checkResp.Body.Close()
+			if checkResp.StatusCode == http.StatusNotFound {
+				t.Log("Instance already deleted (API restart cleanup during chaos tests)")
+				resp.Body.Close()
+				return
+			}
+			resp.Body.Close()
 		}
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})

--- a/tests/kubernetes_e2e_test.go
+++ b/tests/kubernetes_e2e_test.go
@@ -79,7 +79,8 @@ func TestKubernetesE2E(t *testing.T) {
 			// Cluster not found — acceptable during early provisioning
 			t.Log("Cluster not found (may still be provisioning)")
 		default:
-			t.Logf("Kubeconfig endpoint returned %d", resp.StatusCode)
+			// Unexpected status — log for CI searchability but don't fail
+			t.Logf("Kubeconfig endpoint returned unexpected status %d", resp.StatusCode)
 		}
 	})
 

--- a/tests/kubernetes_e2e_test.go
+++ b/tests/kubernetes_e2e_test.go
@@ -69,10 +69,16 @@ func TestKubernetesE2E(t *testing.T) {
 
 		// It might return 404 or empty if not ready, strictly speaking.
 		// But in our current impl, we return what's in DB. If provisioner hasn't updated it, it might be empty.
-		if resp.StatusCode == http.StatusOK {
-			// Success
-		} else {
-			// It's acceptable for now if it fails due to being provisioning
+		switch resp.StatusCode {
+		case http.StatusOK:
+			// kubeconfig available — success
+		case http.StatusBadRequest:
+			// Cluster proxy not yet initialized — acceptable during provisioning
+			t.Log("Kubeconfig not yet available (cluster still provisioning)")
+		case http.StatusNotFound:
+			// Cluster not found — acceptable during early provisioning
+			t.Log("Cluster not found (may still be provisioning)")
+		default:
 			t.Logf("Kubeconfig endpoint returned %d", resp.StatusCode)
 		}
 	})


### PR DESCRIPTION
## Summary
- **TestInstanceTypesE2E/TerminateInstance**: Add retry loop (up to 3 attempts, 500ms backoff) when DELETE returns 500. Check if instance was already deleted via API restart cleanup and pass gracefully.
- **TestKubernetesE2E/Get_Kubeconfig**: Explicitly handle 400 as "still provisioning" in addition to 404, with descriptive log messages.

Fixes #399.

## Test plan
- [x] `go build ./tests/...`
- [x] `go vet ./tests/...`
- [ ] Run E2E tests on CI (verification pending)