### PR TITLE
fix(sdk): resolve JSON parsing errors in CLI list commands

### DIFF
--- a/cmd/cloud/container_cli_test.go
+++ b/cmd/cloud/container_cli_test.go
@@ -61,15 +61,17 @@ func TestListDeploymentsCmd(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		payload := []map[string]interface{}{
-			{
-				"id":            containerTestID,
-				"name":          containerTestName,
-				"image":         "nginx:latest",
-				"replicas":      2,
-				"current_count": 2,
-				"ports":         "80:80",
-				"status":        "running",
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":            containerTestID,
+					"name":          containerTestName,
+					"image":         "nginx:latest",
+					"replicas":      2,
+					"current_count": 2,
+					"ports":         "80:80",
+					"status":        "running",
+				},
 			},
 		}
 		_ = json.NewEncoder(w).Encode(payload)

--- a/cmd/cloud/snapshot_cli_test.go
+++ b/cmd/cloud/snapshot_cli_test.go
@@ -23,14 +23,16 @@ func TestSnapshotListJSONOutput(t *testing.T) {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		payload := []map[string]interface{}{
-			{
-				"id":          snapshotTestID,
-				"volume_id":   uuid.New().String(),
-				"volume_name": "data",
-				"size_gb":     10,
-				"status":      "AVAILABLE",
-				"created_at":  time.Now().UTC().Format(time.RFC3339),
+		payload := map[string]interface{}{
+			"data": []map[string]interface{}{
+				{
+					"id":          snapshotTestID,
+					"volume_id":   uuid.New().String(),
+					"volume_name": "data",
+					"size_gb":     10,
+					"status":      "AVAILABLE",
+					"created_at":  time.Now().UTC().Format(time.RFC3339),
+				},
 			},
 		}
 		_ = json.NewEncoder(w).Encode(payload)

--- a/pkg/sdk/container.go
+++ b/pkg/sdk/container.go
@@ -36,9 +36,12 @@ func (c *Client) CreateDeployment(name, image string, replicas int, ports string
 }
 
 func (c *Client) ListDeployments() ([]Deployment, error) {
-	var deps []Deployment
-	err := c.get("/containers/deployments", &deps)
-	return deps, err
+	var res Response[[]Deployment]
+	err := c.get("/containers/deployments", &res)
+	if err != nil {
+		return nil, err
+	}
+	return res.Data, nil
 }
 
 func (c *Client) GetDeployment(id string) (*Deployment, error) {

--- a/pkg/sdk/container_test.go
+++ b/pkg/sdk/container_test.go
@@ -62,7 +62,7 @@ func TestClientListDeployments(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(expectedDeps)
+		_ = json.NewEncoder(w).Encode(Response[[]Deployment]{Data: expectedDeps})
 	}))
 	defer server.Close()
 

--- a/pkg/sdk/cron.go
+++ b/pkg/sdk/cron.go
@@ -40,9 +40,12 @@ func (c *Client) CreateCronJob(name, schedule, url, method, payload string) (*Cr
 }
 
 func (c *Client) ListCronJobs() ([]CronJob, error) {
-	var jobs []CronJob
-	err := c.get("/cron/jobs", &jobs)
-	return jobs, err
+	var res Response[[]CronJob]
+	err := c.get("/cron/jobs", &res)
+	if err != nil {
+		return nil, err
+	}
+	return res.Data, nil
 }
 
 func (c *Client) GetCronJob(id string) (*CronJob, error) {

--- a/pkg/sdk/cron_test.go
+++ b/pkg/sdk/cron_test.go
@@ -61,7 +61,7 @@ func TestClient_ListCronJobs(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(expectedJobs)
+		_ = json.NewEncoder(w).Encode(Response[[]CronJob]{Data: expectedJobs})
 	}))
 	defer server.Close()
 

--- a/pkg/sdk/gateway.go
+++ b/pkg/sdk/gateway.go
@@ -46,9 +46,12 @@ func (c *Client) CreateGatewayRoute(name, prefix, target string, methods []strin
 }
 
 func (c *Client) ListGatewayRoutes() ([]GatewayRoute, error) {
-	var routes []GatewayRoute
-	err := c.get("/gateway/routes", &routes)
-	return routes, err
+	var res Response[[]GatewayRoute]
+	err := c.get("/gateway/routes", &res)
+	if err != nil {
+		return nil, err
+	}
+	return res.Data, nil
 }
 
 func (c *Client) DeleteGatewayRoute(id string) error {

--- a/pkg/sdk/gateway_test.go
+++ b/pkg/sdk/gateway_test.go
@@ -69,7 +69,7 @@ func TestGatewayListRoutes(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(expectedRoutes)
+		_ = json.NewEncoder(w).Encode(Response[[]GatewayRoute]{Data: expectedRoutes})
 	}))
 	defer server.Close()
 

--- a/pkg/sdk/list_integration_test.go
+++ b/pkg/sdk/list_integration_test.go
@@ -95,7 +95,7 @@ func TestListOperations_EmptyResponse(t *testing.T) {
 
 	deps, err := client.ListDeployments()
 	require.NoError(t, err)
-	assert.Len(t, deps, 0)
+	assert.Empty(t, deps)
 }
 
 // TestListOperations_WithMeta verifies that list operations correctly ignore meta field

--- a/pkg/sdk/list_integration_test.go
+++ b/pkg/sdk/list_integration_test.go
@@ -1,0 +1,129 @@
+package sdk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListOperations_WrappedResponse verifies that list operations correctly
+// unmarshal the API's wrapped response format {"data": [...], "meta": {...}}
+func TestListOperations_WrappedResponse(t *testing.T) {
+	// Test data
+	deployments := []Deployment{
+		{ID: "dep-1", Name: "web", Image: "nginx", Replicas: 2},
+		{ID: "dep-2", Name: "api", Image: "go-api", Replicas: 1},
+	}
+	cronJobs := []CronJob{
+		{ID: "cron-1", Name: "backup", Schedule: "0 0 * * *"},
+		{ID: "cron-2", Name: "cleanup", Schedule: "0 1 * * *"},
+	}
+	gatewayRoutes := []GatewayRoute{
+		{ID: "route-1", Name: "api-route", PathPrefix: "/api"},
+		{ID: "route-2", Name: "web-route", PathPrefix: "/web"},
+	}
+	snapshots := []*domain.Snapshot{
+		{ID: uuid.New(), Description: "snap-1"},
+		{ID: uuid.New(), Description: "snap-2"},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/containers/deployments":
+			_ = json.NewEncoder(w).Encode(Response[[]Deployment]{Data: deployments})
+		case "/cron/jobs":
+			_ = json.NewEncoder(w).Encode(Response[[]CronJob]{Data: cronJobs})
+		case "/gateway/routes":
+			_ = json.NewEncoder(w).Encode(Response[[]GatewayRoute]{Data: gatewayRoutes})
+		case "/snapshots":
+			_ = json.NewEncoder(w).Encode(Response[[]*domain.Snapshot]{Data: snapshots})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, testAPIKey)
+
+	t.Run("ListDeployments", func(t *testing.T) {
+		deps, err := client.ListDeployments()
+		require.NoError(t, err)
+		assert.Len(t, deps, 2)
+		assert.Equal(t, "dep-1", deps[0].ID)
+		assert.Equal(t, "web", deps[0].Name)
+	})
+
+	t.Run("ListCronJobs", func(t *testing.T) {
+		jobs, err := client.ListCronJobs()
+		require.NoError(t, err)
+		assert.Len(t, jobs, 2)
+		assert.Equal(t, "cron-1", jobs[0].ID)
+	})
+
+	t.Run("ListGatewayRoutes", func(t *testing.T) {
+		routes, err := client.ListGatewayRoutes()
+		require.NoError(t, err)
+		assert.Len(t, routes, 2)
+		assert.Equal(t, "route-1", routes[0].ID)
+	})
+
+	t.Run("ListSnapshots", func(t *testing.T) {
+		snaps, err := client.ListSnapshots()
+		require.NoError(t, err)
+		assert.Len(t, snaps, 2)
+	})
+}
+
+// TestListOperations_EmptyResponse verifies that list operations handle empty responses
+func TestListOperations_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Return empty wrapped response
+		_ = json.NewEncoder(w).Encode(Response[[]Deployment]{Data: []Deployment{}})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, testAPIKey)
+
+	deps, err := client.ListDeployments()
+	require.NoError(t, err)
+	assert.Len(t, deps, 0)
+}
+
+// TestListOperations_WithMeta verifies that list operations correctly ignore meta field
+func TestListOperations_WithMeta(t *testing.T) {
+	deployments := []Deployment{{ID: "dep-1", Name: "test"}}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Response includes meta field - should be ignored by SDK
+		resp := struct {
+			Data interface{} `json:"data"`
+			Meta struct {
+				RequestID string `json:"request_id"`
+			} `json:"meta"`
+		}{
+			Data: deployments,
+			Meta: struct {
+				RequestID string `json:"request_id"`
+			}{RequestID: "req-123"},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, testAPIKey)
+
+	deps, err := client.ListDeployments()
+	require.NoError(t, err)
+	assert.Len(t, deps, 1)
+	assert.Equal(t, "dep-1", deps[0].ID)
+}

--- a/pkg/sdk/snapshot.go
+++ b/pkg/sdk/snapshot.go
@@ -23,12 +23,12 @@ func (c *Client) CreateSnapshot(volumeID uuid.UUID, description string) (*domain
 }
 
 func (c *Client) ListSnapshots() ([]*domain.Snapshot, error) {
-	var snapshots []*domain.Snapshot
-	err := c.get("/snapshots", &snapshots)
+	var res Response[[]*domain.Snapshot]
+	err := c.get("/snapshots", &res)
 	if err != nil {
 		return nil, err
 	}
-	return snapshots, nil
+	return res.Data, nil
 }
 
 func (c *Client) GetSnapshot(id string) (*domain.Snapshot, error) {

--- a/pkg/sdk/snapshot_test.go
+++ b/pkg/sdk/snapshot_test.go
@@ -68,7 +68,7 @@ func TestClientListSnapshots(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
 		w.Header().Set(snapshotContentType, snapshotApplicationJSON)
-		_ = json.NewEncoder(w).Encode(expectedSnapshots)
+		_ = json.NewEncoder(w).Encode(Response[[]*domain.Snapshot]{Data: expectedSnapshots})
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## Summary
- Fix JSON parsing errors in 4 CLI list commands caused by API returning wrapped response format `{"data": [...], "meta": {...}}` while SDK expected plain arrays
- Updated SDK methods: `ListDeployments`, `ListSnapshots`, `ListCronJobs`, `ListGatewayRoutes`
- Added integration tests to verify wrapped response handling

## Changes
- `pkg/sdk/container.go` - Use Response wrapper in ListDeployments
- `pkg/sdk/snapshot.go` - Use Response wrapper in ListSnapshots
- `pkg/sdk/cron.go` - Use Response wrapper in ListCronJobs
- `pkg/sdk/gateway.go` - Use Response wrapper in ListGatewayRoutes
- Updated corresponding test mocks
- Added integration tests in `pkg/sdk/list_integration_test.go`

## Test Plan
- [x] Unit tests pass: `go test ./pkg/sdk/...`
- [x] Build succeeds: `go build ./...`
- [x] All CI checks green

## Auto-close Issues
Fixes #409
Fixes #411
Fixes #412
Fixes #417