### PR TITLE
fix: libvirt instance rm error message (#435)

### DIFF
--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -1219,8 +1219,8 @@ func (s *InstanceService) removeInstanceContainer(ctx context.Context, inst *dom
 	}
 
 	if err := s.compute.DeleteInstance(ctx, containerID); err != nil {
-		s.logger.Warn("failed to remove docker container", "container_id", containerID, "error", err)
-		return errors.Wrap(errors.Internal, "failed to remove container", err)
+		s.logger.Warn("failed to remove instance", "backend", s.compute.Type(), "id", containerID, "error", err)
+		return errors.Wrap(errors.Internal, fmt.Sprintf("failed to remove %s instance", s.compute.Type()), err)
 	}
 
 	s.logger.Info("instance terminated", "instance_id", inst.ID)

--- a/internal/core/services/instance_unit_test.go
+++ b/internal/core/services/instance_unit_test.go
@@ -823,7 +823,7 @@ func testInstanceServiceTerminateUnit(t *testing.T) {
 
 		err := svc.TerminateInstance(ctx, instanceID.String())
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to remove container")
+		assert.Contains(t, err.Error(), "failed to remove docker instance")
 		mock.AssertExpectationsForObjects(t, repo, rbacSvc, compute)
 	})
 


### PR DESCRIPTION
## Summary
- Make `removeInstanceContainer` error messages backend-agnostic using `s.compute.Type()` instead of hardcoded "container"
- Follows the same pattern applied to `StopInstance` in PR #484 (issue #430)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/core/services/... -run "Terminate"` passes

---

Fixes #435