### PR TITLE
fix(repos/postgres): return empty slice instead of nil when no databases found

### DIFF
--- a/internal/repositories/postgres/database_repo.go
+++ b/internal/repositories/postgres/database_repo.go
@@ -98,7 +98,7 @@ func (r *DatabaseRepository) scanDatabase(row pgx.Row) (*domain.Database, error)
 
 func (r *DatabaseRepository) scanDatabases(rows pgx.Rows) ([]*domain.Database, error) {
 	defer rows.Close()
-	var databases []*domain.Database
+	databases := make([]*domain.Database, 0)
 	for rows.Next() {
 		db, err := r.scanDatabase(rows)
 		if err != nil {

--- a/internal/repositories/postgres/database_repo.go
+++ b/internal/repositories/postgres/database_repo.go
@@ -106,6 +106,9 @@ func (r *DatabaseRepository) scanDatabases(rows pgx.Rows) ([]*domain.Database, e
 		}
 		databases = append(databases, db)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 	return databases, nil
 }
 

--- a/internal/repositories/postgres/database_repo_unit_test.go
+++ b/internal/repositories/postgres/database_repo_unit_test.go
@@ -191,3 +191,64 @@ func TestDatabaseRepository_Delete(t *testing.T) {
 	err = repo.Delete(ctx, id)
 	require.NoError(t, err)
 }
+
+func TestDatabaseRepository_List_Empty(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDatabaseRepository(mock)
+	tenantID := uuid.New()
+	ctx := appcontext.WithTenantID(context.Background(), tenantID)
+
+	cols := []string{"id", "user_id", "tenant_id", "name", "engine", "version",
+		"status", "role", "primary_id", "vpc_id", "container_id", "port",
+		"username", "password", "created_at", "updated_at", "allocated_storage",
+		"parameters", "metrics_enabled", "metrics_port", "exporter_container_id",
+		"pooling_enabled", "pooling_port", "pooler_container_id", "credential_path"}
+
+	// Return empty rows (no AddRow calls) - verifies slice is non-nil
+	mock.ExpectQuery("SELECT .* FROM databases").
+		WithArgs(tenantID).
+		WillReturnRows(pgxmock.NewRows(cols))
+
+	databases, err := repo.List(ctx)
+	require.NoError(t, err)
+
+	// Key assertions: non-nil empty slice (not nil, which marshals as null)
+	assert.NotNil(t, databases)
+	assert.Empty(t, databases)
+	assert.Equal(t, []*domain.Database{}, databases)
+}
+
+func TestDatabaseRepository_ListReplicas_Empty(t *testing.T) {
+	t.Parallel()
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewDatabaseRepository(mock)
+	primaryID := uuid.New()
+	tenantID := uuid.New()
+	ctx := appcontext.WithTenantID(context.Background(), tenantID)
+
+	cols := []string{"id", "user_id", "tenant_id", "name", "engine", "version",
+		"status", "role", "primary_id", "vpc_id", "container_id", "port",
+		"username", "password", "created_at", "updated_at", "allocated_storage",
+		"parameters", "metrics_enabled", "metrics_port", "exporter_container_id",
+		"pooling_enabled", "pooling_port", "pooler_container_id", "credential_path"}
+
+	// Return empty rows (no AddRow calls) - verifies slice is non-nil
+	mock.ExpectQuery("SELECT .* FROM databases WHERE primary_id = .*").
+		WithArgs(primaryID, tenantID).
+		WillReturnRows(pgxmock.NewRows(cols))
+
+	replicas, err := repo.ListReplicas(ctx, primaryID)
+	require.NoError(t, err)
+
+	// Key assertions: non-nil empty slice (not nil, which marshals as null)
+	assert.NotNil(t, replicas)
+	assert.Empty(t, replicas)
+	assert.Equal(t, []*domain.Database{}, replicas)
+}

--- a/internal/repositories/postgres/database_repo_unit_test.go
+++ b/internal/repositories/postgres/database_repo_unit_test.go
@@ -194,13 +194,6 @@ func TestDatabaseRepository_Delete(t *testing.T) {
 
 func TestDatabaseRepository_List_Empty(t *testing.T) {
 	t.Parallel()
-	mock, err := pgxmock.NewPool()
-	require.NoError(t, err)
-	defer mock.Close()
-
-	repo := NewDatabaseRepository(mock)
-	tenantID := uuid.New()
-	ctx := appcontext.WithTenantID(context.Background(), tenantID)
 
 	cols := []string{"id", "user_id", "tenant_id", "name", "engine", "version",
 		"status", "role", "primary_id", "vpc_id", "container_id", "port",
@@ -208,47 +201,52 @@ func TestDatabaseRepository_List_Empty(t *testing.T) {
 		"parameters", "metrics_enabled", "metrics_port", "exporter_container_id",
 		"pooling_enabled", "pooling_port", "pooler_container_id", "credential_path"}
 
-	// Return empty rows (no AddRow calls) - verifies slice is non-nil
-	mock.ExpectQuery("SELECT .* FROM databases").
-		WithArgs(tenantID).
-		WillReturnRows(pgxmock.NewRows(cols))
+	tests := []struct {
+		name string
+		call func(*DatabaseRepository, context.Context, uuid.UUID, uuid.UUID) ([]*domain.Database, error)
+	}{
+		{
+			name: "List returns empty non-nil slice",
+			call: func(repo *DatabaseRepository, ctx context.Context, tenantID uuid.UUID, _ uuid.UUID) ([]*domain.Database, error) {
+				return repo.List(ctx)
+			},
+		},
+		{
+			name: "ListReplicas returns empty non-nil slice",
+			call: func(repo *DatabaseRepository, ctx context.Context, _ uuid.UUID, primaryID uuid.UUID) ([]*domain.Database, error) {
+				return repo.ListReplicas(ctx, primaryID)
+			},
+		},
+	}
 
-	databases, err := repo.List(ctx)
-	require.NoError(t, err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			mock, err := pgxmock.NewPool()
+			require.NoError(t, err)
+			defer mock.Close()
 
-	// Key assertions: non-nil empty slice (not nil, which marshals as null)
-	assert.NotNil(t, databases)
-	assert.Empty(t, databases)
-	assert.Equal(t, []*domain.Database{}, databases)
-}
+			repo := NewDatabaseRepository(mock)
+			tenantID := uuid.New()
+			primaryID := uuid.New()
+			ctx := appcontext.WithTenantID(context.Background(), tenantID)
 
-func TestDatabaseRepository_ListReplicas_Empty(t *testing.T) {
-	t.Parallel()
-	mock, err := pgxmock.NewPool()
-	require.NoError(t, err)
-	defer mock.Close()
+			query := "SELECT .* FROM databases"
 
-	repo := NewDatabaseRepository(mock)
-	primaryID := uuid.New()
-	tenantID := uuid.New()
-	ctx := appcontext.WithTenantID(context.Background(), tenantID)
+			if tc.name == "List returns empty non-nil slice" {
+				mock.ExpectQuery(query).WithArgs(tenantID).WillReturnRows(pgxmock.NewRows(cols))
+			} else {
+				mock.ExpectQuery("SELECT .* FROM databases WHERE primary_id = .*").WithArgs(primaryID, tenantID).WillReturnRows(pgxmock.NewRows(cols))
+			}
 
-	cols := []string{"id", "user_id", "tenant_id", "name", "engine", "version",
-		"status", "role", "primary_id", "vpc_id", "container_id", "port",
-		"username", "password", "created_at", "updated_at", "allocated_storage",
-		"parameters", "metrics_enabled", "metrics_port", "exporter_container_id",
-		"pooling_enabled", "pooling_port", "pooler_container_id", "credential_path"}
+			result, err := tc.call(repo, ctx, tenantID, primaryID)
+			require.NoError(t, err)
 
-	// Return empty rows (no AddRow calls) - verifies slice is non-nil
-	mock.ExpectQuery("SELECT .* FROM databases WHERE primary_id = .*").
-		WithArgs(primaryID, tenantID).
-		WillReturnRows(pgxmock.NewRows(cols))
+			assert.NotNil(t, result)
+			assert.Empty(t, result)
+			assert.Equal(t, []*domain.Database{}, result)
 
-	replicas, err := repo.ListReplicas(ctx, primaryID)
-	require.NoError(t, err)
-
-	// Key assertions: non-nil empty slice (not nil, which marshals as null)
-	assert.NotNil(t, replicas)
-	assert.Empty(t, replicas)
-	assert.Equal(t, []*domain.Database{}, replicas)
+			require.NoError(t, mock.ExpectationsWereMet())
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Fixes `cloud db list` returning `null` in JSON mode when no databases exist, instead of `[]`.

## Changes

Changed `scanDatabases` in `internal/repositories/postgres/database_repo.go` to initialize the slice with `make()` instead of `var`:

```go
// Before: var databases []*domain.Database  // nil when no rows
// After:  databases := make([]*domain.Database, 0)  // [] when no rows
```

## Root Cause

When Go's `encoding/json` marshals a `nil` slice, it produces `null`. An empty initialized slice produces `[]`.

## Test Plan

- [x] `go build ./internal/repositories/postgres/...` — passes
- [x] `go test -v ./internal/repositories/postgres/...` — all tests pass

## Fixes

Fixes #459

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * List operations now return a non-nil empty collection when no databases are found, preventing null responses and improving client handling.

* **Tests**
  * Added unit tests confirming list operations return an empty (non-nil) collection for no-result cases to prevent regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/486)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->