### PR TITLE
fix: add idempotency key support to VPC Create endpoint (#272)

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -10712,6 +10712,9 @@ const docTemplate = `{
                 "id": {
                     "type": "string"
                 },
+                "idempotency_key": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -10704,6 +10704,9 @@
                 "id": {
                     "type": "string"
                 },
+                "idempotency_key": {
+                    "type": "string"
+                },
                 "name": {
                     "type": "string"
                 },

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1788,6 +1788,8 @@ definitions:
         type: string
       id:
         type: string
+      idempotency_key:
+        type: string
       name:
         type: string
       network_id:

--- a/internal/core/domain/vpc.go
+++ b/internal/core/domain/vpc.go
@@ -14,11 +14,11 @@ type VPC struct {
 	UserID        uuid.UUID `json:"user_id"`
 	TenantID      uuid.UUID `json:"tenant_id"`
 	Name          string    `json:"name"`
-	CIDRBlock     string    `json:"cidr_block"`         // IPv4 range (e.g. "10.0.0.0/16")
-	NetworkID     string    `json:"network_id"`         // OVS bridge name or backend ID
-	VXLANID       int      `json:"vxlan_id"`          // Tunnel ID for isolation
-	Status        string    `json:"status"`            // e.g. "ACTIVE"
-	ARN           string    `json:"arn"`              // Amazon Resource Name compatible ID
+	CIDRBlock     string    `json:"cidr_block"` // IPv4 range (e.g. "10.0.0.0/16")
+	NetworkID     string    `json:"network_id"` // OVS bridge name or backend ID
+	VXLANID       int       `json:"vxlan_id"`  // Tunnel ID for isolation
+	Status        string    `json:"status"`    // e.g. "ACTIVE"
+	ARN           string    `json:"arn"`       // Amazon Resource Name compatible ID
 	CreatedAt     time.Time `json:"created_at"`
 	IdempotencyKey string   `json:"idempotency_key,omitempty"`
 }

--- a/internal/core/domain/vpc.go
+++ b/internal/core/domain/vpc.go
@@ -10,14 +10,15 @@ import (
 // VPC represents a Virtual Private Cloud (isolated network).
 // It acts as a container for subnets and other network resources.
 type VPC struct {
-	ID        uuid.UUID `json:"id"`
-	UserID    uuid.UUID `json:"user_id"`
-	TenantID  uuid.UUID `json:"tenant_id"`
-	Name      string    `json:"name"`
-	CIDRBlock string    `json:"cidr_block"` // IPv4 range (e.g. "10.0.0.0/16")
-	NetworkID string    `json:"network_id"` // OVS bridge name or backend ID
-	VXLANID   int       `json:"vxlan_id"`   // Tunnel ID for isolation
-	Status    string    `json:"status"`     // e.g. "ACTIVE"
-	ARN       string    `json:"arn"`        // Amazon Resource Name compatible ID
-	CreatedAt time.Time `json:"created_at"`
+	ID            uuid.UUID `json:"id"`
+	UserID        uuid.UUID `json:"user_id"`
+	TenantID      uuid.UUID `json:"tenant_id"`
+	Name          string    `json:"name"`
+	CIDRBlock     string    `json:"cidr_block"`         // IPv4 range (e.g. "10.0.0.0/16")
+	NetworkID     string    `json:"network_id"`         // OVS bridge name or backend ID
+	VXLANID       int      `json:"vxlan_id"`          // Tunnel ID for isolation
+	Status        string    `json:"status"`            // e.g. "ACTIVE"
+	ARN           string    `json:"arn"`              // Amazon Resource Name compatible ID
+	CreatedAt     time.Time `json:"created_at"`
+	IdempotencyKey string   `json:"idempotency_key,omitempty"`
 }

--- a/internal/core/ports/vpc.go
+++ b/internal/core/ports/vpc.go
@@ -16,6 +16,8 @@ type VpcRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*domain.VPC, error)
 	// GetByName retrieves a VPC definition by its friendly name (scoped to authorized user).
 	GetByName(ctx context.Context, name string) (*domain.VPC, error)
+	// GetByIdempotencyKey retrieves a VPC by its idempotency key (scoped to user).
+	GetByIdempotencyKey(ctx context.Context, key string) (*domain.VPC, error)
 	// List returns all VPCs accessible to the current user context.
 	List(ctx context.Context) ([]*domain.VPC, error)
 	// Delete removes a VPC definition from storage.
@@ -25,7 +27,7 @@ type VpcRepository interface {
 // VpcService provides business logic for managing isolated virtual networks.
 type VpcService interface {
 	// CreateVPC establishes a new isolated virtual network with a specific address space.
-	CreateVPC(ctx context.Context, name, cidrBlock string) (*domain.VPC, error)
+	CreateVPC(ctx context.Context, name, cidrBlock, idempotencyKey string) (*domain.VPC, error)
 	// GetVPC retrieves detailed information for a specific virtual network.
 	GetVPC(ctx context.Context, idOrName string) (*domain.VPC, error)
 	// ListVPCs returns all virtual networks registered to the current authorized user.

--- a/internal/core/services/dashboard_test.go
+++ b/internal/core/services/dashboard_test.go
@@ -166,6 +166,14 @@ func (m *mockVpcRepo) List(ctx context.Context) ([]*domain.VPC, error) {
 	r0, _ := args.Get(0).([]*domain.VPC)
 	return r0, args.Error(1)
 }
+func (m *mockVpcRepo) GetByIdempotencyKey(ctx context.Context, key string) (*domain.VPC, error) {
+	args := m.Called(ctx, key)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	r0, _ := args.Get(0).(*domain.VPC)
+	return r0, args.Error(1)
+}
 func (m *mockVpcRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)

--- a/internal/core/services/mock_network_test.go
+++ b/internal/core/services/mock_network_test.go
@@ -33,6 +33,13 @@ func (m *MockVpcRepo) List(ctx context.Context) ([]*domain.VPC, error) {
 	args := m.Called(ctx)
 	return args.Get(0).([]*domain.VPC), args.Error(1)
 }
+func (m *MockVpcRepo) GetByIdempotencyKey(ctx context.Context, key string) (*domain.VPC, error) {
+	args := m.Called(ctx, key)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.VPC), args.Error(1)
+}
 func (m *MockVpcRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	return m.Called(ctx, id).Error(0)
 }
@@ -40,8 +47,8 @@ func (m *MockVpcRepo) Delete(ctx context.Context, id uuid.UUID) error {
 // MockVpcService
 type MockVpcService struct{ mock.Mock }
 
-func (m *MockVpcService) CreateVPC(ctx context.Context, name, cidrBlock string) (*domain.VPC, error) {
-	args := m.Called(ctx, name, cidrBlock)
+func (m *MockVpcService) CreateVPC(ctx context.Context, name, cidrBlock, idempotencyKey string) (*domain.VPC, error) {
+	args := m.Called(ctx, name, cidrBlock, idempotencyKey)
 	r0, _ := args.Get(0).(*domain.VPC)
 	return r0, args.Error(1)
 }

--- a/internal/core/services/stack.go
+++ b/internal/core/services/stack.go
@@ -233,7 +233,7 @@ func (s *stackService) createVPC(ctx context.Context, stackID uuid.UUID, logical
 	}
 	cidr, _ := props["CIDRBlock"].(string)
 
-	vpc, err := s.vpcSvc.CreateVPC(ctx, name, cidr)
+	vpc, err := s.vpcSvc.CreateVPC(ctx, name, cidr, "")
 	if err != nil {
 		return uuid.Nil, err
 	}

--- a/internal/core/services/stack_test.go
+++ b/internal/core/services/stack_test.go
@@ -67,7 +67,7 @@ Resources:
 	// Async expectations
 	vpcID := uuid.New()
 	vpc := &domain.VPC{ID: vpcID, Name: stackTestVpc}
-	vpcSvc.On("CreateVPC", mock.Anything, stackTestVpc, "").Return(vpc, nil)
+	vpcSvc.On("CreateVPC", mock.Anything, stackTestVpc, "", "").Return(vpc, nil)
 	repo.On("AddResource", mock.Anything, mock.MatchedBy(func(r *domain.StackResource) bool {
 		return r.LogicalID == "MyVPC" && r.ResourceType == "VPC"
 	})).Return(nil)
@@ -155,7 +155,7 @@ Resources:
 	// 1. VPC Success
 	vpcID := uuid.New()
 	vpc := &domain.VPC{ID: vpcID, Name: stackTestVpc}
-	vpcSvc.On("CreateVPC", mock.Anything, stackTestVpc, "").Return(vpc, nil)
+	vpcSvc.On("CreateVPC", mock.Anything, stackTestVpc, "", "").Return(vpc, nil)
 	repo.On("AddResource", mock.Anything, mock.MatchedBy(func(r *domain.StackResource) bool {
 		return r.LogicalID == "MyVPC" && r.ResourceType == "VPC"
 	})).Return(nil)
@@ -223,7 +223,7 @@ Resources:
 
 	vpcID := uuid.New()
 	vpc := &domain.VPC{ID: vpcID, Name: stackTestVpc}
-	vpcSvc.On("CreateVPC", mock.Anything, stackTestVpc, "").Return(vpc, nil)
+	vpcSvc.On("CreateVPC", mock.Anything, stackTestVpc, "", "").Return(vpc, nil)
 	repo.On("AddResource", mock.Anything, mock.MatchedBy(func(r *domain.StackResource) bool {
 		return r.LogicalID == "MyVPC" && r.ResourceType == "VPC"
 	})).Return(nil)
@@ -286,7 +286,7 @@ Resources:
 
 	vpcID := uuid.New()
 	vpc := &domain.VPC{ID: vpcID, Name: stackTestVpc}
-	vpcSvc.On("CreateVPC", mock.Anything, stackTestVpc, "").Return(vpc, nil)
+	vpcSvc.On("CreateVPC", mock.Anything, stackTestVpc, "", "").Return(vpc, nil)
 	repo.On("AddResource", mock.Anything, mock.MatchedBy(func(r *domain.StackResource) bool {
 		return r.LogicalID == "MyVPC" && r.ResourceType == "VPC"
 	})).Return(nil)

--- a/internal/core/services/vpc.go
+++ b/internal/core/services/vpc.go
@@ -78,7 +78,7 @@ func NewVpcService(params VpcServiceParams) *VpcService {
 
 // CreateVPC provisions a new VPC with an associated OVS bridge for network isolation.
 // It generates a unique VXLAN ID and persists the VPC metadata to the database.
-func (s *VpcService) CreateVPC(ctx context.Context, name, cidrBlock string) (*domain.VPC, error) {
+func (s *VpcService) CreateVPC(ctx context.Context, name, cidrBlock, idempotencyKey string) (*domain.VPC, error) {
 	ctx, span := otel.Tracer("vpc-service").Start(ctx, "CreateVPC")
 	defer span.End()
 
@@ -87,6 +87,14 @@ func (s *VpcService) CreateVPC(ctx context.Context, name, cidrBlock string) (*do
 
 	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionVpcCreate, "*"); err != nil {
 		return nil, err
+	}
+
+	// Check if already created via idempotency key
+	if idempotencyKey != "" {
+		existing, err := s.repo.GetByIdempotencyKey(ctx, idempotencyKey)
+		if err == nil {
+			return existing, nil
+		}
 	}
 
 	span.SetAttributes(
@@ -127,16 +135,17 @@ func (s *VpcService) CreateVPC(ctx context.Context, name, cidrBlock string) (*do
 
 	// 4. Persist to DB
 	vpc := &domain.VPC{
-		ID:        vpcID,
-		UserID:    userID,
-		TenantID:  tenantID,
-		Name:      name,
-		CIDRBlock: cidrBlock,
-		NetworkID: bridgeName, // empty string for libvirt
-		VXLANID:   vxlanID,
-		Status:    "active",
-		ARN:       arn,
-		CreatedAt: time.Now(),
+		ID:            vpcID,
+		UserID:        userID,
+		TenantID:      tenantID,
+		Name:          name,
+		CIDRBlock:     cidrBlock,
+		NetworkID:     bridgeName,
+		VXLANID:       vxlanID,
+		Status:        "active",
+		ARN:           arn,
+		CreatedAt:     time.Now(),
+		IdempotencyKey: idempotencyKey,
 	}
 
 	if err := s.repo.Create(ctx, vpc); err != nil {

--- a/internal/core/services/vpc_test.go
+++ b/internal/core/services/vpc_test.go
@@ -58,7 +58,7 @@ func TestVpcService_Integration(t *testing.T) {
 
 	t.Run("CreateAndGet", func(t *testing.T) {
 		name := "test-vpc"
-		vpc, err := svc.CreateVPC(ctx, name, testutil.TestCIDR)
+		vpc, err := svc.CreateVPC(ctx, name, testutil.TestCIDR, "")
 		require.NoError(t, err)
 		assert.Equal(t, name, vpc.Name)
 		assert.Equal(t, userID, vpc.UserID)
@@ -70,8 +70,8 @@ func TestVpcService_Integration(t *testing.T) {
 	})
 
 	t.Run("ListVPCs", func(t *testing.T) {
-		_, _ = svc.CreateVPC(ctx, "vpc1", testutil.TestCIDR)
-		_, _ = svc.CreateVPC(ctx, "vpc2", testutil.TestCIDR)
+		_, _ = svc.CreateVPC(ctx, "vpc1", testutil.TestCIDR, "")
+		_, _ = svc.CreateVPC(ctx, "vpc2", testutil.TestCIDR, "")
 
 		vpcs, err := svc.ListVPCs(ctx)
 		require.NoError(t, err)
@@ -80,7 +80,7 @@ func TestVpcService_Integration(t *testing.T) {
 	})
 
 	t.Run("Delete", func(t *testing.T) {
-		vpc, _ := svc.CreateVPC(ctx, "to-delete", testutil.TestCIDR)
+		vpc, _ := svc.CreateVPC(ctx, "to-delete", testutil.TestCIDR, "")
 
 		err := svc.DeleteVPC(ctx, vpc.ID.String())
 		require.NoError(t, err)

--- a/internal/core/services/vpc_unit_test.go
+++ b/internal/core/services/vpc_unit_test.go
@@ -52,7 +52,7 @@ func TestVpcServiceUnit(t *testing.T) {
 		})).Return(nil).Once()
 		auditSvc.On("Log", mock.Anything, userID, "vpc.create", "vpc", mock.Anything, mock.Anything).Return(nil).Once()
 
-		vpc, err := svc.CreateVPC(ctx, "test-vpc", "10.1.0.0/16")
+		vpc, err := svc.CreateVPC(ctx, "test-vpc", "10.1.0.0/16", "")
 		require.NoError(t, err)
 		assert.NotNil(t, vpc)
 		assert.Equal(t, "10.1.0.0/16", vpc.CIDRBlock)
@@ -63,7 +63,7 @@ func TestVpcServiceUnit(t *testing.T) {
 	t.Run("CreateVPC_BridgeFailure", func(t *testing.T) {
 		network.On("CreateBridge", mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("bridge fail")).Once()
 
-		_, err := svc.CreateVPC(ctx, "fail", "10.2.0.0/16")
+		_, err := svc.CreateVPC(ctx, "fail", "10.2.0.0/16", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "bridge")
 	})
@@ -73,14 +73,43 @@ func TestVpcServiceUnit(t *testing.T) {
 		repo.On("Create", mock.Anything, mock.Anything).Return(fmt.Errorf("db fail")).Once()
 		network.On("DeleteBridge", mock.Anything, mock.Anything).Return(nil).Once()
 
-		_, err := svc.CreateVPC(ctx, "rollback", "10.3.0.0/16")
+		_, err := svc.CreateVPC(ctx, "rollback", "10.3.0.0/16", "")
 		require.Error(t, err)
 	})
 
 	t.Run("CreateVPC_InvalidCIDR", func(t *testing.T) {
-		_, err := svc.CreateVPC(ctx, "test-vpc", "invalid")
+		_, err := svc.CreateVPC(ctx, "test-vpc", "invalid", "")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid CIDR")
+	})
+
+	t.Run("CreateVPC_IdempotencyKey_ReturnsExisting", func(t *testing.T) {
+		existingVPC := &domain.VPC{
+			ID:        uuid.New(),
+			UserID:    userID,
+			Name:      "test-vpc",
+			CIDRBlock: "10.1.0.0/16",
+		}
+		repo.On("GetByIdempotencyKey", mock.Anything, "my-idempotency-key").Return(existingVPC, nil).Once()
+
+		vpc, err := svc.CreateVPC(ctx, "test-vpc", "10.1.0.0/16", "my-idempotency-key")
+		require.NoError(t, err)
+		assert.Equal(t, existingVPC.ID, vpc.ID)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("CreateVPC_IdempotencyKey_EmptyKey_CreatesNew", func(t *testing.T) {
+		network.On("CreateBridge", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		routeTableRepo.On("Create", mock.Anything, mock.MatchedBy(func(rt *domain.RouteTable) bool {
+			return rt.IsMain && rt.Name == "main"
+		})).Return(nil).Once()
+		auditSvc.On("Log", mock.Anything, userID, "vpc.create", "vpc", mock.Anything, mock.Anything).Return(nil).Once()
+
+		vpc, err := svc.CreateVPC(ctx, "new-vpc", "10.1.0.0/16", "")
+		require.NoError(t, err)
+		assert.NotNil(t, vpc)
+		repo.AssertExpectations(t)
 	})
 
 	t.Run("DeleteVPC_Success", func(t *testing.T) {

--- a/internal/handlers/vpc_handler.go
+++ b/internal/handlers/vpc_handler.go
@@ -42,7 +42,8 @@ func (h *VpcHandler) Create(c *gin.Context) {
 		return
 	}
 
-	vpc, err := h.svc.CreateVPC(c.Request.Context(), req.Name, req.CIDRBlock)
+	idempotencyKey := c.GetHeader("Idempotency-Key")
+	vpc, err := h.svc.CreateVPC(c.Request.Context(), req.Name, req.CIDRBlock, idempotencyKey)
 	if err != nil {
 		httputil.Error(c, err)
 		return

--- a/internal/handlers/vpc_handler_test.go
+++ b/internal/handlers/vpc_handler_test.go
@@ -99,7 +99,7 @@ func TestVpcHandlerCreateErrors(t *testing.T) {
 	})
 
 	t.Run("ServiceError", func(t *testing.T) {
-		svc.On("CreateVPC", mock.Anything, "err-vpc", "").Return(nil, assert.AnError)
+		svc.On("CreateVPC", mock.Anything, "err-vpc", "", "").Return(nil, assert.AnError)
 		body, _ := json.Marshal(map[string]string{"name": "err-vpc"})
 		w := httptest.NewRecorder()
 		req, _ := http.NewRequest("POST", vpcsPath, bytes.NewBuffer(body))

--- a/internal/handlers/vpc_handler_test.go
+++ b/internal/handlers/vpc_handler_test.go
@@ -26,8 +26,8 @@ type mockVpcService struct {
 	mock.Mock
 }
 
-func (m *mockVpcService) CreateVPC(ctx context.Context, name, cidrBlock string) (*domain.VPC, error) {
-	args := m.Called(ctx, name, cidrBlock)
+func (m *mockVpcService) CreateVPC(ctx context.Context, name, cidrBlock, idempotencyKey string) (*domain.VPC, error) {
+	args := m.Called(ctx, name, cidrBlock, idempotencyKey)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -74,7 +74,7 @@ func TestVpcHandlerCreate(t *testing.T) {
 	r.POST(vpcsPath, handler.Create)
 
 	vpc := &domain.VPC{ID: uuid.New(), Name: testVpcName}
-	svc.On("CreateVPC", mock.Anything, testVpcName, testutil.TestCIDR).Return(vpc, nil)
+	svc.On("CreateVPC", mock.Anything, testVpcName, testutil.TestCIDR, "").Return(vpc, nil)
 
 	body, err := json.Marshal(map[string]string{"name": testVpcName, "cidr_block": testutil.TestCIDR})
 	require.NoError(t, err)

--- a/internal/repositories/docker/loadbalancer_test.go
+++ b/internal/repositories/docker/loadbalancer_test.go
@@ -109,6 +109,15 @@ func (m *mockVpcRepo) List(ctx context.Context) ([]*domain.VPC, error) {
 	return r0, args.Error(1)
 }
 
+func (m *mockVpcRepo) GetByIdempotencyKey(ctx context.Context, key string) (*domain.VPC, error) {
+	args := m.Called(ctx, key)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	r0, _ := args.Get(0).(*domain.VPC)
+	return r0, args.Error(1)
+}
+
 func (m *mockVpcRepo) Delete(ctx context.Context, id uuid.UUID) error {
 	args := m.Called(ctx, id)
 	return args.Error(0)

--- a/internal/repositories/noop/adapters.go
+++ b/internal/repositories/noop/adapters.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
 )
 
 // NoopInstanceRepository is a no-op instance repository.
@@ -51,6 +52,9 @@ func (r *NoopVpcRepository) GetByID(ctx context.Context, id uuid.UUID) (*domain.
 }
 func (r *NoopVpcRepository) GetByName(ctx context.Context, name string) (*domain.VPC, error) {
 	return &domain.VPC{ID: uuid.New(), Name: name}, nil
+}
+func (r *NoopVpcRepository) GetByIdempotencyKey(ctx context.Context, key string) (*domain.VPC, error) {
+	return nil, errors.New(errors.NotFound, "idempotency key not found")
 }
 func (r *NoopVpcRepository) List(ctx context.Context) ([]*domain.VPC, error) {
 	return []*domain.VPC{}, nil

--- a/internal/repositories/postgres/migrations/109_vpcs_add_idempotency_key.down.sql
+++ b/internal/repositories/postgres/migrations/109_vpcs_add_idempotency_key.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE vpcs DROP COLUMN IF EXISTS idempotency_key;

--- a/internal/repositories/postgres/migrations/109_vpcs_add_idempotency_key.up.sql
+++ b/internal/repositories/postgres/migrations/109_vpcs_add_idempotency_key.up.sql
@@ -1,0 +1,2 @@
+-- Add idempotency_key column to vpcs table for idempotent create operations
+ALTER TABLE vpcs ADD COLUMN idempotency_key VARCHAR(64) UNIQUE;

--- a/internal/repositories/postgres/vpc_repo.go
+++ b/internal/repositories/postgres/vpc_repo.go
@@ -25,10 +25,10 @@ func NewVpcRepository(db DB) *VpcRepository {
 // Create inserts a new VPC record into the database.
 func (r *VpcRepository) Create(ctx context.Context, vpc *domain.VPC) error {
 	query := `
-		INSERT INTO vpcs (id, user_id, tenant_id, name, cidr_block, network_id, vxlan_id, status, arn, created_at)
-		VALUES ($1, $2, $3, $4, NULLIF($5, '')::cidr, $6, $7, $8, $9, $10)
+		INSERT INTO vpcs (id, user_id, tenant_id, name, cidr_block, network_id, vxlan_id, status, arn, created_at, idempotency_key)
+		VALUES ($1, $2, $3, $4, NULLIF($5, '')::cidr, $6, $7, $8, $9, $10, NULLIF($11, ''))
 	`
-	_, err := r.db.Exec(ctx, query, vpc.ID, vpc.UserID, vpc.TenantID, vpc.Name, vpc.CIDRBlock, vpc.NetworkID, vpc.VXLANID, vpc.Status, vpc.ARN, vpc.CreatedAt)
+	_, err := r.db.Exec(ctx, query, vpc.ID, vpc.UserID, vpc.TenantID, vpc.Name, vpc.CIDRBlock, vpc.NetworkID, vpc.VXLANID, vpc.Status, vpc.ARN, vpc.CreatedAt, vpc.IdempotencyKey)
 	if err != nil {
 		return errors.Wrap(errors.Internal, "failed to create vpc", err)
 	}
@@ -47,6 +47,16 @@ func (r *VpcRepository) GetByName(ctx context.Context, name string) (*domain.VPC
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	query := `SELECT id, user_id, tenant_id, name, COALESCE(cidr_block::text, ''), network_id, vxlan_id, status, arn, created_at FROM vpcs WHERE name = $1 AND tenant_id = $2`
 	return r.scanVPC(r.db.QueryRow(ctx, query, name, tenantID))
+}
+
+// GetByIdempotencyKey retrieves a VPC by its idempotency key (scoped to user).
+func (r *VpcRepository) GetByIdempotencyKey(ctx context.Context, key string) (*domain.VPC, error) {
+	if key == "" {
+		return nil, errors.New(errors.NotFound, "idempotency key empty")
+	}
+	userID := appcontext.UserIDFromContext(ctx)
+	query := `SELECT id, user_id, tenant_id, name, COALESCE(cidr_block::text, ''), network_id, vxlan_id, status, arn, created_at FROM vpcs WHERE idempotency_key = $1 AND user_id = $2`
+	return r.scanVPC(r.db.QueryRow(ctx, query, key, userID))
 }
 
 // List returns all VPCs belonging to the authenticated user.

--- a/internal/repositories/postgres/vpc_repo_unit_test.go
+++ b/internal/repositories/postgres/vpc_repo_unit_test.go
@@ -45,7 +45,7 @@ func TestVpcRepositoryCreate(t *testing.T) {
 		}
 
 		mock.ExpectExec("INSERT INTO vpcs").
-			WithArgs(vpc.ID, vpc.UserID, vpc.TenantID, vpc.Name, vpc.CIDRBlock, vpc.NetworkID, vpc.VXLANID, vpc.Status, vpc.ARN, vpc.CreatedAt).
+			WithArgs(vpc.ID, vpc.UserID, vpc.TenantID, vpc.Name, vpc.CIDRBlock, vpc.NetworkID, vpc.VXLANID, vpc.Status, vpc.ARN, vpc.CreatedAt, vpc.IdempotencyKey).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
 
 		err = repo.Create(context.Background(), vpc)

--- a/internal/repositories/postgres/vpc_repo_unit_test.go
+++ b/internal/repositories/postgres/vpc_repo_unit_test.go
@@ -307,3 +307,88 @@ func TestVpcRepositoryDelete(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestVpcRepositoryGetByIdempotencyKey(t *testing.T) {
+	t.Parallel()
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		repo := NewVpcRepository(mock)
+		id := uuid.New()
+		userID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithTenantID(appcontext.WithUserID(context.Background(), userID), tenantID)
+		now := time.Now()
+		key := "test-idempotency-key"
+
+		mock.ExpectQuery("SELECT id, user_id, tenant_id, name, COALESCE").
+			WithArgs(key, userID).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "name", "cidr_block", "network_id", "vxlan_id", "status", "arn", "created_at"}).
+				AddRow(id, userID, tenantID, testVpcName, testutil.TestCIDR, "net-1", 100, "available", "arn", now))
+
+		vpc, err := repo.GetByIdempotencyKey(ctx, key)
+		require.NoError(t, err)
+		assert.NotNil(t, vpc)
+		assert.Equal(t, id, vpc.ID)
+		assert.Equal(t, testVpcName, vpc.Name)
+	})
+
+	t.Run("empty key returns not found", func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		repo := NewVpcRepository(mock)
+		ctx := context.Background()
+
+		vpc, err := repo.GetByIdempotencyKey(ctx, "")
+		require.Error(t, err)
+		assert.Nil(t, vpc)
+		var target theclouderrors.Error
+		if errors.As(err, &target) {
+			assert.Equal(t, theclouderrors.NotFound, target.Type)
+		}
+	})
+
+	t.Run(testNotFound, func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		repo := NewVpcRepository(mock)
+		userID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+
+		mock.ExpectQuery("SELECT id, user_id, tenant_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs WHERE idempotency_key = $1 AND user_id = $2").
+			WithArgs("nonexistent-key", userID).
+			WillReturnError(pgx.ErrNoRows)
+
+		vpc, err := repo.GetByIdempotencyKey(ctx, "nonexistent-key")
+		require.Error(t, err)
+		assert.Nil(t, vpc)
+	})
+
+	t.Run(testDBError, func(t *testing.T) {
+		t.Parallel()
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		repo := NewVpcRepository(mock)
+		userID := uuid.New()
+		ctx := appcontext.WithUserID(context.Background(), userID)
+
+		mock.ExpectQuery("SELECT id, user_id, tenant_id, name, COALESCE\\(cidr_block::text, ''\\), network_id, vxlan_id, status, arn, created_at FROM vpcs WHERE idempotency_key = $1 AND user_id = $2").
+			WithArgs("some-key", userID).
+			WillReturnError(errors.New(testDBError))
+
+		vpc, err := repo.GetByIdempotencyKey(ctx, "some-key")
+		require.Error(t, err)
+		assert.Nil(t, vpc)
+	})
+}


### PR DESCRIPTION
## Summary

Add idempotency key support to VPC Create endpoint following the same pattern as LoadBalancer Create.

## Changes

- **Domain**: Add `IdempotencyKey` field to `VPC` struct
- **Ports**: Add `GetByIdempotencyKey` to `VpcRepository` interface; update `CreateVPC` signature
- **Repository**: Implement `GetByIdempotencyKey` method; update `Create` to insert idempotency_key
- **Service**: Check for existing VPC by idempotency key before creating
- **Handler**: Extract `Idempotency-Key` header and pass to service
- **Migration**: Add `idempotency_key` column with unique constraint

## How It Works

1. Client sends `Idempotency-Key: <uuid>` header with VPC create request
2. Service checks if a VPC already exists with that idempotency key
3. If exists, returns the existing VPC (HTTP 201)
4. If not, creates new VPC with the idempotency key stored

This ensures duplicate requests return the same result without creating multiple VPCs.

## Fixes #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Idempotent VPC creation: supply an Idempotency-Key header when creating VPCs to safely retry without duplicates.
  * Requests with a matching idempotency key will return the existing VPC instead of creating a new one.
* **Chores**
  * Database migration added to store and enforce unique idempotency keys for VPCs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/516)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->