### PR TITLE
fix: wrap container service errors with meaningful messages

### DIFF
--- a/internal/core/services/container.go
+++ b/internal/core/services/container.go
@@ -10,6 +10,7 @@ import (
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
 )
 
 // ContainerService manages deployments and their containers.
@@ -55,7 +56,7 @@ func (s *ContainerService) CreateDeployment(ctx context.Context, name, image str
 	}
 
 	if err := s.repo.CreateDeployment(ctx, dep); err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.Internal, "failed to create deployment", err)
 	}
 
 	if err := s.eventSvc.RecordEvent(ctx, "DEPLOYMENT_CREATED", dep.ID.String(), "DEPLOYMENT", nil); err != nil {
@@ -91,7 +92,12 @@ func (s *ContainerService) GetDeployment(ctx context.Context, id uuid.UUID) (*do
 		return nil, err
 	}
 
-	return s.repo.GetDeploymentByID(ctx, id, userID)
+	dep, err := s.repo.GetDeploymentByID(ctx, id, userID)
+	if err != nil {
+		return nil, errors.Wrap(errors.Internal, "failed to get deployment", err)
+	}
+
+	return dep, nil
 }
 
 func (s *ContainerService) ScaleDeployment(ctx context.Context, id uuid.UUID, replicas int) error {
@@ -104,13 +110,13 @@ func (s *ContainerService) ScaleDeployment(ctx context.Context, id uuid.UUID, re
 
 	dep, err := s.repo.GetDeploymentByID(ctx, id, userID)
 	if err != nil {
-		return err
+		return errors.Wrap(errors.Internal, "failed to get deployment", err)
 	}
 
 	dep.Replicas = replicas
 	dep.Status = domain.DeploymentStatusScaling
 	if err := s.repo.UpdateDeployment(ctx, dep); err != nil {
-		return err
+		return errors.Wrap(errors.Internal, "failed to update deployment", err)
 	}
 
 	if err := s.auditSvc.Log(ctx, userID, "container.deployment_scale", "deployment", id.String(), map[string]interface{}{
@@ -132,12 +138,12 @@ func (s *ContainerService) DeleteDeployment(ctx context.Context, id uuid.UUID) e
 
 	dep, err := s.repo.GetDeploymentByID(ctx, id, userID)
 	if err != nil {
-		return err
+		return errors.Wrap(errors.Internal, "failed to get deployment", err)
 	}
 
 	dep.Status = domain.DeploymentStatusDeleting
 	if err := s.repo.UpdateDeployment(ctx, dep); err != nil {
-		return err
+		return errors.Wrap(errors.Internal, "failed to update deployment", err)
 	}
 
 	if err := s.auditSvc.Log(ctx, userID, "container.deployment_delete", "deployment", id.String(), map[string]interface{}{}); err != nil {


### PR DESCRIPTION
## Summary
Wrap container service errors with proper `errors.Error` type to ensure meaningful error messages are returned instead of generic "An unexpected error occurred".

## Problem
When `container deploy` (or other container operations) fail, the API returns a raw database error that `httputil.Error()` doesn't recognize. It defaults to INTERNAL error with "An unexpected error occurred".

## Solution
Wrap repository errors with `errors.Wrap(errors.Internal, "meaningful context", err)` in the service layer, following the pattern from other services like `route_table.go`.

## Changes
`internal/core/services/container.go`:
- CreateDeployment: wrap `repo.CreateDeployment` error
- GetDeployment: wrap `repo.GetDeploymentByID` error
- ScaleDeployment: wrap `repo.GetDeploymentByID` and `repo.UpdateDeployment` errors
- DeleteDeployment: wrap `repo.GetDeploymentByID` and `repo.UpdateDeployment` errors

## Verification
- [x] `go build ./...` passes
- [ ] CI passes

Fixes #455