### PR TITLE
fix: prevent memory exhaustion in LocalStore.Read

### DIFF
--- a/internal/storage/node/store.go
+++ b/internal/storage/node/store.go
@@ -135,7 +135,7 @@ func (s *LocalStore) ReadStream(bucket, key string) (io.ReadCloser, int64, error
 }
 
 // Read retrieves data from disk.
-// Warning: for large files (>100MB), use ReadStream() instead to avoid memory exhaustion.
+// Warning: for large files (>maxReadBytes), use ReadStream() instead to avoid memory exhaustion.
 func (s *LocalStore) Read(bucket, key string) ([]byte, int64, error) {
 	path, err := s.getObjectPath(bucket, key)
 	if err != nil {
@@ -148,7 +148,7 @@ func (s *LocalStore) Read(bucket, key string) ([]byte, int64, error) {
 		return nil, 0, err
 	}
 	if info.Size() > maxReadBytes {
-		return nil, 0, fmt.Errorf("file too large (%d bytes) for Read(), use ReadStream() for large files", info.Size())
+		return nil, 0, fmt.Errorf("file too large (%d bytes, max %d) for Read(), use ReadStream() for large files", info.Size(), maxReadBytes)
 	}
 
 	rc, timestamp, err := s.ReadStream(bucket, key)

--- a/internal/storage/node/store.go
+++ b/internal/storage/node/store.go
@@ -137,27 +137,48 @@ func (s *LocalStore) ReadStream(bucket, key string) (io.ReadCloser, int64, error
 // Read retrieves data from disk.
 // Warning: for large files (>maxReadBytes), use ReadStream() instead to avoid memory exhaustion.
 func (s *LocalStore) Read(bucket, key string) ([]byte, int64, error) {
+	s.mu.RLock()
 	path, err := s.getObjectPath(bucket, key)
+	s.mu.RUnlock()
 	if err != nil {
 		return nil, 0, err
 	}
 
-	// Check file size before reading to prevent memory exhaustion
-	info, err := os.Stat(path)
+	f, err := os.Open(filepath.Clean(path))
 	if err != nil {
+		return nil, 0, err
+	}
+
+	// Check size on the opened file to avoid TOCTOU with ReadStream's separate open
+	info, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
 		return nil, 0, err
 	}
 	if info.Size() > maxReadBytes {
+		_ = f.Close()
 		return nil, 0, fmt.Errorf("file too large (%d bytes, max %d) for Read(), use ReadStream() for large files", info.Size(), maxReadBytes)
 	}
 
-	rc, timestamp, err := s.ReadStream(bucket, key)
-	if err != nil {
-		return nil, 0, err
+	// Read metadata
+	var timestamp int64
+	metaPath := filepath.Clean(path + ".meta")
+	metaBytes, err := os.ReadFile(metaPath)
+	if err == nil && len(metaBytes) >= 8 {
+		uVal := binary.LittleEndian.Uint64(metaBytes)
+		if uVal > math.MaxInt64 {
+			timestamp = math.MaxInt64
+		} else {
+			timestamp = int64(uVal)
+		}
+	} else {
+		timestamp = info.ModTime().UnixNano()
 	}
-	defer func() { _ = rc.Close() }()
 
-	data, err := io.ReadAll(rc)
+	// Use LimitedReader to prevent reading more than maxReadBytes even if file grows
+	lr := io.LimitedReader{R: f, N: maxReadBytes + 1}
+	data, err := io.ReadAll(&lr)
+	_ = f.Close()
 	if err != nil {
 		return nil, 0, err
 	}

--- a/internal/storage/node/store.go
+++ b/internal/storage/node/store.go
@@ -25,6 +25,10 @@ type LocalStore struct {
 
 const maxObjectSize = 5 * 1024 * 1024 * 1024 // 5 GB
 
+// maxReadBytes is the maximum size for the Read() convenience method.
+// Files larger than this should use ReadStream() to avoid memory exhaustion.
+const maxReadBytes = 100 * 1024 * 1024 // 100 MB
+
 // NewLocalStore initializes a new local storage backend.
 func NewLocalStore(dataDir string) (*LocalStore, error) {
 	if err := os.MkdirAll(dataDir, 0750); err != nil {
@@ -131,7 +135,22 @@ func (s *LocalStore) ReadStream(bucket, key string) (io.ReadCloser, int64, error
 }
 
 // Read retrieves data from disk.
+// Warning: for large files (>100MB), use ReadStream() instead to avoid memory exhaustion.
 func (s *LocalStore) Read(bucket, key string) ([]byte, int64, error) {
+	path, err := s.getObjectPath(bucket, key)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Check file size before reading to prevent memory exhaustion
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	if info.Size() > maxReadBytes {
+		return nil, 0, fmt.Errorf("file too large (%d bytes) for Read(), use ReadStream() for large files", info.Size())
+	}
+
 	rc, timestamp, err := s.ReadStream(bucket, key)
 	if err != nil {
 		return nil, 0, err

--- a/internal/storage/node/store_test.go
+++ b/internal/storage/node/store_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -145,4 +146,36 @@ func TestLocalStoreInvalidAbsolutePath(t *testing.T) {
 	err := store.Write("bucket", "/abs/path", []byte("data"), 0)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, os.ErrInvalid)
+}
+
+func TestLocalStoreReadSizeLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, _ := NewLocalStore(tmpDir)
+	bucket := "test-bucket"
+	key := "largefile.bin"
+
+	// Create a file larger than maxReadBytes (100MB)
+	// Use WriteStream which doesn't have the size check
+	largeData := make([]byte, maxReadBytes+1024)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+
+	err := store.Write(bucket, key, largeData, 0)
+	require.NoError(t, err)
+
+	// Read() should fail due to size limit
+	_, _, err = store.Read(bucket, key)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file too large")
+
+	// But ReadStream() should still work
+	rc, _, err := store.ReadStream(bucket, key)
+	require.NoError(t, err)
+	defer rc.Close()
+
+	// Verify we can read the data via stream
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, len(largeData), len(data))
 }


### PR DESCRIPTION
## Summary

Add size check before loading file into memory via `io.ReadAll()`. Files larger than 100MB now return an error suggesting `ReadStream()` instead.

## Changes

- `store.go:26`: Add `maxReadBytes` constant (100MB)
- `store.go:136-165`: Add size check in `Read()` method before calling `ReadStream`
- `store_test.go`: Add `TestLocalStoreReadSizeLimit` test

## Why

The `Read()` method used `io.ReadAll()` which loads the entire file into memory. With a 5GB max object size, this could cause OOM for large files. `ReadStream()` exists as a memory-safe alternative.

## Test plan

- [x] `go test ./internal/storage/node/...` - all tests pass
- [x] New test verifies files >100MB are rejected by `Read()`
- [x] New test verifies `ReadStream()` still works for large files

## Related Issues

Fixes #497

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Direct read operations now enforce a 100MB maximum; attempting to read files larger than 100MB returns a “file too large” error. Use the streaming read method to access bigger files.

* **Tests**
  * Added a test to verify direct reads reject oversized files while streaming reads still succeed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/517)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->