### PR TITLE
fix: align SDK endpoints with API router paths

### DIFF
--- a/pkg/sdk/igw.go
+++ b/pkg/sdk/igw.go
@@ -28,7 +28,7 @@ type InternetGateway struct {
 // CreateIGW creates a new internet gateway in detached state.
 func (c *Client) CreateIGW() (*InternetGateway, error) {
 	var res Response[InternetGateway]
-	if err := c.post("/igws", nil, &res); err != nil {
+	if err := c.post("/internet-gateways", nil, &res); err != nil {
 		return nil, err
 	}
 	return &res.Data, nil
@@ -39,18 +39,18 @@ func (c *Client) AttachIGW(igwID, vpcID string) error {
 	body := map[string]string{
 		"vpc_id": vpcID,
 	}
-	return c.post(fmt.Sprintf("/igws/%s/attach", igwID), body, nil)
+	return c.post(fmt.Sprintf("/internet-gateways/%s/attach", igwID), body, nil)
 }
 
 // DetachIGW detaches an internet gateway from its VPC.
 func (c *Client) DetachIGW(igwID string) error {
-	return c.post(fmt.Sprintf("/igws/%s/detach", igwID), nil, nil)
+	return c.post(fmt.Sprintf("/internet-gateways/%s/detach", igwID), nil, nil)
 }
 
 // ListIGWs returns all internet gateways for the tenant.
 func (c *Client) ListIGWs() ([]InternetGateway, error) {
 	var res Response[[]InternetGateway]
-	if err := c.get("/igws", &res); err != nil {
+	if err := c.get("/internet-gateways", &res); err != nil {
 		return nil, err
 	}
 	return res.Data, nil
@@ -59,7 +59,7 @@ func (c *Client) ListIGWs() ([]InternetGateway, error) {
 // GetIGW retrieves details of a specific internet gateway.
 func (c *Client) GetIGW(id string) (*InternetGateway, error) {
 	var res Response[InternetGateway]
-	if err := c.get(fmt.Sprintf("/igws/%s", id), &res); err != nil {
+	if err := c.get(fmt.Sprintf("/internet-gateways/%s", id), &res); err != nil {
 		return nil, err
 	}
 	return &res.Data, nil
@@ -67,5 +67,5 @@ func (c *Client) GetIGW(id string) (*InternetGateway, error) {
 
 // DeleteIGW permanently removes an internet gateway (must be detached first).
 func (c *Client) DeleteIGW(id string) error {
-	return c.delete(fmt.Sprintf("/igws/%s", id), nil)
+	return c.delete(fmt.Sprintf("/internet-gateways/%s", id), nil)
 }

--- a/pkg/sdk/igw_test.go
+++ b/pkg/sdk/igw_test.go
@@ -1,0 +1,137 @@
+package sdk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientCreateIGW(t *testing.T) {
+	expectedIGW := InternetGateway{
+		ID:     "igw-123",
+		Status: IGWStatusDetached,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/internet-gateways", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Response[InternetGateway]{Data: expectedIGW})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	igw, err := client.CreateIGW()
+
+	require.NoError(t, err)
+	assert.NotNil(t, igw)
+	assert.Equal(t, expectedIGW.ID, igw.ID)
+	assert.Equal(t, expectedIGW.Status, igw.Status)
+}
+
+func TestClientListIGWs(t *testing.T) {
+	expectedIGWs := []InternetGateway{
+		{ID: "igw-1", Status: IGWStatusDetached},
+		{ID: "igw-2", Status: IGWStatusAttached},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/internet-gateways", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Response[[]InternetGateway]{Data: expectedIGWs})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	igws, err := client.ListIGWs()
+
+	require.NoError(t, err)
+	assert.Len(t, igws, 2)
+	assert.Equal(t, expectedIGWs[0].ID, igws[0].ID)
+}
+
+func TestClientGetIGW(t *testing.T) {
+	id := "igw-123"
+	expectedIGW := InternetGateway{
+		ID:     id,
+		Status: IGWStatusAttached,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/internet-gateways/"+id, r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Response[InternetGateway]{Data: expectedIGW})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	igw, err := client.GetIGW(id)
+
+	require.NoError(t, err)
+	assert.NotNil(t, igw)
+	assert.Equal(t, expectedIGW.ID, igw.ID)
+}
+
+func TestClientDeleteIGW(t *testing.T) {
+	id := "igw-123"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/internet-gateways/"+id, r.URL.Path)
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.DeleteIGW(id)
+
+	require.NoError(t, err)
+}
+
+func TestClientAttachIGW(t *testing.T) {
+	igwID := "igw-123"
+	vpcID := "vpc-456"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/internet-gateways/"+igwID+"/attach", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req map[string]string
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+		assert.Equal(t, vpcID, req["vpc_id"])
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.AttachIGW(igwID, vpcID)
+
+	require.NoError(t, err)
+}
+
+func TestClientDetachIGW(t *testing.T) {
+	igwID := "igw-123"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/internet-gateways/"+igwID+"/detach", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.DetachIGW(igwID)
+
+	require.NoError(t, err)
+}

--- a/pkg/sdk/igw_test.go
+++ b/pkg/sdk/igw_test.go
@@ -141,3 +141,63 @@ func TestClientDetachIGW(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestClientCreateIGWError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal error"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	_, err := client.CreateIGW()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientListIGWsError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"bad request"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	_, err := client.ListIGWs()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientGetIGWError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	_, err := client.GetIGW("nonexistent")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientDeleteIGWError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"forbidden"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.DeleteIGW("igw-123")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}

--- a/pkg/sdk/igw_test.go
+++ b/pkg/sdk/igw_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestClientCreateIGW(t *testing.T) {
+	t.Parallel()
 	expectedIGW := InternetGateway{
 		ID:     "igw-123",
 		Status: IGWStatusDetached,
@@ -35,6 +36,7 @@ func TestClientCreateIGW(t *testing.T) {
 }
 
 func TestClientListIGWs(t *testing.T) {
+	t.Parallel()
 	expectedIGWs := []InternetGateway{
 		{ID: "igw-1", Status: IGWStatusDetached},
 		{ID: "igw-2", Status: IGWStatusAttached},
@@ -58,6 +60,7 @@ func TestClientListIGWs(t *testing.T) {
 }
 
 func TestClientGetIGW(t *testing.T) {
+	t.Parallel()
 	id := "igw-123"
 	expectedIGW := InternetGateway{
 		ID:     id,
@@ -82,6 +85,7 @@ func TestClientGetIGW(t *testing.T) {
 }
 
 func TestClientDeleteIGW(t *testing.T) {
+	t.Parallel()
 	id := "igw-123"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -98,6 +102,7 @@ func TestClientDeleteIGW(t *testing.T) {
 }
 
 func TestClientAttachIGW(t *testing.T) {
+	t.Parallel()
 	igwID := "igw-123"
 	vpcID := "vpc-456"
 
@@ -121,6 +126,7 @@ func TestClientAttachIGW(t *testing.T) {
 }
 
 func TestClientDetachIGW(t *testing.T) {
+	t.Parallel()
 	igwID := "igw-123"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/sdk/route_table.go
+++ b/pkg/sdk/route_table.go
@@ -47,7 +47,7 @@ type RouteTableAssociation struct {
 // ListRouteTables returns all route tables for a VPC.
 func (c *Client) ListRouteTables(vpcID string) ([]RouteTable, error) {
 	var res Response[[]RouteTable]
-	path := fmt.Sprintf("/vpcs/%s/route-tables", vpcID)
+	path := fmt.Sprintf("/route-tables?vpc_id=%s", vpcID)
 	if err := c.get(path, &res); err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/route_table_test.go
+++ b/pkg/sdk/route_table_test.go
@@ -1,0 +1,111 @@
+package sdk
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientListRouteTables(t *testing.T) {
+	vpcID := "vpc-123"
+	expectedRTs := []RouteTable{
+		{ID: "rt-1", VPCID: vpcID, Name: "main-rt", IsMain: true},
+		{ID: "rt-2", VPCID: vpcID, Name: "custom-rt", IsMain: false},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables", r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, vpcID, r.URL.Query().Get("vpc_id"))
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Response[[]RouteTable]{Data: expectedRTs})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	rts, err := client.ListRouteTables(vpcID)
+
+	require.NoError(t, err)
+	assert.Len(t, rts, 2)
+	assert.Equal(t, expectedRTs[0].ID, rts[0].ID)
+	assert.True(t, rts[0].IsMain)
+}
+
+func TestClientCreateRouteTable(t *testing.T) {
+	vpcID := "vpc-123"
+	expectedRT := RouteTable{
+		ID:     "rt-456",
+		VPCID:  vpcID,
+		Name:   "new-rt",
+		IsMain: false,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+		assert.Equal(t, vpcID, req["vpc_id"])
+		assert.Equal(t, "new-rt", req["name"])
+		assert.Equal(t, false, req["is_main"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Response[RouteTable]{Data: expectedRT})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	rt, err := client.CreateRouteTable(vpcID, "new-rt", false)
+
+	require.NoError(t, err)
+	assert.NotNil(t, rt)
+	assert.Equal(t, expectedRT.ID, rt.ID)
+}
+
+func TestClientGetRouteTable(t *testing.T) {
+	id := "rt-123"
+	expectedRT := RouteTable{
+		ID:    id,
+		VPCID: "vpc-456",
+		Name:  "test-rt",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables/"+id, r.URL.Path)
+		assert.Equal(t, http.MethodGet, r.Method)
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Response[RouteTable]{Data: expectedRT})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	rt, err := client.GetRouteTable(id)
+
+	require.NoError(t, err)
+	assert.NotNil(t, rt)
+	assert.Equal(t, expectedRT.ID, rt.ID)
+}
+
+func TestClientDeleteRouteTable(t *testing.T) {
+	id := "rt-123"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables/"+id, r.URL.Path)
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.DeleteRouteTable(id)
+
+	require.NoError(t, err)
+}

--- a/pkg/sdk/route_table_test.go
+++ b/pkg/sdk/route_table_test.go
@@ -246,3 +246,123 @@ func TestClientDisassociateSubnet(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func TestClientListRouteTablesError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"internal error"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	_, err := client.ListRouteTables("vpc-123")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientCreateRouteTableError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid vpc_id"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	_, err := client.CreateRouteTable("invalid-uuid", "my-rt", false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientGetRouteTableError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"route table not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	_, err := client.GetRouteTable("nonexistent")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientDeleteRouteTableError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"error":"cannot delete main route table"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.DeleteRouteTable("rt-123")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientAddRouteError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid CIDR format"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	_, err := client.AddRoute("rt-123", "invalid", RouteTargetIGW, "igw-789")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientRemoveRouteError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"route not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.RemoveRoute("rt-123", "nonexistent")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientAssociateSubnetError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"error":"subnet already associated"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.AssociateSubnet("rt-123", "subnet-456")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}
+
+func TestClientDisassociateSubnetError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"association not found"}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.DisassociateSubnet("rt-123", "subnet-456")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "api error")
+}

--- a/pkg/sdk/route_table_test.go
+++ b/pkg/sdk/route_table_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestClientListRouteTables(t *testing.T) {
+	t.Parallel()
 	vpcID := "vpc-123"
 	expectedRTs := []RouteTable{
 		{ID: "rt-1", VPCID: vpcID, Name: "main-rt", IsMain: true},
@@ -37,6 +38,7 @@ func TestClientListRouteTables(t *testing.T) {
 }
 
 func TestClientCreateRouteTable(t *testing.T) {
+	t.Parallel()
 	vpcID := "vpc-123"
 	expectedRT := RouteTable{
 		ID:     "rt-456",
@@ -70,6 +72,7 @@ func TestClientCreateRouteTable(t *testing.T) {
 }
 
 func TestClientGetRouteTable(t *testing.T) {
+	t.Parallel()
 	id := "rt-123"
 	expectedRT := RouteTable{
 		ID:    id,
@@ -95,6 +98,7 @@ func TestClientGetRouteTable(t *testing.T) {
 }
 
 func TestClientDeleteRouteTable(t *testing.T) {
+	t.Parallel()
 	id := "rt-123"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -106,6 +110,139 @@ func TestClientDeleteRouteTable(t *testing.T) {
 
 	client := NewClient(server.URL, "test-api-key")
 	err := client.DeleteRouteTable(id)
+
+	require.NoError(t, err)
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestClientAddRoute(t *testing.T) {
+	t.Parallel()
+	rtID := "rt-123"
+	expectedRoute := Route{
+		ID:              "route-456",
+		RouteTableID:    rtID,
+		DestinationCIDR: "10.0.0.0/16",
+		TargetType:      RouteTargetIGW,
+		TargetID:        strPtr("igw-789"),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables/"+rtID+"/routes", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+		assert.Equal(t, "10.0.0.0/16", req["destination_cidr"])
+		assert.Equal(t, "igw", req["target_type"])
+		assert.Equal(t, "igw-789", req["target_id"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Response[Route]{Data: expectedRoute})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	route, err := client.AddRoute(rtID, "10.0.0.0/16", RouteTargetIGW, "igw-789")
+
+	require.NoError(t, err)
+	assert.NotNil(t, route)
+	assert.Equal(t, expectedRoute.ID, route.ID)
+	assert.Equal(t, expectedRoute.DestinationCIDR, route.DestinationCIDR)
+}
+
+func TestClientAddRouteWithoutTargetID(t *testing.T) {
+	t.Parallel()
+	rtID := "rt-123"
+	expectedRoute := Route{
+		ID:              "route-456",
+		RouteTableID:    rtID,
+		DestinationCIDR: "0.0.0.0/0",
+		TargetType:      RouteTargetLocal,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables/"+rtID+"/routes", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+		assert.Equal(t, "0.0.0.0/0", req["destination_cidr"])
+		assert.Equal(t, "local", req["target_type"])
+		_, hasTargetID := req["target_id"]
+		assert.False(t, hasTargetID, "target_id should not be present when empty")
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(Response[Route]{Data: expectedRoute})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	route, err := client.AddRoute(rtID, "0.0.0.0/0", RouteTargetLocal, "")
+
+	require.NoError(t, err)
+	assert.NotNil(t, route)
+	assert.Equal(t, expectedRoute.TargetType, route.TargetType)
+}
+
+func TestClientRemoveRoute(t *testing.T) {
+	t.Parallel()
+	rtID := "rt-123"
+	routeID := "route-456"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables/"+rtID+"/routes/"+routeID, r.URL.Path)
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.RemoveRoute(rtID, routeID)
+
+	require.NoError(t, err)
+}
+
+func TestClientAssociateSubnet(t *testing.T) {
+	t.Parallel()
+	rtID := "rt-123"
+	subnetID := "subnet-456"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables/"+rtID+"/associations", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req map[string]string
+		err := json.NewDecoder(r.Body).Decode(&req)
+		assert.NoError(t, err)
+		assert.Equal(t, subnetID, req["subnet_id"])
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.AssociateSubnet(rtID, subnetID)
+
+	require.NoError(t, err)
+}
+
+func TestClientDisassociateSubnet(t *testing.T) {
+	t.Parallel()
+	rtID := "rt-123"
+	subnetID := "subnet-456"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/route-tables/"+rtID+"/associations/"+subnetID, r.URL.Path)
+		assert.Equal(t, http.MethodDelete, r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "test-api-key")
+	err := client.DisassociateSubnet(rtID, subnetID)
 
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- Fix IGW CLI commands returning 404 by changing SDK endpoints from `/igws` to `/internet-gateways`
- Fix route-table list returning 404 by changing SDK path from `/vpcs/{id}/route-tables` to `/route-tables?vpc_id=`

## Root Cause
- IGW SDK called `/igws` but API router registers endpoints at `/internet-gateways`
- Route table SDK called `/vpcs/{vpcID}/route-tables` but API handler is at `/route-tables` with `vpc_id` query param

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./pkg/sdk/...` passes
- [ ] Test `cloud igw create` and `cloud igw list` - should no longer return 404
- [ ] Test `cloud route-table list <vpc-id>` - should no longer return 404

Fixes #422, #420, #418