### PR TITLE
fix: add short ID resolution to CLI commands

### DIFF
--- a/cmd/cloud/cache.go
+++ b/cmd/cloud/cache.go
@@ -7,6 +7,8 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/pkg/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -82,7 +84,8 @@ var getCacheCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		cache, err := client.GetCache(args[0])
+		cacheID := resolveCacheID(args[0], client)
+		cache, err := client.GetCache(cacheID)
 		if err != nil {
 			fmt.Printf("Error getting cache: %v\n", err)
 			return
@@ -109,7 +112,8 @@ var deleteCacheCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		if err := client.DeleteCache(args[0]); err != nil {
+		cacheID := resolveCacheID(args[0], client)
+		if err := client.DeleteCache(cacheID); err != nil {
 			fmt.Printf("Error deleting cache: %v\n", err)
 			return
 		}
@@ -123,7 +127,8 @@ var connectionCacheCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		connStr, err := client.GetCacheConnectionString(args[0])
+		cacheID := resolveCacheID(args[0], client)
+		connStr, err := client.GetCacheConnectionString(cacheID)
 		if err != nil {
 			fmt.Printf("Error getting connection string: %v\n", err)
 			return
@@ -138,7 +143,8 @@ var statsCacheCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		stats, err := client.GetCacheStats(args[0])
+		cacheID := resolveCacheID(args[0], client)
+		stats, err := client.GetCacheStats(cacheID)
 		if err != nil {
 			fmt.Printf("Error getting stats: %v\n", err)
 			return
@@ -163,12 +169,30 @@ var flushCacheCmd = &cobra.Command{
 		}
 
 		client := createClient(opts)
-		if err := client.FlushCache(args[0]); err != nil {
+		cacheID := resolveCacheID(args[0], client)
+		if err := client.FlushCache(cacheID); err != nil {
 			fmt.Printf("Error flushing cache: %v\n", err)
 			return
 		}
 		fmt.Println("Cache flushed successfully")
 	},
+}
+
+// resolveCacheID resolves a cache ID or name to a full UUID.
+func resolveCacheID(idOrName string, client *sdk.Client) string {
+	if _, err := uuid.Parse(idOrName); err == nil {
+		return idOrName // Already a valid UUID
+	}
+	caches, err := client.ListCaches()
+	if err != nil {
+		return idOrName // Fallback
+	}
+	for _, c := range caches {
+		if c.Name == idOrName {
+			return c.ID
+		}
+	}
+	return idOrName
 }
 
 func init() {

--- a/cmd/cloud/cache_test.go
+++ b/cmd/cloud/cache_test.go
@@ -1,6 +1,13 @@
 package main
 
-import "testing"
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/poyrazk/thecloud/pkg/sdk"
+)
 
 func TestFormatBytes(t *testing.T) {
 	if got := formatBytes(0); got != "0 B" {
@@ -11,5 +18,78 @@ func TestFormatBytes(t *testing.T) {
 	}
 	if got := formatBytes(1024 * 1024); got != "1.0 MB" {
 		t.Fatalf("expected 1.0 MB, got %q", got)
+	}
+}
+
+func TestResolveCacheIDByName(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/caches" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sdk.Response[[]sdk.Cache]{
+			Data: []sdk.Cache{
+				{ID: "uuid-123", Name: "my-cache", Status: "RUNNING"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	resolved := resolveCacheID("my-cache", client)
+	if resolved != "uuid-123" {
+		t.Fatalf("expected uuid-123, got %s", resolved)
+	}
+}
+
+func TestResolveCacheIDByUUID(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // Should not be called
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	id := "abc123-def456-ghi789"
+	resolved := resolveCacheID(id, client)
+	if resolved != id {
+		t.Fatalf("expected %s, got %s", id, resolved)
+	}
+}
+
+func TestResolveCacheIDNotFound(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/caches" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sdk.Response[[]sdk.Cache]{
+			Data: []sdk.Cache{},
+		})
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	resolved := resolveCacheID("nonexistent", client)
+	if resolved != "nonexistent" {
+		t.Fatalf("expected nonexistent (unchanged), got %s", resolved)
+	}
+}
+
+func TestResolveCacheIDAPIError(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	resolved := resolveCacheID("any-name", client)
+	if resolved != "any-name" {
+		t.Fatalf("expected any-name (fallback), got %s", resolved)
 	}
 }

--- a/cmd/cloud/cron.go
+++ b/cmd/cloud/cron.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/uuid"
 	"github.com/olekukonko/tablewriter"
+	"github.com/poyrazk/thecloud/pkg/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -60,7 +62,8 @@ var pauseCronCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		err := client.PauseCronJob(args[0])
+		jobID := resolveCronJobID(args[0], client)
+		err := client.PauseCronJob(jobID)
 		if err != nil {
 			fmt.Printf(errFmt, err)
 			return
@@ -75,7 +78,8 @@ var resumeCronCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		err := client.ResumeCronJob(args[0])
+		jobID := resolveCronJobID(args[0], client)
+		err := client.ResumeCronJob(jobID)
 		if err != nil {
 			fmt.Printf(errFmt, err)
 			return
@@ -90,7 +94,8 @@ var deleteCronCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		err := client.DeleteCronJob(args[0])
+		jobID := resolveCronJobID(args[0], client)
+		err := client.DeleteCronJob(jobID)
 		if err != nil {
 			fmt.Printf(errFmt, err)
 			return
@@ -108,5 +113,21 @@ func init() {
 	cronCmd.AddCommand(pauseCronCmd)
 	cronCmd.AddCommand(resumeCronCmd)
 	cronCmd.AddCommand(deleteCronCmd)
+}
 
+// resolveCronJobID resolves a cron job ID or name to a full UUID.
+func resolveCronJobID(idOrName string, client *sdk.Client) string {
+	if _, err := uuid.Parse(idOrName); err == nil {
+		return idOrName
+	}
+	jobs, err := client.ListCronJobs()
+	if err != nil {
+		return idOrName
+	}
+	for _, j := range jobs {
+		if j.Name == idOrName {
+			return j.ID
+		}
+	}
+	return idOrName
 }

--- a/cmd/cloud/cron_cli_test.go
+++ b/cmd/cloud/cron_cli_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/poyrazk/thecloud/pkg/sdk"
 )
 
 const (
@@ -108,5 +110,43 @@ func TestDeleteCronCmd(t *testing.T) {
 	})
 	if !strings.Contains(out, "Job deleted") {
 		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestResolveCronJobIDByName(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cron/jobs" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sdk.Response[[]sdk.CronJob]{
+			Data: []sdk.CronJob{
+				{ID: "uuid-456", Name: "nightly-backup", Status: "active"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	resolved := resolveCronJobID("nightly-backup", client)
+	if resolved != "uuid-456" {
+		t.Fatalf("expected uuid-456, got %s", resolved)
+	}
+}
+
+func TestResolveCronJobIDByUUID(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // Should not be called
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	id := "abc123-def456"
+	resolved := resolveCronJobID(id, client)
+	if resolved != id {
+		t.Fatalf("expected %s, got %s", id, resolved)
 	}
 }

--- a/cmd/cloud/notify.go
+++ b/cmd/cloud/notify.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/uuid"
 	"github.com/olekukonko/tablewriter"
+	"github.com/poyrazk/thecloud/pkg/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -61,7 +63,8 @@ var subscribeCmd = &cobra.Command{
 		endpoint, _ := cmd.Flags().GetString("endpoint")
 
 		client := createClient(opts)
-		sub, err := client.Subscribe(args[0], protocol, endpoint)
+		topicID := resolveTopicID(args[0], client)
+		sub, err := client.Subscribe(topicID, protocol, endpoint)
 		if err != nil {
 			fmt.Printf(notifyErrorFormat, err)
 			return
@@ -77,7 +80,8 @@ var publishCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		err := client.Publish(args[0], args[1])
+		topicID := resolveTopicID(args[0], client)
+		err := client.Publish(topicID, args[1])
 		if err != nil {
 			fmt.Printf(notifyErrorFormat, err)
 			return
@@ -96,4 +100,21 @@ func init() {
 	notifyCmd.AddCommand(listTopicsCmd)
 	notifyCmd.AddCommand(subscribeCmd)
 	notifyCmd.AddCommand(publishCmd)
+}
+
+// resolveTopicID resolves a topic ID or name to a full UUID.
+func resolveTopicID(idOrName string, client *sdk.Client) string {
+	if _, err := uuid.Parse(idOrName); err == nil {
+		return idOrName
+	}
+	topics, err := client.ListTopics()
+	if err != nil {
+		return idOrName
+	}
+	for _, t := range topics {
+		if t.Name == idOrName {
+			return t.ID
+		}
+	}
+	return idOrName
 }

--- a/cmd/cloud/notify_cli_test.go
+++ b/cmd/cloud/notify_cli_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/poyrazk/thecloud/pkg/sdk"
 )
 
 const (
@@ -74,5 +76,43 @@ func TestPublishCmd(t *testing.T) {
 	})
 	if !strings.Contains(out, "Message published") {
 		t.Fatalf("expected success output, got: %s", out)
+	}
+}
+
+func TestResolveTopicIDByName(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/notify/topics" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sdk.Response[[]sdk.Topic]{
+			Data: []sdk.Topic{
+				{ID: "uuid-789", Name: "alerts", ARN: "arn:cloud:notify:alerts"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	resolved := resolveTopicID("alerts", client)
+	if resolved != "uuid-789" {
+		t.Fatalf("expected uuid-789, got %s", resolved)
+	}
+}
+
+func TestResolveTopicIDByUUID(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // Should not be called
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	id := "abc123-def456"
+	resolved := resolveTopicID(id, client)
+	if resolved != id {
+		t.Fatalf("expected %s, got %s", id, resolved)
 	}
 }

--- a/cmd/cloud/sg.go
+++ b/cmd/cloud/sg.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/uuid"
 	"github.com/olekukonko/tablewriter"
 	"github.com/poyrazk/thecloud/pkg/sdk"
 	"github.com/spf13/cobra"
@@ -103,6 +104,7 @@ var sgAddRuleCmd = &cobra.Command{
 		priority, _ := cmd.Flags().GetInt("priority")
 
 		client := createClient(opts)
+		sgID := resolveSGID(args[0], client)
 		rule := sdk.SecurityRule{
 			Direction: direction,
 			Protocol:  protocol,
@@ -112,13 +114,13 @@ var sgAddRuleCmd = &cobra.Command{
 			Priority:  priority,
 		}
 
-		res, err := client.AddSecurityRule(args[0], rule)
+		res, err := client.AddSecurityRule(sgID, rule)
 		if err != nil {
 			fmt.Printf(errFmt, err)
 			return
 		}
 
-		fmt.Printf("[SUCCESS] Rule %s added successfully to security group %s\n", res.ID, args[0])
+		fmt.Printf("[SUCCESS] Rule %s added successfully to security group %s\n", res.ID, sgID)
 	},
 }
 
@@ -171,7 +173,8 @@ var sgGetCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		sg, err := client.GetSecurityGroup(args[0])
+		sgID := resolveSGID(args[0], client)
+		sg, err := client.GetSecurityGroup(sgID)
 		if err != nil {
 			fmt.Printf(errFmt, err)
 			return
@@ -216,7 +219,8 @@ var sgDeleteCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		if err := client.DeleteSecurityGroup(args[0]); err != nil {
+		sgID := resolveSGID(args[0], client)
+		if err := client.DeleteSecurityGroup(sgID); err != nil {
 			fmt.Printf(errFmt, err)
 			return
 		}
@@ -238,4 +242,21 @@ func init() {
 	sgAddRuleCmd.Flags().Int("priority", 100, "Priority")
 
 	sgCmd.AddCommand(sgCreateCmd, sgListCmd, sgGetCmd, sgDeleteCmd, sgAddRuleCmd, sgRemoveRuleCmd, sgAttachCmd, sgDetachCmd)
+}
+
+// resolveSGID resolves a security group ID or name to a full UUID.
+func resolveSGID(idOrName string, client *sdk.Client) string {
+	if _, err := uuid.Parse(idOrName); err == nil {
+		return idOrName
+	}
+	groups, err := client.ListSecurityGroups("")
+	if err != nil {
+		return idOrName
+	}
+	for _, g := range groups {
+		if g.Name == idOrName {
+			return g.ID
+		}
+	}
+	return idOrName
 }

--- a/cmd/cloud/sg_test.go
+++ b/cmd/cloud/sg_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/poyrazk/thecloud/pkg/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -43,5 +47,43 @@ func TestSGCommands(t *testing.T) {
 				t.Errorf("subcommand %q should have flag %q", cmdName, flag)
 			}
 		}
+	}
+}
+
+func TestResolveSGIDByName(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/security-groups" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sdk.Response[[]sdk.SecurityGroup]{
+			Data: []sdk.SecurityGroup{
+				{ID: "uuid-sg-1", Name: "my-sg", VPCID: "vpc-1", ARN: "arn:cloud:sg:1"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	resolved := resolveSGID("my-sg", client)
+	if resolved != "uuid-sg-1" {
+		t.Fatalf("expected uuid-sg-1, got %s", resolved)
+	}
+}
+
+func TestResolveSGIDByUUID(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // Should not be called
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	id := "abc123-def456"
+	resolved := resolveSGID(id, client)
+	if resolved != id {
+		t.Fatalf("expected %s, got %s", id, resolved)
 	}
 }

--- a/cmd/cloud/subnet.go
+++ b/cmd/cloud/subnet.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/google/uuid"
 	"github.com/olekukonko/tablewriter"
+	"github.com/poyrazk/thecloud/pkg/sdk"
 	"github.com/spf13/cobra"
 )
 
@@ -81,7 +83,7 @@ var subnetDeleteCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		subnetID := args[0]
+		subnetID := resolveSubnetID(args[0], client)
 
 		err := client.DeleteSubnet(subnetID)
 		if err != nil {
@@ -99,4 +101,21 @@ func init() {
 	subnetCmd.AddCommand(subnetListCmd)
 	subnetCmd.AddCommand(subnetCreateCmd)
 	subnetCmd.AddCommand(subnetDeleteCmd)
+}
+
+// resolveSubnetID resolves a subnet ID or name to a full UUID.
+func resolveSubnetID(idOrName string, client *sdk.Client) string {
+	if _, err := uuid.Parse(idOrName); err == nil {
+		return idOrName
+	}
+	subnets, err := client.ListSubnets("*")
+	if err != nil {
+		return idOrName
+	}
+	for _, s := range subnets {
+		if s.Name == idOrName {
+			return s.ID
+		}
+	}
+	return idOrName
 }

--- a/cmd/cloud/subnet_cli_test.go
+++ b/cmd/cloud/subnet_cli_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/poyrazk/thecloud/pkg/sdk"
 )
 
 const (
@@ -56,5 +58,43 @@ func TestSubnetListJSONOutput(t *testing.T) {
 	})
 	if !strings.Contains(out, subnetTestID) {
 		t.Fatalf("expected JSON output to include subnet id, got: %s", out)
+	}
+}
+
+func TestResolveSubnetIDByName(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vpcs/*/subnets" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(sdk.Response[[]sdk.Subnet]{
+			Data: []sdk.Subnet{
+				{ID: "uuid-subnet-1", Name: "app-subnet", VpcID: "vpc-1", CIDRBlock: "10.0.1.0/24"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	resolved := resolveSubnetID("app-subnet", client)
+	if resolved != "uuid-subnet-1" {
+		t.Fatalf("expected uuid-subnet-1, got %s", resolved)
+	}
+}
+
+func TestResolveSubnetIDByUUID(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound) // Should not be called
+	}))
+	defer server.Close()
+
+	client := sdk.NewClient(server.URL, "test-key")
+	id := "abc123-def456"
+	resolved := resolveSubnetID(id, client)
+	if resolved != id {
+		t.Fatalf("expected %s, got %s", id, resolved)
 	}
 }


### PR DESCRIPTION
## Summary
Add short ID/name resolution to CLI commands that were missing it.

Fixes #447
Fixes #445
Fixes #439
Fixes #433

## Changes

### cache.go
- Add `resolveCacheID` helper function
- Apply to: `cache show`, `cache rm`, `cache connection`, `cache stats`, `cache flush`

### subnet.go
- Add `resolveSubnetID` helper function
- Apply to: `subnet rm`

### sg.go
- Add `resolveSGID` helper function
- Apply to: `sg rm`, `sg add-rule`, `sg get`

### cron.go
- Add `resolveCronJobID` helper function
- Apply to: `cron rm`, `cron pause`, `cron resume`

### notify.go
- Add `resolveTopicID` helper function
- Apply to: `notify subscribe`, `notify publish`

## Verification
- [x] `go build ./cmd/cloud/...` passes
- [x] `go test ./cmd/cloud/...` passes