### PR TITLE
Fix storage bugs (#424, #460, #416)

### DIFF
--- a/internal/core/services/storage.go
+++ b/internal/core/services/storage.go
@@ -178,7 +178,7 @@ func (s *StorageService) Upload(ctx context.Context, bucketName, key string, r i
 		return nil, err
 	}
 
-	versionID := "null" // Default version ID when versioning is disabled
+	versionID := "" // Default version ID when versioning is disabled
 	if bucket.VersioningEnabled {
 		versionID = generateVersionID()
 	}
@@ -325,7 +325,7 @@ func (s *StorageService) Download(ctx context.Context, bucket, key string) (io.R
 
 	// 2. Open file
 	storeKey := key
-	if obj.VersionID != "null" {
+	if obj.VersionID != "" {
 		storeKey = versionedStoreKey(key, obj.VersionID)
 	}
 
@@ -394,7 +394,7 @@ func (s *StorageService) DownloadVersion(ctx context.Context, bucket, key, versi
 
 	// 2. Open file
 	storeKey := key
-	if obj.VersionID != "null" {
+	if obj.VersionID != "" {
 		storeKey = versionedStoreKey(key, obj.VersionID)
 	}
 
@@ -625,7 +625,7 @@ func (s *StorageService) CleanupDeleted(ctx context.Context, limit int) (int, er
 	deletedCount := 0
 	for _, obj := range deleted {
 		storeKey := obj.Key
-		if obj.VersionID != "null" {
+		if obj.VersionID != "" {
 			storeKey = versionedStoreKey(obj.Key, obj.VersionID)
 		}
 
@@ -653,7 +653,7 @@ func (s *StorageService) CleanupPendingUploads(ctx context.Context, olderThan ti
 	cleanedCount := 0
 	for _, obj := range pending {
 		storeKey := obj.Key
-		if obj.VersionID != "null" {
+		if obj.VersionID != "" {
 			storeKey = versionedStoreKey(obj.Key, obj.VersionID)
 		}
 

--- a/internal/core/services/storage.go
+++ b/internal/core/services/storage.go
@@ -432,7 +432,7 @@ func (s *StorageService) DeleteVersion(ctx context.Context, bucket, key, version
 
 	// 2. Delete from store
 	storeKey := key
-	if versionID != "null" {
+	if versionID != "" {
 		storeKey = versionedStoreKey(key, versionID)
 	}
 

--- a/internal/core/services/storage_unit_test.go
+++ b/internal/core/services/storage_unit_test.go
@@ -178,7 +178,7 @@ func TestStorageServiceUnit(t *testing.T) {
 	})
 
 	t.Run("Download", func(t *testing.T) {
-		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: "null", SizeBytes: 12}
+		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: "", SizeBytes: 12}
 		mockRepo.On("GetMeta", mock.Anything, "my-bucket", "test.txt").Return(obj, nil).Once()
 		mockStore.On("Read", mock.Anything, "my-bucket", "test.txt").Return(io.NopCloser(strings.NewReader("hello world!")), nil).Once()
 		mockRepo.On("GetBucket", mock.Anything, "my-bucket").Return(&domain.Bucket{Name: "my-bucket"}, nil).Once()
@@ -196,7 +196,7 @@ func TestStorageServiceUnit(t *testing.T) {
 	})
 
 	t.Run("Download Bucket Lookup Failure Closes Reader", func(t *testing.T) {
-		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: "null"}
+		obj := &domain.Object{Bucket: "my-bucket", Key: "test.txt", VersionID: ""}
 		reader := &trackingReadCloser{Reader: strings.NewReader("hello world!")}
 		mockRepo.On("GetMeta", mock.Anything, "my-bucket", "test.txt").Return(obj, nil).Once()
 		mockStore.On("Read", mock.Anything, "my-bucket", "test.txt").Return(reader, nil).Once()
@@ -281,10 +281,10 @@ func TestStorageServiceUnit(t *testing.T) {
 	})
 
 	t.Run("CleanupDeleted", func(t *testing.T) {
-		deleted := []*domain.Object{{Bucket: "b1", Key: "k1", VersionID: "null"}}
+		deleted := []*domain.Object{{Bucket: "b1", Key: "k1", VersionID: ""}}
 		mockRepo.On("ListDeleted", mock.Anything, 10).Return(deleted, nil).Once()
 		mockStore.On("Delete", mock.Anything, "b1", "k1").Return(nil).Once()
-		mockRepo.On("HardDelete", mock.Anything, "b1", "k1", "null").Return(nil).Once()
+		mockRepo.On("HardDelete", mock.Anything, "b1", "k1", "").Return(nil).Once()
 
 		count, err := svc.CleanupDeleted(ctx, 10)
 		require.NoError(t, err)
@@ -294,10 +294,10 @@ func TestStorageServiceUnit(t *testing.T) {
 	})
 
 	t.Run("CleanupPendingUploads", func(t *testing.T) {
-		pending := []*domain.Object{{Bucket: "b1", Key: "k1", VersionID: "null"}}
+		pending := []*domain.Object{{Bucket: "b1", Key: "k1", VersionID: ""}}
 		mockRepo.On("ListPending", mock.Anything, mock.Anything, 10).Return(pending, nil).Once()
 		mockStore.On("Delete", mock.Anything, "b1", "k1").Return(nil).Once()
-		mockRepo.On("HardDelete", mock.Anything, "b1", "k1", "null").Return(nil).Once()
+		mockRepo.On("HardDelete", mock.Anything, "b1", "k1", "").Return(nil).Once()
 
 		count, err := svc.CleanupPendingUploads(ctx, time.Hour, 10)
 		require.NoError(t, err)
@@ -421,10 +421,10 @@ func TestStorageServiceUnit(t *testing.T) {
 	t.Run("CleanupDeleted_HardDeleteError", func(t *testing.T) {
 		mockRepo.ExpectedCalls = nil
 		mockStore.ExpectedCalls = nil
-		deleted := []*domain.Object{{Bucket: "b", Key: "k", VersionID: "null"}}
+		deleted := []*domain.Object{{Bucket: "b", Key: "k", VersionID: ""}}
 		mockRepo.On("ListDeleted", mock.Anything, 10).Return(deleted, nil).Once()
 		mockStore.On("Delete", mock.Anything, "b", "k").Return(nil).Once()
-		mockRepo.On("HardDelete", mock.Anything, "b", "k", "null").Return(fmt.Errorf("hard delete failed")).Once()
+		mockRepo.On("HardDelete", mock.Anything, "b", "k", "").Return(fmt.Errorf("hard delete failed")).Once()
 		_, err := svc.CleanupDeleted(ctx, 10)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "hard delete failed")
@@ -592,7 +592,7 @@ func TestStorageServiceUnit(t *testing.T) {
 		mockRepo.ExpectedCalls = nil
 		mockStore.ExpectedCalls = nil
 
-		mockRepo.On("GetMeta", mock.Anything, "b", "k").Return(&domain.Object{Bucket: "b", Key: "k", VersionID: "null"}, nil).Once()
+		mockRepo.On("GetMeta", mock.Anything, "b", "k").Return(&domain.Object{Bucket: "b", Key: "k", VersionID: ""}, nil).Once()
 		mockStore.On("Read", mock.Anything, "b", "k").Return(io.NopCloser(strings.NewReader("data")), nil).Once()
 		mockRepo.On("GetBucket", mock.Anything, "b").Return(nil, fmt.Errorf("bucket error")).Once()
 		_, _, err := svc.Download(ctx, "b", "k")

--- a/internal/handlers/storage_handler.go
+++ b/internal/handlers/storage_handler.go
@@ -641,6 +641,8 @@ func (h *StorageHandler) ListVersions(c *gin.Context) {
 	if !ok {
 		return
 	}
+	// Normalize key to basename for consistency with Upload
+	key = path.Base(key)
 
 	versions, err := h.svc.ListVersions(c.Request.Context(), bucket, key)
 	if err != nil {

--- a/internal/handlers/storage_handler.go
+++ b/internal/handlers/storage_handler.go
@@ -134,10 +134,14 @@ func (h *StorageHandler) Upload(c *gin.Context) {
 		return
 	}
 
+	// Use only the filename (last path segment) as the object key, not the full path.
+	// This mirrors contentDispositionAttachment which already uses path.Base for the same reason.
+	objectKey := path.Base(key)
+
 	providedChecksum := c.GetHeader(headerContentSha256)
 
 	// Read from request body (stream)
-	obj, err := h.svc.Upload(c.Request.Context(), bucket, key, io.LimitReader(c.Request.Body, maxUploadSize), providedChecksum)
+	obj, err := h.svc.Upload(c.Request.Context(), bucket, objectKey, io.LimitReader(c.Request.Body, maxUploadSize), providedChecksum)
 	if err != nil {
 		httputil.Error(c, err)
 		return

--- a/internal/handlers/storage_handler.go
+++ b/internal/handlers/storage_handler.go
@@ -166,6 +166,8 @@ func (h *StorageHandler) Download(c *gin.Context) {
 	if !ok {
 		return
 	}
+	// Normalize key to basename for consistency with Upload
+	key = path.Base(key)
 	versionID := c.Query("versionId")
 
 	var reader io.ReadCloser
@@ -234,6 +236,8 @@ func (h *StorageHandler) Delete(c *gin.Context) {
 	if !ok {
 		return
 	}
+	// Normalize key to basename for consistency with Upload
+	key = path.Base(key)
 	versionID := c.Query("versionId")
 
 	var err error

--- a/internal/handlers/storage_handler_errors_test.go
+++ b/internal/handlers/storage_handler_errors_test.go
@@ -36,7 +36,7 @@ func TestStorageHandlerErrors(t *testing.T) { //nolint:gocyclo
 			method: http.MethodPut,
 			path:   "/storage/b1/key1",
 			setupMock: func(m *mockStorageService) {
-				m.On("Upload", mock.Anything, "b1", "/key1", mock.Anything, "").
+				m.On("Upload", mock.Anything, "b1", "key1", mock.Anything, "").
 					Return(nil, internalerrors.New(internalerrors.Internal, "upload failed"))
 			},
 			checkCode: http.StatusInternalServerError,
@@ -46,7 +46,7 @@ func TestStorageHandlerErrors(t *testing.T) { //nolint:gocyclo
 			method: http.MethodGet,
 			path:   "/storage/b1/key1",
 			setupMock: func(m *mockStorageService) {
-				m.On("Download", mock.Anything, "b1", "/key1").
+				m.On("Download", mock.Anything, "b1", "key1").
 					Return(nil, nil, internalerrors.New(internalerrors.Internal, "download failed"))
 			},
 			checkCode: http.StatusInternalServerError,
@@ -199,7 +199,7 @@ func TestStorageHandlerErrors(t *testing.T) { //nolint:gocyclo
 			method: http.MethodGet,
 			path:   "/storage/versions/b1/key1",
 			setupMock: func(m *mockStorageService) {
-				m.On("ListVersions", mock.Anything, "b1", "/key1").
+				m.On("ListVersions", mock.Anything, "b1", "key1").
 					Return(nil, internalerrors.New(internalerrors.Internal, "list versions failed"))
 			},
 			checkCode: http.StatusInternalServerError,

--- a/internal/handlers/storage_handler_test.go
+++ b/internal/handlers/storage_handler_test.go
@@ -258,7 +258,7 @@ func TestStorageHandlerUpload(t *testing.T) {
 
 	t.Run("Success without Checksum", func(t *testing.T) {
 		obj := &domain.Object{Key: testTxtKey}
-		mockSvc.On("Upload", mock.Anything, "b1", testTxtPath, mock.Anything, "").Return(obj, nil).Once()
+		mockSvc.On("Upload", mock.Anything, "b1", testTxtKey, mock.Anything, "").Return(obj, nil).Once()
 
 		req := httptest.NewRequest(http.MethodPut, testTxtFullURL, strings.NewReader("hello"))
 		w := httptest.NewRecorder()
@@ -269,7 +269,7 @@ func TestStorageHandlerUpload(t *testing.T) {
 	t.Run("Success with Checksum", func(t *testing.T) {
 		checksum := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 		obj := &domain.Object{Key: testTxtKey, Checksum: checksum}
-		mockSvc.On("Upload", mock.Anything, "b1", testTxtPath, mock.Anything, checksum).Return(obj, nil).Once()
+		mockSvc.On("Upload", mock.Anything, "b1", testTxtKey, mock.Anything, checksum).Return(obj, nil).Once()
 
 		req := httptest.NewRequest(http.MethodPut, testTxtFullURL, strings.NewReader("hello"))
 		req.Header.Set("X-Content-Sha256", checksum)
@@ -330,7 +330,7 @@ func TestStorageHandlerDelete(t *testing.T) {
 	mockSvc, handler, r := setupStorageHandlerTest()
 	r.DELETE(bucketKeyPath, handler.Delete)
 
-	mockSvc.On("DeleteObject", mock.Anything, "b1", testTxtPath).Return(nil)
+	mockSvc.On("DeleteObject", mock.Anything, "b1", testTxtKey).Return(nil)
 
 	req := httptest.NewRequest(http.MethodDelete, testTxtFullURL, nil)
 	w := httptest.NewRecorder()
@@ -349,7 +349,7 @@ func TestStorageHandlerDownload(t *testing.T) {
 	reader := io.NopCloser(strings.NewReader(content))
 	obj := &domain.Object{Key: testTxtKey, SizeBytes: int64(len(content)), ContentType: "text/plain"}
 
-	mockSvc.On("Download", mock.Anything, "b1", testTxtPath).Return(reader, obj, nil)
+	mockSvc.On("Download", mock.Anything, "b1", testTxtKey).Return(reader, obj, nil)
 
 	req := httptest.NewRequest(http.MethodGet, testTxtFullURL, nil)
 	w := httptest.NewRecorder()
@@ -432,7 +432,7 @@ func TestStorageHandlerVersioning(t *testing.T) {
 
 	// List Versions
 	versions := []*domain.Object{{Key: testTxtKey, VersionID: "v1"}}
-	mockSvc.On("ListVersions", mock.Anything, "b1", testTxtPath).Return(versions, nil)
+	mockSvc.On("ListVersions", mock.Anything, "b1", testTxtKey).Return(versions, nil)
 	req = httptest.NewRequest(http.MethodGet, "/storage/versions/b1/test.txt", nil)
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -498,7 +498,7 @@ func TestStorageHandlerUploadError(t *testing.T) {
 	mockSvc, handler, r := setupStorageHandlerTest()
 	r.PUT(bucketKeyPath, handler.Upload)
 
-	mockSvc.On("Upload", mock.Anything, "b1", testTxtPath, mock.Anything, "").Return(nil, errors.New(errors.Internal, "upload failed"))
+	mockSvc.On("Upload", mock.Anything, "b1", testTxtKey, mock.Anything, "").Return(nil, errors.New(errors.Internal, "upload failed"))
 
 	req := httptest.NewRequest(http.MethodPut, testTxtFullURL, strings.NewReader("hello"))
 	w := httptest.NewRecorder()
@@ -526,7 +526,7 @@ func TestStorageHandlerDeleteError(t *testing.T) {
 	mockSvc, handler, r := setupStorageHandlerTest()
 	r.DELETE(bucketKeyPath, handler.Delete)
 
-	mockSvc.On("DeleteObject", mock.Anything, "b1", testTxtPath).Return(errors.New(errors.Internal, "delete failed"))
+	mockSvc.On("DeleteObject", mock.Anything, "b1", testTxtKey).Return(errors.New(errors.Internal, "delete failed"))
 
 	req := httptest.NewRequest(http.MethodDelete, testTxtFullURL, nil)
 	w := httptest.NewRecorder()
@@ -635,7 +635,7 @@ func TestStorageHandlerVersioningErrors(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 
 	// List Error
-	mockSvc.On("ListVersions", mock.Anything, "b1", testTxtPath).Return(nil, errors.New(errors.Internal, "list versions failed"))
+	mockSvc.On("ListVersions", mock.Anything, "b1", testTxtKey).Return(nil, errors.New(errors.Internal, "list versions failed"))
 	req = httptest.NewRequest(http.MethodGet, "/storage/versions/b1/test.txt", nil)
 	w = httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/pkg/crypto/presign.go
+++ b/pkg/crypto/presign.go
@@ -19,8 +19,8 @@ func SignURL(secretKey, baseURL, method, bucket, key string, expires time.Time) 
 		return "", fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	// Clean path - strip leading slash to match VerifyURL behavior
-	cleanKey := strings.TrimPrefix(key, "/")
+	// Clean path - strip all leading slashes to match VerifyURL behavior
+	cleanKey := strings.TrimLeft(key, "/")
 	path := fmt.Sprintf("/storage/presigned/%s/%s", bucket, cleanKey)
 	u.Path = path
 


### PR DESCRIPTION
## Summary
- Fixes #424: Presign URL path malformed when key has multiple leading slashes — use `TrimLeft` instead of `TrimPrefix` to strip all leading slashes
- Fixes #460: Storage versions shows `null` as VERSION ID — use empty string instead of string `"null"` for clearer JSON output
- Fixes #416: Storage upload uses full file path as object key — use `path.Base` to extract just the filename

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/core/services/... -run TestStorageServiceUnit`
- [x] `go test ./pkg/crypto/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Use empty version ID when bucket versioning is disabled so storage reads/deletes non-versioned objects correctly
  * Normalize uploaded/downloaded/deleted object keys to the final path segment before processing
  * Fix presigned URL signing to handle keys with multiple leading slashes

* **Tests**
  * Update unit tests and handler tests to match normalized keys and empty version ID behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/513)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->