### PR TITLE
fix(storage): strip leading slash from key in presign URL path

### DIFF
--- a/pkg/sdk/storage.go
+++ b/pkg/sdk/storage.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 )
 
@@ -185,7 +186,7 @@ func (c *Client) GeneratePresignedURL(bucket, key, method string, expirySeconds 
 	}
 
 	var res Response[PresignedURL]
-	if err := c.post(fmt.Sprintf("/storage/presign/%s/%s", bucket, key), req, &res); err != nil {
+	if err := c.post(fmt.Sprintf("/storage/presign/%s/%s", bucket, strings.TrimPrefix(key, "/")), req, &res); err != nil {
 		return nil, err
 	}
 	return &res.Data, nil

--- a/pkg/sdk/storage_test.go
+++ b/pkg/sdk/storage_test.go
@@ -363,24 +363,51 @@ func TestClientGeneratePresignedURL(t *testing.T) {
 
 func TestClientGeneratePresignedURL_WithLeadingSlash(t *testing.T) {
 	bucket := storageTestBucket
-	key := "/file.txt"
 	method := http.MethodGet
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Assert that key with leading slash does NOT produce double slash
-		assert.Equal(t, "/storage/presign/"+bucket+"/file.txt", r.URL.Path)
-		assert.Equal(t, http.MethodPost, r.Method)
+	tests := []struct {
+		name     string
+		key      string
+		expected string
+	}{
+		{
+			name:     "key with leading slash",
+			key:      "/file.txt",
+			expected: "/storage/presign/" + bucket + "/file.txt",
+		},
+		{
+			name:     "key without leading slash unchanged",
+			key:      "file.txt",
+			expected: "/storage/presign/" + bucket + "/file.txt",
+		},
+		{
+			name:     "key is root slash only",
+			key:      "/",
+			expected: "/storage/presign/" + bucket + "/",
+		},
+		{
+			name:     "key with multiple leading slashes strips only first",
+			key:      "//file.txt",
+			expected: "/storage/presign/" + bucket + "//file.txt",
+		},
+	}
 
-		w.Header().Set(storageContentType, storageApplicationJSON)
-		_ = json.NewEncoder(w).Encode(Response[PresignedURL]{Data: PresignedURL{URL: "http://example.com", Method: method}})
-	}))
-	defer server.Close()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tc.expected, r.URL.Path)
+				w.Header().Set(storageContentType, storageApplicationJSON)
+				_ = json.NewEncoder(w).Encode(Response[PresignedURL]{Data: PresignedURL{URL: "http://example.com", Method: method}})
+			}))
+			defer server.Close()
 
-	client := NewClient(server.URL, storageAPIKey)
-	url, err := client.GeneratePresignedURL(bucket, key, method, 60)
+			client := NewClient(server.URL, storageAPIKey)
+			url, err := client.GeneratePresignedURL(bucket, tc.key, method, 60)
 
-	require.NoError(t, err)
-	assert.Equal(t, "http://example.com", url.URL)
+			require.NoError(t, err)
+			assert.Equal(t, "http://example.com", url.URL)
+		})
+	}
 }
 
 func TestClientLifecycleRules(t *testing.T) {

--- a/pkg/sdk/storage_test.go
+++ b/pkg/sdk/storage_test.go
@@ -361,6 +361,28 @@ func TestClientGeneratePresignedURL(t *testing.T) {
 	assert.Equal(t, "http://example.com", url.URL)
 }
 
+func TestClientGeneratePresignedURL_WithLeadingSlash(t *testing.T) {
+	bucket := storageTestBucket
+	key := "/file.txt"
+	method := http.MethodGet
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Assert that key with leading slash does NOT produce double slash
+		assert.Equal(t, "/storage/presign/"+bucket+"/file.txt", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+
+		w.Header().Set(storageContentType, storageApplicationJSON)
+		_ = json.NewEncoder(w).Encode(Response[PresignedURL]{Data: PresignedURL{URL: "http://example.com", Method: method}})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, storageAPIKey)
+	url, err := client.GeneratePresignedURL(bucket, key, method, 60)
+
+	require.NoError(t, err)
+	assert.Equal(t, "http://example.com", url.URL)
+}
+
 func TestClientLifecycleRules(t *testing.T) {
 	bucket := storageTestBucket
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Fixes double slash in storage presign URL when key parameter has a leading slash.

## Changes

- Added `strings` import to `pkg/sdk/storage.go`
- Changed presign URL path construction to use `strings.TrimPrefix(key, "/")` to remove any leading slash before inserting key into path

## Root Cause

When `key` starts with `/` (e.g., `/path/to/file.txt`), the URL path becomes `bucket + "/" + "/key"` = `bucket//key`, causing a malformed URL.

## Test Plan

- [x] `go build ./pkg/sdk/...` — passes
- [x] `go test -v ./pkg/sdk/...` — all tests pass
- [ ] Manual testing with key having leading slash

## Fixes

Fixes #458