### PR TITLE
feat(cli): add missing VPC show, notify unsubscribe, and instance resize commands

### DIFF
--- a/cmd/cloud/instance.go
+++ b/cmd/cloud/instance.go
@@ -257,6 +257,22 @@ var rmCmd = &cobra.Command{
 	},
 }
 
+var resizeCmd = &cobra.Command{
+	Use:   "resize [id/name] [instance-type]",
+	Short: "Resize an instance to a new instance type",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		instanceType := args[1]
+		client := createClient(opts)
+		if err := client.ResizeInstance(id, instanceType); err != nil {
+			fmt.Printf(fmtErrorLog, err)
+			return
+		}
+		fmt.Printf("[SUCCESS] Instance %s resized to %s.\n", id, instanceType)
+	},
+}
+
 var statsCmd = &cobra.Command{
 	Use:   "stats [id/name]",
 	Short: "Show instance statistics (CPU/Mem)",
@@ -398,6 +414,7 @@ func init() {
 	instanceCmd.AddCommand(showCmd)
 	instanceCmd.AddCommand(consoleCmd)
 	instanceCmd.AddCommand(rmCmd)
+	instanceCmd.AddCommand(resizeCmd)
 	instanceCmd.AddCommand(statsCmd)
 	instanceCmd.AddCommand(metadataCmd)
 	instanceCmd.AddCommand(sshCmd)

--- a/cmd/cloud/instance_test.go
+++ b/cmd/cloud/instance_test.go
@@ -236,7 +236,7 @@ func TestStatsCmdRequiresOneArg(t *testing.T) {
 func TestInstanceCmdHasSubcommands(t *testing.T) {
 	subcommands := instanceCmd.Commands()
 
-	expectedCommands := []string{"list", "launch", "stop", "logs", "show", "rm", "stats"}
+	expectedCommands := []string{"list", "launch", "stop", "logs", "show", "rm", "resize", "stats"}
 	found := make(map[string]bool)
 
 	for _, cmd := range subcommands {
@@ -247,6 +247,27 @@ func TestInstanceCmdHasSubcommands(t *testing.T) {
 		if !found[expected] {
 			t.Errorf("instance command missing subcommand: %s", expected)
 		}
+	}
+}
+
+func TestResizeCmdRequiresTwoArgs(t *testing.T) {
+	if resizeCmd.Args == nil {
+		t.Fatal("resize command should require args")
+	}
+
+	err := resizeCmd.Args(resizeCmd, []string{})
+	if err == nil {
+		t.Error("resize command should error with no args")
+	}
+
+	err = resizeCmd.Args(resizeCmd, []string{"id1"})
+	if err == nil {
+		t.Error("resize command should error with only 1 arg")
+	}
+
+	err = resizeCmd.Args(resizeCmd, []string{"id1", "basic-4"})
+	if err != nil {
+		t.Errorf("resize command should accept 2 args, got error: %v", err)
 	}
 }
 

--- a/cmd/cloud/notify.go
+++ b/cmd/cloud/notify.go
@@ -87,6 +87,22 @@ var publishCmd = &cobra.Command{
 	},
 }
 
+var unsubscribeCmd = &cobra.Command{
+	Use:   "unsubscribe [subscription-id]",
+	Short: "Unsubscribe from a topic",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		err := client.Unsubscribe(args[0])
+		if err != nil {
+			fmt.Printf(notifyErrorFormat, err)
+			return
+		}
+
+		fmt.Println("[SUCCESS] Unsubscribed successfully")
+	},
+}
+
 func init() {
 	subscribeCmd.Flags().StringP("protocol", "p", "webhook", "Protocol (webhook/queue)")
 	subscribeCmd.Flags().StringP("endpoint", "e", "", "Endpoint (URL or Queue ID)")
@@ -96,4 +112,5 @@ func init() {
 	notifyCmd.AddCommand(listTopicsCmd)
 	notifyCmd.AddCommand(subscribeCmd)
 	notifyCmd.AddCommand(publishCmd)
+	notifyCmd.AddCommand(unsubscribeCmd)
 }

--- a/cmd/cloud/vpc.go
+++ b/cmd/cloud/vpc.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -97,9 +98,41 @@ var vpcRmCmd = &cobra.Command{
 	},
 }
 
+var vpcShowCmd = &cobra.Command{
+	Use:   "show [id/name]",
+	Short: "Show VPC details",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		client := createClient(opts)
+		vpc, err := client.GetVPC(id)
+		if err != nil {
+			fmt.Printf(vpcErrorFormat, err)
+			return
+		}
+
+		if opts.JSON {
+			printJSON(vpc)
+			return
+		}
+
+		fmt.Print("\nVPC Details\n")
+		fmt.Println(strings.Repeat("-", 40))
+		fmt.Printf(fmtDetailRow, "ID:", vpc.ID)
+		fmt.Printf(fmtDetailRow, "Name:", vpc.Name)
+		fmt.Printf(fmtDetailRow, "CIDR:", vpc.CIDRBlock)
+		fmt.Printf(fmtDetailRow, "VXLAN ID:", fmt.Sprintf("%d", vpc.VXLANID))
+		fmt.Printf(fmtDetailRow, "Network ID:", vpc.NetworkID)
+		fmt.Printf(fmtDetailRow, "Status:", vpc.Status)
+		fmt.Printf(fmtDetailRow, "Created At:", vpc.CreatedAt.Format("2006-01-02 15:04:05"))
+		fmt.Println()
+	},
+}
+
 func init() {
 	vpcCreateCmd.Flags().String("cidr-block", "10.0.0.0/16", "CIDR block for the VPC")
 	vpcCmd.AddCommand(vpcListCmd)
 	vpcCmd.AddCommand(vpcCreateCmd)
 	vpcCmd.AddCommand(vpcRmCmd)
+	vpcCmd.AddCommand(vpcShowCmd)
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -212,6 +212,23 @@ Terminate and remove an instance. (Alias: `delete`)
 cloud instance rm my-server
 ```
 
+### `instance resize <id> <instance-type>`
+
+Resize an instance to a new instance type.
+
+```bash
+cloud instance resize my-server basic-4
+```
+
+**Examples**:
+```bash
+# Resize to a larger instance type
+cloud instance resize my-server standard-2
+
+# Resize to a smaller instance type
+cloud instance resize my-server basic-1
+```
+
 ### `instance stats <id>`
 
 Show real-time resource usage.
@@ -1010,6 +1027,58 @@ Delete a function schedule.
 
 ```bash
 cloud fn-schedule rm [schedule-id]
+```
+
+---
+
+## CloudNotify Commands
+
+Manage pub/sub messaging topics and subscriptions.
+
+### `notify create-topic <name>`
+
+Create a new notification topic.
+
+```bash
+cloud notify create-topic my-topic
+```
+
+### `notify list-topics`
+
+List all notification topics.
+
+```bash
+cloud notify list-topics
+```
+
+### `notify subscribe <topic-id>`
+
+Subscribe to a topic to receive notifications.
+
+```bash
+cloud notify subscribe topic-uuid --endpoint https://example.com/webhook
+```
+
+**Flags**:
+| Flag | Short | Required | Default | Description |
+|------|-------|----------|---------|-------------|
+| `--protocol` | `-p` | No | `webhook` | Protocol (webhook or queue) |
+| `--endpoint` | `-e` | Yes | - | Endpoint URL or queue ID |
+
+### `notify unsubscribe <subscription-id>`
+
+Unsubscribe from a topic.
+
+```bash
+cloud notify unsubscribe subscription-uuid
+```
+
+### `notify publish <topic-id> <message>`
+
+Publish a message to a topic.
+
+```bash
+cloud notify publish topic-uuid "Hello, world!"
 ```
 
 ---

--- a/pkg/sdk/compute.go
+++ b/pkg/sdk/compute.go
@@ -135,6 +135,14 @@ func (c *Client) GetInstanceLogs(idOrName string) (string, error) {
 	return string(resp.Body()), nil
 }
 
+// ResizeInstance changes the instance type of a running or stopped instance.
+func (c *Client) ResizeInstance(idOrName, newInstanceType string) error {
+	body := map[string]string{
+		"instance_type": newInstanceType,
+	}
+	return c.post(fmt.Sprintf("/instances/%s/resize", idOrName), body, nil)
+}
+
 // InstanceStats captures resource usage for an instance.
 type InstanceStats struct {
 	CPUPercentage    float64 `json:"cpu_percentage"`

--- a/pkg/sdk/compute_test.go
+++ b/pkg/sdk/compute_test.go
@@ -240,7 +240,9 @@ func TestClientResizeInstance(t *testing.T) {
 
 		var req map[string]string
 		err := json.NewDecoder(r.Body).Decode(&req)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("failed to decode request: %v", err)
+		}
 		assert.Equal(t, "basic-4", req["instance_type"])
 
 		w.WriteHeader(http.StatusOK)

--- a/pkg/sdk/compute_test.go
+++ b/pkg/sdk/compute_test.go
@@ -232,3 +232,34 @@ func TestClientAPIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "api error")
 	assert.Contains(t, err.Error(), "invalid input")
 }
+
+func TestClientResizeInstance(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, computeInstancesPath+computeInstanceID+"/resize", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		var req map[string]string
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		assert.Equal(t, "basic-4", req["instance_type"])
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, computeAPIKey)
+	err := client.ResizeInstance(computeInstanceID, "basic-4")
+	require.NoError(t, err)
+}
+
+func TestClientResizeInstanceError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, computeAPIKey)
+	err := client.ResizeInstance(computeInstanceID, "basic-4")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
Add 3 missing CLI commands to address enhancement issues:

- `cloud vpc show [id/name]` - Show VPC details (fixes #441)
- `cloud notify unsubscribe [subscription-id]` - Unsubscribe from notifications (fixes #443)
- `cloud instance resize [id] [instance-type]` - Resize compute instances (partially addresses #442)

## Changes

### New CLI Commands
- `cmd/cloud/vpc.go` - Added `vpcShowCmd` command
- `cmd/cloud/notify.go` - Added `unsubscribeCmd` command
- `cmd/cloud/instance.go` - Added `resizeCmd` command

### SDK Changes
- `pkg/sdk/compute.go` - Added `ResizeInstance()` method

## Issues Addressed
- Fixes #441: CLI is missing 'cloud vpc show' command
- Fixes #443: CLI notify module missing 'unsubscribe' command
- Partially addresses #442: CLI instance resize (db/cache/volume resize still need API support)

## Test Plan
- [x] Build succeeds: `go build ./cmd/cloud/...`
- [x] Unit tests pass: `go test ./cmd/cloud/...`