### PR TITLE
fix: fail fast when benchmark output is empty (#397)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -27,6 +27,17 @@ jobs:
             | grep -E '^(goos:|goarch:|pkg:|cpu:|Benchmark|PASS$|ok\s)' \
             | tee bench.txt
 
+      - name: Check Benchmark Output
+        run: |
+          if [ ! -s bench.txt ]; then
+            echo "ERROR: bench.txt is empty. Benchmark command produced no output."
+            echo "This likely means 'go test' failed or produced no benchmark data."
+            echo "Running without 2>/dev/null to expose actual error:"
+            go test -run '^$' -bench=. -benchmem ./internal/core/services/... 2>&1 || true
+            exit 1
+          fi
+          echo "Benchmark output OK ($(wc -l < bench.txt) lines)"
+
       - name: Store Benchmark Result (PR)
         if: github.event_name == 'pull_request'
         uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
## Summary

Add a "Check Benchmark Output" step to the Benchmarks CI workflow. When `bench.txt` is empty, the step now prints the actual `go test` error (without `2>/dev/null` suppression) so the real failure cause is visible, rather than producing a cryptic "No benchmark result found" error from `benchmark-action`.

This change:
- Fails fast with a descriptive error when benchmarks can't produce output
- Reveals the underlying cause (compilation error, Go version mismatch, etc.)
- Doesn't affect the happy path where benchmarks run correctly

Fixes #397.

## Test plan
- [x] `go test -run '^$' -bench=. -benchmem ./internal/core/services/...` runs successfully locally
- [ ] CI verification pending