### PR TITLE
fix: add short ID resolution to SDK and CLI commands

### DIFF
--- a/cmd/cloud/autoscaling_cli_test.go
+++ b/cmd/cloud/autoscaling_cli_test.go
@@ -115,6 +115,28 @@ func TestASGListJSONOutput(t *testing.T) {
 func TestASGDeleteCmd(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		// Handle list request for ID resolution
+		if r.URL.Path == "/autoscaling/groups" && r.Method == http.MethodGet {
+			payload := map[string]interface{}{
+				"data": []map[string]interface{}{
+					{
+						"id":            asgTestID,
+						"name":          asgTestName,
+						"vpc_id":        "vpc-1",
+						"image":         "nginx:latest",
+						"min_instances": 1,
+						"max_instances": 3,
+						"desired_count": 2,
+						"current_count": 1,
+						"status":        "active",
+						"created_at":    time.Now().UTC().Format(time.RFC3339),
+					},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(payload)
+			return
+		}
+		// Handle delete request
 		if r.URL.Path != "/autoscaling/groups/"+asgTestID || r.Method != http.MethodDelete {
 			w.WriteHeader(http.StatusNotFound)
 			return

--- a/cmd/cloud/cli_commands_test.go
+++ b/cmd/cloud/cli_commands_test.go
@@ -155,7 +155,7 @@ func handleVolumes(w http.ResponseWriter, r *http.Request) bool {
 		resp := sdk.Response[sdk.Volume]{
 			Data: sdk.Volume{
 				ID:        volID,
-				Name:      "data", // Original mock returns "data" - keep for create test
+				Name:      "data",
 				SizeGB:    20,
 				Status:    "available",
 				CreatedAt: time.Now().UTC(),

--- a/cmd/cloud/cli_commands_test.go
+++ b/cmd/cloud/cli_commands_test.go
@@ -134,14 +134,14 @@ func handleVPCs(w http.ResponseWriter, r *http.Request) bool {
 }
 
 func handleVolumes(w http.ResponseWriter, r *http.Request) bool {
+	volID := uuid.New()
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/volumes":
-		volID := uuid.New()
 		resp := sdk.Response[[]sdk.Volume]{
 			Data: []sdk.Volume{
 				{
 					ID:        volID,
-					Name:      "data",
+					Name:      "vol-1", // Named "vol-1" so short ID resolution by name works
 					SizeGB:    20,
 					Status:    "available",
 					CreatedAt: time.Now().UTC(),
@@ -152,11 +152,10 @@ func handleVolumes(w http.ResponseWriter, r *http.Request) bool {
 		_ = json.NewEncoder(w).Encode(resp)
 		return true
 	case r.Method == http.MethodPost && r.URL.Path == "/volumes":
-		volID := uuid.New()
 		resp := sdk.Response[sdk.Volume]{
 			Data: sdk.Volume{
 				ID:        volID,
-				Name:      "data",
+				Name:      "data", // Original mock returns "data" - keep for create test
 				SizeGB:    20,
 				Status:    "available",
 				CreatedAt: time.Now().UTC(),
@@ -165,7 +164,8 @@ func handleVolumes(w http.ResponseWriter, r *http.Request) bool {
 		}
 		_ = json.NewEncoder(w).Encode(resp)
 		return true
-	case r.Method == http.MethodDelete && r.URL.Path == "/volumes/vol-1":
+	case r.Method == http.MethodDelete && strings.HasPrefix(r.URL.Path, "/volumes/"):
+		// Accept any volume ID prefix since resolveID may resolve short IDs to full UUID
 		return respondNoContent(w)
 	}
 	return false
@@ -491,7 +491,7 @@ func TestVolumeListCommandJSONOutput(t *testing.T) {
 	out := captureStdout(t, func() {
 		volumeListCmd.Run(volumeListCmd, nil)
 	})
-	if !strings.Contains(out, "\"name\": \"data\"") {
+	if !strings.Contains(out, "\"name\": \"vol-1\"") {
 		t.Fatalf("expected volume list output, got: %s", out)
 	}
 }

--- a/cmd/cloud/dns.go
+++ b/cmd/cloud/dns.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/olekukonko/tablewriter"
@@ -64,12 +65,30 @@ var dnsCreateZoneCmd = &cobra.Command{
 
 		var vpcID *uuid.UUID
 		if vpcStr != "" {
+			// Try to resolve as full UUID first
 			uid, err := uuid.Parse(vpcStr)
 			if err != nil {
-				fmt.Printf("Error: invalid vpc-id format: %v\n", err)
-				return
+				// Not a UUID, try to resolve by name or short ID
+				client := createClient(opts)
+				vpcs, err := client.ListVPCs()
+				if err == nil {
+					for _, vpc := range vpcs {
+						if vpc.Name == vpcStr || strings.HasPrefix(vpc.ID, vpcStr) {
+							uid, err := uuid.Parse(vpc.ID)
+							if err == nil {
+								vpcID = &uid
+								break
+							}
+						}
+					}
+				}
+				if vpcID == nil {
+					fmt.Printf("Error: invalid vpc-id format: %v\n", err)
+					return
+				}
+			} else {
+				vpcID = &uid
 			}
-			vpcID = &uid
 		}
 
 		client := createClient(opts)

--- a/pkg/sdk/autoscaling.go
+++ b/pkg/sdk/autoscaling.go
@@ -67,7 +67,11 @@ func (c *Client) ListScalingGroups() ([]ScalingGroup, error) {
 	return respData.Data, nil
 }
 
-func (c *Client) GetScalingGroup(id string) (*ScalingGroup, error) {
+func (c *Client) GetScalingGroup(idOrName string) (*ScalingGroup, error) {
+	id := c.resolveID("scaling-group", func() ([]interface{}, error) {
+		groups, err := c.ListScalingGroups()
+		return interfaceSlice(groups), err
+	}, func(v interface{}) string { return v.(ScalingGroup).ID }, func(v interface{}) string { return v.(ScalingGroup).Name }, idOrName)
 	var respData Response[ScalingGroup]
 	resp, err := c.resty.R().
 		SetResult(&respData).
@@ -82,7 +86,11 @@ func (c *Client) GetScalingGroup(id string) (*ScalingGroup, error) {
 	return &respData.Data, nil
 }
 
-func (c *Client) DeleteScalingGroup(id string) error {
+func (c *Client) DeleteScalingGroup(idOrName string) error {
+	id := c.resolveID("scaling-group", func() ([]interface{}, error) {
+		groups, err := c.ListScalingGroups()
+		return interfaceSlice(groups), err
+	}, func(v interface{}) string { return v.(ScalingGroup).ID }, func(v interface{}) string { return v.(ScalingGroup).Name }, idOrName)
 	resp, err := c.resty.R().Delete(c.apiURL + "/autoscaling/groups/" + id)
 	if err != nil {
 		return err

--- a/pkg/sdk/autoscaling.go
+++ b/pkg/sdk/autoscaling.go
@@ -68,10 +68,13 @@ func (c *Client) ListScalingGroups() ([]ScalingGroup, error) {
 }
 
 func (c *Client) GetScalingGroup(idOrName string) (*ScalingGroup, error) {
-	id := c.resolveID("scaling-group", func() ([]interface{}, error) {
+	id, err := c.resolveID("scaling-group", func() ([]interface{}, error) {
 		groups, err := c.ListScalingGroups()
 		return interfaceSlice(groups), err
 	}, func(v interface{}) string { return v.(ScalingGroup).ID }, func(v interface{}) string { return v.(ScalingGroup).Name }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	var respData Response[ScalingGroup]
 	resp, err := c.resty.R().
 		SetResult(&respData).
@@ -87,10 +90,13 @@ func (c *Client) GetScalingGroup(idOrName string) (*ScalingGroup, error) {
 }
 
 func (c *Client) DeleteScalingGroup(idOrName string) error {
-	id := c.resolveID("scaling-group", func() ([]interface{}, error) {
+	id, err := c.resolveID("scaling-group", func() ([]interface{}, error) {
 		groups, err := c.ListScalingGroups()
 		return interfaceSlice(groups), err
 	}, func(v interface{}) string { return v.(ScalingGroup).ID }, func(v interface{}) string { return v.(ScalingGroup).Name }, idOrName)
+	if err != nil {
+		return err
+	}
 	resp, err := c.resty.R().Delete(c.apiURL + "/autoscaling/groups/" + id)
 	if err != nil {
 		return err

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -179,33 +179,41 @@ func (c *Client) patchWithContext(ctx context.Context, path string, body interfa
 
 // resolveID resolves a partial ID or name to a full UUID.
 // It tries: (1) valid UUID, (2) exact name match, (3) ID prefix match.
-// Returns the resolved ID or original input if resolution fails.
-func (c *Client) resolveID(resourceType string, listFn func() ([]interface{}, error), getID func(interface{}) string, getName func(interface{}) string, idOrName string) string {
+// Returns the resolved ID or an error if not found or ambiguous.
+func (c *Client) resolveID(resourceType string, listFn func() ([]interface{}, error), getID func(interface{}) string, getName func(interface{}) string, idOrName string) (string, error) {
 	// If it's a valid UUID, use it directly
 	if _, err := uuid.Parse(idOrName); err == nil {
-		return idOrName
+		return idOrName, nil
 	}
 
 	// Try to resolve by name or prefix
 	items, err := listFn()
 	if err != nil {
-		return idOrName // fallback to original
+		return "", err
 	}
 
+	// Check for exact name match
 	for _, item := range items {
 		if getName(item) == idOrName {
-			return getID(item)
+			return getID(item), nil
 		}
 	}
 
-	// Try prefix match
+	// Try prefix match - track matches for ambiguity check
+	var matches []string
 	for _, item := range items {
 		if strings.HasPrefix(getID(item), idOrName) {
-			return getID(item)
+			matches = append(matches, getID(item))
 		}
 	}
 
-	return idOrName // fallback to original
+	if len(matches) == 0 {
+		return "", fmt.Errorf("%s not found: %s", resourceType, idOrName)
+	}
+	if len(matches) > 1 {
+		return "", fmt.Errorf("%s ambiguous: %s matches %d resources", resourceType, idOrName, len(matches))
+	}
+	return matches[0], nil
 }
 
 // interfaceSlice converts a slice of any type to []interface{}

--- a/pkg/sdk/client.go
+++ b/pkg/sdk/client.go
@@ -4,8 +4,10 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/google/uuid"
 )
 
 // Client is the API client for the platform.
@@ -173,4 +175,53 @@ func (c *Client) patchWithContext(ctx context.Context, path string, body interfa
 	}
 
 	return nil
+}
+
+// resolveID resolves a partial ID or name to a full UUID.
+// It tries: (1) valid UUID, (2) exact name match, (3) ID prefix match.
+// Returns the resolved ID or original input if resolution fails.
+func (c *Client) resolveID(resourceType string, listFn func() ([]interface{}, error), getID func(interface{}) string, getName func(interface{}) string, idOrName string) string {
+	// If it's a valid UUID, use it directly
+	if _, err := uuid.Parse(idOrName); err == nil {
+		return idOrName
+	}
+
+	// Try to resolve by name or prefix
+	items, err := listFn()
+	if err != nil {
+		return idOrName // fallback to original
+	}
+
+	for _, item := range items {
+		if getName(item) == idOrName {
+			return getID(item)
+		}
+	}
+
+	// Try prefix match
+	for _, item := range items {
+		if strings.HasPrefix(getID(item), idOrName) {
+			return getID(item)
+		}
+	}
+
+	return idOrName // fallback to original
+}
+
+// interfaceSlice converts a slice of any type to []interface{}
+func interfaceSlice[T any](slice []T) []interface{} {
+	result := make([]interface{}, len(slice))
+	for i, v := range slice {
+		result[i] = v
+	}
+	return result
+}
+
+// interfaceSlicePtr converts a slice of pointer type to []interface{}
+func interfaceSlicePtr[T any](slice []*T) []interface{} {
+	result := make([]interface{}, len(slice))
+	for i, v := range slice {
+		result[i] = v
+	}
+	return result
 }

--- a/pkg/sdk/client_test.go
+++ b/pkg/sdk/client_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -137,7 +138,7 @@ func TestResolveID_ValidUUID(t *testing.T) {
 		func(v interface{}) string { return v.(struct{ ID, Name string }).ID },
 		func(v interface{}) string { return v.(struct{ ID, Name string }).Name },
 		"abc123")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "abc123", id)
 }
 
@@ -150,7 +151,7 @@ func TestResolveID_NameMatch(t *testing.T) {
 		func(v interface{}) string { return v.(struct{ ID, Name string }).ID },
 		func(v interface{}) string { return v.(struct{ ID, Name string }).Name },
 		"test-name")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "abc123", id)
 }
 
@@ -163,8 +164,8 @@ func TestResolveID_NotFound(t *testing.T) {
 		func(v interface{}) string { return v.(struct{ ID, Name string }).ID },
 		func(v interface{}) string { return v.(struct{ ID, Name string }).Name },
 		"nonexistent")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "not found")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
 }
 
 func TestResolveID_Ambiguous(t *testing.T) {

--- a/pkg/sdk/client_test.go
+++ b/pkg/sdk/client_test.go
@@ -127,3 +127,65 @@ func TestClientPatchStatusError(t *testing.T) {
 	err := client.patch("/fail", map[string]string{"a": "b"}, &res)
 	assert.Error(t, err)
 }
+
+func TestResolveID_ValidUUID(t *testing.T) {
+	client := NewClient("http://localhost", clientTestAPIKey)
+	items := []interface{}{
+		struct{ ID, Name string }{"abc123", "test"},
+	}
+	id, err := client.resolveID("test", func() ([]interface{}, error) { return items, nil },
+		func(v interface{}) string { return v.(struct{ ID, Name string }).ID },
+		func(v interface{}) string { return v.(struct{ ID, Name string }).Name },
+		"abc123")
+	assert.NoError(t, err)
+	assert.Equal(t, "abc123", id)
+}
+
+func TestResolveID_NameMatch(t *testing.T) {
+	client := NewClient("http://localhost", clientTestAPIKey)
+	items := []interface{}{
+		struct{ ID, Name string }{"abc123", "test-name"},
+	}
+	id, err := client.resolveID("test", func() ([]interface{}, error) { return items, nil },
+		func(v interface{}) string { return v.(struct{ ID, Name string }).ID },
+		func(v interface{}) string { return v.(struct{ ID, Name string }).Name },
+		"test-name")
+	assert.NoError(t, err)
+	assert.Equal(t, "abc123", id)
+}
+
+func TestResolveID_NotFound(t *testing.T) {
+	client := NewClient("http://localhost", clientTestAPIKey)
+	items := []interface{}{
+		struct{ ID, Name string }{"abc123", "test"},
+	}
+	_, err := client.resolveID("test", func() ([]interface{}, error) { return items, nil },
+		func(v interface{}) string { return v.(struct{ ID, Name string }).ID },
+		func(v interface{}) string { return v.(struct{ ID, Name string }).Name },
+		"nonexistent")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestResolveID_Ambiguous(t *testing.T) {
+	client := NewClient("http://localhost", clientTestAPIKey)
+	items := []interface{}{
+		struct{ ID, Name string }{"abc123", "test-a"},
+		struct{ ID, Name string }{"abc456", "test-b"},
+	}
+	_, err := client.resolveID("test", func() ([]interface{}, error) { return items, nil },
+		func(v interface{}) string { return v.(struct{ ID, Name string }).ID },
+		func(v interface{}) string { return v.(struct{ ID, Name string }).Name },
+		"abc")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ambiguous")
+}
+
+func TestResolveID_ListError(t *testing.T) {
+	client := NewClient("http://localhost", clientTestAPIKey)
+	_, err := client.resolveID("test", func() ([]interface{}, error) { return nil, assert.AnError },
+		func(v interface{}) string { return "" },
+		func(v interface{}) string { return "" },
+		"abc")
+	assert.Error(t, err)
+}

--- a/pkg/sdk/client_test.go
+++ b/pkg/sdk/client_test.go
@@ -178,7 +178,7 @@ func TestResolveID_Ambiguous(t *testing.T) {
 		func(v interface{}) string { return v.(struct{ ID, Name string }).ID },
 		func(v interface{}) string { return v.(struct{ ID, Name string }).Name },
 		"abc")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ambiguous")
 }
 
@@ -188,5 +188,5 @@ func TestResolveID_ListError(t *testing.T) {
 		func(v interface{}) string { return "" },
 		func(v interface{}) string { return "" },
 		"abc")
-	assert.Error(t, err)
+	require.Error(t, err)
 }

--- a/pkg/sdk/function.go
+++ b/pkg/sdk/function.go
@@ -114,10 +114,13 @@ func (c *Client) UpdateFunction(id string, req *FunctionUpdateRequest) (*Functio
 }
 
 func (c *Client) InvokeFunction(idOrName string, payload []byte, async bool) (*Invocation, error) {
-	id := c.resolveID("function", func() ([]interface{}, error) {
+	id, err := c.resolveID("function", func() ([]interface{}, error) {
 		fns, err := c.ListFunctions()
 		return interfaceSlicePtr(fns), err
 	}, func(v interface{}) string { return v.(*Function).ID }, func(v interface{}) string { return v.(*Function).Name }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	url := functionsPath + id + "/invoke"
 	if async {
 		url += "?async=true"

--- a/pkg/sdk/function.go
+++ b/pkg/sdk/function.go
@@ -113,7 +113,11 @@ func (c *Client) UpdateFunction(id string, req *FunctionUpdateRequest) (*Functio
 	return &resp.Data, nil
 }
 
-func (c *Client) InvokeFunction(id string, payload []byte, async bool) (*Invocation, error) {
+func (c *Client) InvokeFunction(idOrName string, payload []byte, async bool) (*Invocation, error) {
+	id := c.resolveID("function", func() ([]interface{}, error) {
+		fns, err := c.ListFunctions()
+		return interfaceSlicePtr(fns), err
+	}, func(v interface{}) string { return v.(*Function).ID }, func(v interface{}) string { return v.(*Function).Name }, idOrName)
 	url := functionsPath + id + "/invoke"
 	if async {
 		url += "?async=true"

--- a/pkg/sdk/function_schedule.go
+++ b/pkg/sdk/function_schedule.go
@@ -84,7 +84,11 @@ func (c *Client) ListFunctionSchedules() ([]*FunctionSchedule, error) {
 	return resp.Data, nil
 }
 
-func (c *Client) GetFunctionSchedule(id string) (*FunctionSchedule, error) {
+func (c *Client) GetFunctionSchedule(idOrName string) (*FunctionSchedule, error) {
+	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+		schedules, err := c.ListFunctionSchedules()
+		return interfaceSlicePtr(schedules), err
+	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
 	var resp Response[FunctionSchedule]
 	if err := c.get(functionSchedulesPath+"/"+id, &resp); err != nil {
 		return nil, err
@@ -92,21 +96,37 @@ func (c *Client) GetFunctionSchedule(id string) (*FunctionSchedule, error) {
 	return &resp.Data, nil
 }
 
-func (c *Client) DeleteFunctionSchedule(id string) error {
+func (c *Client) DeleteFunctionSchedule(idOrName string) error {
+	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+		schedules, err := c.ListFunctionSchedules()
+		return interfaceSlicePtr(schedules), err
+	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
 	return c.delete(functionSchedulesPath+"/"+id, nil)
 }
 
-func (c *Client) PauseFunctionSchedule(id string) error {
+func (c *Client) PauseFunctionSchedule(idOrName string) error {
+	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+		schedules, err := c.ListFunctionSchedules()
+		return interfaceSlicePtr(schedules), err
+	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
 	var resp Response[any]
 	return c.post(functionSchedulesPath+"/"+id+"/pause", nil, &resp)
 }
 
-func (c *Client) ResumeFunctionSchedule(id string) error {
+func (c *Client) ResumeFunctionSchedule(idOrName string) error {
+	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+		schedules, err := c.ListFunctionSchedules()
+		return interfaceSlicePtr(schedules), err
+	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
 	var resp Response[any]
 	return c.post(functionSchedulesPath+"/"+id+"/resume", nil, &resp)
 }
 
-func (c *Client) GetFunctionScheduleRuns(id string) ([]*FunctionScheduleRun, error) {
+func (c *Client) GetFunctionScheduleRuns(idOrName string) ([]*FunctionScheduleRun, error) {
+	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+		schedules, err := c.ListFunctionSchedules()
+		return interfaceSlicePtr(schedules), err
+	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
 	var resp Response[[]*FunctionScheduleRun]
 	if err := c.get(functionSchedulesPath+"/"+id+"/runs", &resp); err != nil {
 		return nil, err

--- a/pkg/sdk/function_schedule.go
+++ b/pkg/sdk/function_schedule.go
@@ -85,10 +85,13 @@ func (c *Client) ListFunctionSchedules() ([]*FunctionSchedule, error) {
 }
 
 func (c *Client) GetFunctionSchedule(idOrName string) (*FunctionSchedule, error) {
-	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+	id, err := c.resolveID("function-schedule", func() ([]interface{}, error) {
 		schedules, err := c.ListFunctionSchedules()
 		return interfaceSlicePtr(schedules), err
 	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	var resp Response[FunctionSchedule]
 	if err := c.get(functionSchedulesPath+"/"+id, &resp); err != nil {
 		return nil, err
@@ -97,36 +100,48 @@ func (c *Client) GetFunctionSchedule(idOrName string) (*FunctionSchedule, error)
 }
 
 func (c *Client) DeleteFunctionSchedule(idOrName string) error {
-	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+	id, err := c.resolveID("function-schedule", func() ([]interface{}, error) {
 		schedules, err := c.ListFunctionSchedules()
 		return interfaceSlicePtr(schedules), err
 	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
+	if err != nil {
+		return err
+	}
 	return c.delete(functionSchedulesPath+"/"+id, nil)
 }
 
 func (c *Client) PauseFunctionSchedule(idOrName string) error {
-	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+	id, err := c.resolveID("function-schedule", func() ([]interface{}, error) {
 		schedules, err := c.ListFunctionSchedules()
 		return interfaceSlicePtr(schedules), err
 	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
+	if err != nil {
+		return err
+	}
 	var resp Response[any]
 	return c.post(functionSchedulesPath+"/"+id+"/pause", nil, &resp)
 }
 
 func (c *Client) ResumeFunctionSchedule(idOrName string) error {
-	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+	id, err := c.resolveID("function-schedule", func() ([]interface{}, error) {
 		schedules, err := c.ListFunctionSchedules()
 		return interfaceSlicePtr(schedules), err
 	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
+	if err != nil {
+		return err
+	}
 	var resp Response[any]
 	return c.post(functionSchedulesPath+"/"+id+"/resume", nil, &resp)
 }
 
 func (c *Client) GetFunctionScheduleRuns(idOrName string) ([]*FunctionScheduleRun, error) {
-	id := c.resolveID("function-schedule", func() ([]interface{}, error) {
+	id, err := c.resolveID("function-schedule", func() ([]interface{}, error) {
 		schedules, err := c.ListFunctionSchedules()
 		return interfaceSlicePtr(schedules), err
 	}, func(v interface{}) string { return v.(*FunctionSchedule).ID }, func(v interface{}) string { return v.(*FunctionSchedule).Name }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	var resp Response[[]*FunctionScheduleRun]
 	if err := c.get(functionSchedulesPath+"/"+id+"/runs", &resp); err != nil {
 		return nil, err

--- a/pkg/sdk/secret.go
+++ b/pkg/sdk/secret.go
@@ -44,13 +44,21 @@ func (c *Client) ListSecrets() ([]*Secret, error) {
 }
 
 func (c *Client) GetSecret(idOrName string) (*Secret, error) {
+	id := c.resolveID("secret", func() ([]interface{}, error) {
+		secrets, err := c.ListSecrets()
+		return interfaceSlicePtr(secrets), err
+	}, func(v interface{}) string { return v.(*Secret).ID }, func(v interface{}) string { return v.(*Secret).Name }, idOrName)
 	var resp Response[Secret]
-	if err := c.get("/secrets/"+idOrName, &resp); err != nil {
+	if err := c.get("/secrets/"+id, &resp); err != nil {
 		return nil, err
 	}
 	return &resp.Data, nil
 }
 
 func (c *Client) DeleteSecret(idOrName string) error {
-	return c.delete("/secrets/"+idOrName, nil)
+	id := c.resolveID("secret", func() ([]interface{}, error) {
+		secrets, err := c.ListSecrets()
+		return interfaceSlicePtr(secrets), err
+	}, func(v interface{}) string { return v.(*Secret).ID }, func(v interface{}) string { return v.(*Secret).Name }, idOrName)
+	return c.delete("/secrets/"+id, nil)
 }

--- a/pkg/sdk/secret.go
+++ b/pkg/sdk/secret.go
@@ -44,10 +44,13 @@ func (c *Client) ListSecrets() ([]*Secret, error) {
 }
 
 func (c *Client) GetSecret(idOrName string) (*Secret, error) {
-	id := c.resolveID("secret", func() ([]interface{}, error) {
+	id, err := c.resolveID("secret", func() ([]interface{}, error) {
 		secrets, err := c.ListSecrets()
 		return interfaceSlicePtr(secrets), err
 	}, func(v interface{}) string { return v.(*Secret).ID }, func(v interface{}) string { return v.(*Secret).Name }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	var resp Response[Secret]
 	if err := c.get("/secrets/"+id, &resp); err != nil {
 		return nil, err
@@ -56,9 +59,12 @@ func (c *Client) GetSecret(idOrName string) (*Secret, error) {
 }
 
 func (c *Client) DeleteSecret(idOrName string) error {
-	id := c.resolveID("secret", func() ([]interface{}, error) {
+	id, err := c.resolveID("secret", func() ([]interface{}, error) {
 		secrets, err := c.ListSecrets()
 		return interfaceSlicePtr(secrets), err
 	}, func(v interface{}) string { return v.(*Secret).ID }, func(v interface{}) string { return v.(*Secret).Name }, idOrName)
+	if err != nil {
+		return err
+	}
 	return c.delete("/secrets/"+id, nil)
 }

--- a/pkg/sdk/secret_test.go
+++ b/pkg/sdk/secret_test.go
@@ -88,6 +88,14 @@ func TestClientGetSecret(t *testing.T) {
 	expectedSecret := Secret{ID: secretTestID, Name: secretTestName}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle list request for ID resolution
+		if r.URL.Path == "/secrets" && r.Method == http.MethodGet {
+			w.Header().Set(secretTestContentType, secretTestAppJSON)
+			resp := Response[[]*Secret]{Data: []*Secret{{ID: secretTestID, Name: secretTestName}}}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// Handle get request
 		assert.Equal(t, "/secrets/"+secretTestID, r.URL.Path)
 		assert.Equal(t, http.MethodGet, r.Method)
 
@@ -108,6 +116,14 @@ func TestClientGetSecret(t *testing.T) {
 func TestClientDeleteSecret(t *testing.T) {
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Handle list request for ID resolution
+		if r.URL.Path == "/secrets" && r.Method == http.MethodGet {
+			w.Header().Set(secretTestContentType, secretTestAppJSON)
+			resp := Response[[]*Secret]{Data: []*Secret{{ID: secretTestID, Name: secretTestName}}}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+		// Handle delete request
 		assert.Equal(t, "/secrets/"+secretTestID, r.URL.Path)
 		assert.Equal(t, http.MethodDelete, r.Method)
 

--- a/pkg/sdk/snapshot.go
+++ b/pkg/sdk/snapshot.go
@@ -31,7 +31,11 @@ func (c *Client) ListSnapshots() ([]*domain.Snapshot, error) {
 	return res.Data, nil
 }
 
-func (c *Client) GetSnapshot(id string) (*domain.Snapshot, error) {
+func (c *Client) GetSnapshot(idOrName string) (*domain.Snapshot, error) {
+	id := c.resolveID("snapshot", func() ([]interface{}, error) {
+		snaps, err := c.ListSnapshots()
+		return interfaceSlice(snaps), err
+	}, func(v interface{}) string { return v.(*domain.Snapshot).ID.String() }, func(v interface{}) string { return v.(*domain.Snapshot).VolumeName }, idOrName)
 	var snapshot domain.Snapshot
 	err := c.get(fmt.Sprintf("/snapshots/%s", id), &snapshot)
 	if err != nil {
@@ -40,11 +44,19 @@ func (c *Client) GetSnapshot(id string) (*domain.Snapshot, error) {
 	return &snapshot, nil
 }
 
-func (c *Client) DeleteSnapshot(id string) error {
+func (c *Client) DeleteSnapshot(idOrName string) error {
+	id := c.resolveID("snapshot", func() ([]interface{}, error) {
+		snaps, err := c.ListSnapshots()
+		return interfaceSlice(snaps), err
+	}, func(v interface{}) string { return v.(*domain.Snapshot).ID.String() }, func(v interface{}) string { return v.(*domain.Snapshot).VolumeName }, idOrName)
 	return c.delete(fmt.Sprintf("/snapshots/%s", id), nil)
 }
 
-func (c *Client) RestoreSnapshot(id string, newVolumeName string) (*domain.Volume, error) {
+func (c *Client) RestoreSnapshot(idOrName string, newVolumeName string) (*domain.Volume, error) {
+	id := c.resolveID("snapshot", func() ([]interface{}, error) {
+		snaps, err := c.ListSnapshots()
+		return interfaceSlice(snaps), err
+	}, func(v interface{}) string { return v.(*domain.Snapshot).ID.String() }, func(v interface{}) string { return v.(*domain.Snapshot).VolumeName }, idOrName)
 	req := map[string]interface{}{
 		"new_volume_name": newVolumeName,
 	}

--- a/pkg/sdk/snapshot.go
+++ b/pkg/sdk/snapshot.go
@@ -32,12 +32,15 @@ func (c *Client) ListSnapshots() ([]*domain.Snapshot, error) {
 }
 
 func (c *Client) GetSnapshot(idOrName string) (*domain.Snapshot, error) {
-	id := c.resolveID("snapshot", func() ([]interface{}, error) {
+	id, err := c.resolveID("snapshot", func() ([]interface{}, error) {
 		snaps, err := c.ListSnapshots()
 		return interfaceSlice(snaps), err
 	}, func(v interface{}) string { return v.(*domain.Snapshot).ID.String() }, func(v interface{}) string { return v.(*domain.Snapshot).VolumeName }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	var snapshot domain.Snapshot
-	err := c.get(fmt.Sprintf("/snapshots/%s", id), &snapshot)
+	err = c.get(fmt.Sprintf("/snapshots/%s", id), &snapshot)
 	if err != nil {
 		return nil, err
 	}
@@ -45,24 +48,30 @@ func (c *Client) GetSnapshot(idOrName string) (*domain.Snapshot, error) {
 }
 
 func (c *Client) DeleteSnapshot(idOrName string) error {
-	id := c.resolveID("snapshot", func() ([]interface{}, error) {
+	id, err := c.resolveID("snapshot", func() ([]interface{}, error) {
 		snaps, err := c.ListSnapshots()
 		return interfaceSlice(snaps), err
 	}, func(v interface{}) string { return v.(*domain.Snapshot).ID.String() }, func(v interface{}) string { return v.(*domain.Snapshot).VolumeName }, idOrName)
+	if err != nil {
+		return err
+	}
 	return c.delete(fmt.Sprintf("/snapshots/%s", id), nil)
 }
 
 func (c *Client) RestoreSnapshot(idOrName string, newVolumeName string) (*domain.Volume, error) {
-	id := c.resolveID("snapshot", func() ([]interface{}, error) {
+	id, err := c.resolveID("snapshot", func() ([]interface{}, error) {
 		snaps, err := c.ListSnapshots()
 		return interfaceSlice(snaps), err
 	}, func(v interface{}) string { return v.(*domain.Snapshot).ID.String() }, func(v interface{}) string { return v.(*domain.Snapshot).VolumeName }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	req := map[string]interface{}{
 		"new_volume_name": newVolumeName,
 	}
 
 	var vol domain.Volume
-	err := c.post(fmt.Sprintf("/snapshots/%s/restore", id), req, &vol)
+	err = c.post(fmt.Sprintf("/snapshots/%s/restore", id), req, &vol)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sdk/volume.go
+++ b/pkg/sdk/volume.go
@@ -41,10 +41,13 @@ func (c *Client) CreateVolume(name string, sizeGB int) (*Volume, error) {
 }
 
 func (c *Client) GetVolume(idOrName string) (*Volume, error) {
-	id := c.resolveID("volume", func() ([]interface{}, error) {
+	id, err := c.resolveID("volume", func() ([]interface{}, error) {
 		vols, err := c.ListVolumes()
 		return interfaceSlice(vols), err
 	}, func(v interface{}) string { return v.(Volume).ID.String() }, func(v interface{}) string { return v.(Volume).Name }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	var res Response[Volume]
 	if err := c.get(fmt.Sprintf("/volumes/%s", id), &res); err != nil {
 		return nil, err
@@ -53,10 +56,13 @@ func (c *Client) GetVolume(idOrName string) (*Volume, error) {
 }
 
 func (c *Client) DeleteVolume(idOrName string) error {
-	id := c.resolveID("volume", func() ([]interface{}, error) {
+	id, err := c.resolveID("volume", func() ([]interface{}, error) {
 		vols, err := c.ListVolumes()
 		return interfaceSlice(vols), err
 	}, func(v interface{}) string { return v.(Volume).ID.String() }, func(v interface{}) string { return v.(Volume).Name }, idOrName)
+	if err != nil {
+		return err
+	}
 	return c.delete(fmt.Sprintf("/volumes/%s", id), nil)
 }
 

--- a/pkg/sdk/volume.go
+++ b/pkg/sdk/volume.go
@@ -41,15 +41,23 @@ func (c *Client) CreateVolume(name string, sizeGB int) (*Volume, error) {
 }
 
 func (c *Client) GetVolume(idOrName string) (*Volume, error) {
+	id := c.resolveID("volume", func() ([]interface{}, error) {
+		vols, err := c.ListVolumes()
+		return interfaceSlice(vols), err
+	}, func(v interface{}) string { return v.(Volume).ID.String() }, func(v interface{}) string { return v.(Volume).Name }, idOrName)
 	var res Response[Volume]
-	if err := c.get(fmt.Sprintf("/volumes/%s", idOrName), &res); err != nil {
+	if err := c.get(fmt.Sprintf("/volumes/%s", id), &res); err != nil {
 		return nil, err
 	}
 	return &res.Data, nil
 }
 
 func (c *Client) DeleteVolume(idOrName string) error {
-	return c.delete(fmt.Sprintf("/volumes/%s", idOrName), nil)
+	id := c.resolveID("volume", func() ([]interface{}, error) {
+		vols, err := c.ListVolumes()
+		return interfaceSlice(vols), err
+	}, func(v interface{}) string { return v.(Volume).ID.String() }, func(v interface{}) string { return v.(Volume).Name }, idOrName)
+	return c.delete(fmt.Sprintf("/volumes/%s", id), nil)
 }
 
 func (c *Client) AttachVolume(volumeID, instanceID, mountPath string) (string, error) {

--- a/pkg/sdk/vpc_peering.go
+++ b/pkg/sdk/vpc_peering.go
@@ -41,11 +41,15 @@ func (c *Client) ListVPCPeerings() ([]VPCPeering, error) {
 }
 
 // GetVPCPeering retrieves details of a specific VPC peering connection.
+// Note: VPC Peering resources don't have a Name field, so getName returns ID (matching by ID prefix only).
 func (c *Client) GetVPCPeering(idOrName string) (*VPCPeering, error) {
-	id := c.resolveID("vpc-peering", func() ([]interface{}, error) {
+	id, err := c.resolveID("vpc-peering", func() ([]interface{}, error) {
 		peerings, err := c.ListVPCPeerings()
 		return interfaceSlice(peerings), err
 	}, func(v interface{}) string { return v.(VPCPeering).ID }, func(v interface{}) string { return v.(VPCPeering).ID }, idOrName)
+	if err != nil {
+		return nil, err
+	}
 	var res Response[VPCPeering]
 	if err := c.get(fmt.Sprintf("/vpc-peerings/%s", id), &res); err != nil {
 		return nil, err

--- a/pkg/sdk/vpc_peering.go
+++ b/pkg/sdk/vpc_peering.go
@@ -41,7 +41,11 @@ func (c *Client) ListVPCPeerings() ([]VPCPeering, error) {
 }
 
 // GetVPCPeering retrieves details of a specific VPC peering connection.
-func (c *Client) GetVPCPeering(id string) (*VPCPeering, error) {
+func (c *Client) GetVPCPeering(idOrName string) (*VPCPeering, error) {
+	id := c.resolveID("vpc-peering", func() ([]interface{}, error) {
+		peerings, err := c.ListVPCPeerings()
+		return interfaceSlice(peerings), err
+	}, func(v interface{}) string { return v.(VPCPeering).ID }, func(v interface{}) string { return v.(VPCPeering).ID }, idOrName)
 	var res Response[VPCPeering]
 	if err := c.get(fmt.Sprintf("/vpc-peerings/%s", id), &res); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Add `resolveID()` helper in `pkg/sdk/client.go` that resolves partial IDs or names to full UUIDs
- Update SDK methods to use `idOrName` parameter: GetVolume, DeleteVolume, GetSnapshot, DeleteSnapshot, RestoreSnapshot, GetSecret, DeleteSecret, InvokeFunction, GetFunctionSchedule, DeleteFunctionSchedule, PauseFunctionSchedule, ResumeFunctionSchedule, GetFunctionScheduleRuns, GetScalingGroup, DeleteScalingGroup, GetVPCPeering
- Add VPC ID resolution to `dns create-zone --vpc-id` in CLI

Fixes #476, #475, #474, #473, #471, #470, #469, #461, #457, #453

## Resolution Pattern
The `resolveID` helper tries in order:
1. Valid UUID - use directly
2. Exact name match - resolve to ID
3. ID prefix match - resolve to full ID

## Testing
- `go test ./pkg/sdk/...` ✅
- `go test ./cmd/cloud/...` ✅
- Build verified ✅