### PR TITLE
fix: CLI secrets get and rm resolve short IDs

### DIFF
--- a/internal/handlers/secret_handler.go
+++ b/internal/handlers/secret_handler.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/poyrazk/thecloud/pkg/httputil"
@@ -71,17 +72,25 @@ func (h *SecretHandler) resolveShortID(ctx context.Context, idStr string) (uuid.
 	// Then try short ID prefix match
 	secrets, err := h.svc.ListSecrets(ctx)
 	if err != nil {
-		return uuid.Nil, errors.New(errors.NotFound, "secret not found")
+		return uuid.Nil, err
 	}
 
 	idStrLower := strings.ToLower(idStr)
+	var candidates []*domain.Secret
 	for _, s := range secrets {
 		if strings.HasPrefix(s.ID.String(), idStr) || strings.HasPrefix(strings.ToLower(s.Name), idStrLower) {
-			return s.ID, nil
+			candidates = append(candidates, s)
 		}
 	}
 
-	return uuid.Nil, errors.New(errors.NotFound, "secret not found")
+	if len(candidates) == 0 {
+		return uuid.Nil, errors.New(errors.NotFound, "secret not found")
+	}
+	if len(candidates) > 1 {
+		return uuid.Nil, errors.New(errors.InvalidInput, "ambiguous secret identifier")
+	}
+
+	return candidates[0].ID, nil
 }
 
 func (h *SecretHandler) Get(c *gin.Context) {

--- a/internal/handlers/secret_handler.go
+++ b/internal/handlers/secret_handler.go
@@ -2,7 +2,9 @@
 package httphandlers
 
 import (
+	"context"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -55,18 +57,39 @@ func (h *SecretHandler) List(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, secrets)
 }
 
+func (h *SecretHandler) resolveShortID(ctx context.Context, idStr string) (uuid.UUID, error) {
+	// First try as full UUID
+	if id, err := uuid.Parse(idStr); err == nil {
+		return id, nil
+	}
+
+	// Then try by name
+	if secret, err := h.svc.GetSecretByName(ctx, idStr); err == nil {
+		return secret.ID, nil
+	}
+
+	// Then try short ID prefix match
+	secrets, err := h.svc.ListSecrets(ctx)
+	if err != nil {
+		return uuid.Nil, errors.New(errors.NotFound, "secret not found")
+	}
+
+	idStrLower := strings.ToLower(idStr)
+	for _, s := range secrets {
+		if strings.HasPrefix(s.ID.String(), idStr) || strings.HasPrefix(strings.ToLower(s.Name), idStrLower) {
+			return s.ID, nil
+		}
+	}
+
+	return uuid.Nil, errors.New(errors.NotFound, "secret not found")
+}
+
 func (h *SecretHandler) Get(c *gin.Context) {
 	idStr := c.Param("id")
 
-	id, err := uuid.Parse(idStr)
+	id, err := h.resolveShortID(c.Request.Context(), idStr)
 	if err != nil {
-		// Try by name if not UUID
-		secret, err := h.svc.GetSecretByName(c.Request.Context(), idStr)
-		if err != nil {
-			httputil.Error(c, err)
-			return
-		}
-		httputil.Success(c, http.StatusOK, secret)
+		httputil.Error(c, err)
 		return
 	}
 
@@ -81,15 +104,11 @@ func (h *SecretHandler) Get(c *gin.Context) {
 
 func (h *SecretHandler) Delete(c *gin.Context) {
 	idStr := c.Param("id")
-	id, err := uuid.Parse(idStr)
+
+	id, err := h.resolveShortID(c.Request.Context(), idStr)
 	if err != nil {
-		// Try by name
-		secret, err := h.svc.GetSecretByName(c.Request.Context(), idStr)
-		if err != nil {
-			httputil.Error(c, err)
-			return
-		}
-		id = secret.ID
+		httputil.Error(c, err)
+		return
 	}
 
 	if err := h.svc.DeleteSecret(c.Request.Context(), id); err != nil {

--- a/internal/handlers/secret_handler_test.go
+++ b/internal/handlers/secret_handler_test.go
@@ -154,8 +154,10 @@ func TestSecretHandlerGetByName(t *testing.T) {
 
 	r.GET(secretsPath+"/:id", handler.Get)
 
-	secret := &domain.Secret{ID: uuid.New(), Name: testSecretName}
+	id := uuid.New()
+	secret := &domain.Secret{ID: id, Name: testSecretName}
 	svc.On("GetSecretByName", mock.Anything, testSecretName).Return(secret, nil)
+	svc.On("GetSecret", mock.Anything, id).Return(secret, nil)
 
 	req, err := http.NewRequest(http.MethodGet, secretsPath+"/"+testSecretName, nil)
 	require.NoError(t, err)
@@ -196,6 +198,7 @@ func TestSecretHandlerDelete(t *testing.T) {
 		svc, handler, r := setupSecretHandlerTest(t)
 		r.DELETE(secretsPath+"/:id", handler.Delete)
 		svc.On("GetSecretByName", mock.Anything, testSecretName).Return(nil, errors.New(errors.NotFound, errSecretNotFound))
+		svc.On("ListSecrets", mock.Anything).Return(nil, errors.New(errors.NotFound, errSecretNotFound))
 		req, _ := http.NewRequest(http.MethodDelete, secretsPath+"/"+testSecretName, nil)
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)
@@ -270,6 +273,7 @@ func TestSecretHandlerGetError(t *testing.T) {
 		svc, handler, r := setupSecretHandlerTest(t)
 		r.GET(secretsPath+"/:id", handler.Get)
 		svc.On("GetSecretByName", mock.Anything, "name").Return(nil, errors.New(errors.NotFound, errSecretNotFound))
+		svc.On("ListSecrets", mock.Anything).Return(nil, errors.New(errors.NotFound, errSecretNotFound))
 		req, _ := http.NewRequest(http.MethodGet, secretsPath+"/name", nil)
 		w := httptest.NewRecorder()
 		r.ServeHTTP(w, req)

--- a/internal/handlers/secret_handler_test.go
+++ b/internal/handlers/secret_handler_test.go
@@ -167,6 +167,50 @@ func TestSecretHandlerGetByName(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestSecretHandlerGetByShortID(t *testing.T) {
+	t.Parallel()
+	svc, handler, r := setupSecretHandlerTest(t)
+	defer svc.AssertExpectations(t)
+
+	r.GET(secretsPath+"/:id", handler.Get)
+
+	id := uuid.New()
+	secret := &domain.Secret{ID: id, Name: testSecretName}
+	shortPrefix := id.String()[:8]
+	svc.On("GetSecretByName", mock.Anything, shortPrefix).Return(nil, errors.New(errors.NotFound, "not found"))
+	svc.On("ListSecrets", mock.Anything).Return([]*domain.Secret{secret}, nil)
+	svc.On("GetSecret", mock.Anything, id).Return(secret, nil)
+
+	req, err := http.NewRequest(http.MethodGet, secretsPath+"/"+shortPrefix, nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSecretHandlerDeleteByShortID(t *testing.T) {
+	t.Parallel()
+	svc, handler, r := setupSecretHandlerTest(t)
+	defer svc.AssertExpectations(t)
+
+	r.DELETE(secretsPath+"/:id", handler.Delete)
+
+	id := uuid.New()
+	secret := &domain.Secret{ID: id, Name: testSecretName}
+	shortPrefix := id.String()[:8]
+	svc.On("GetSecretByName", mock.Anything, shortPrefix).Return(nil, errors.New(errors.NotFound, "not found"))
+	svc.On("ListSecrets", mock.Anything).Return([]*domain.Secret{secret}, nil)
+	svc.On("DeleteSecret", mock.Anything, id).Return(nil)
+
+	req, err := http.NewRequest(http.MethodDelete, secretsPath+"/"+shortPrefix, nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestSecretHandlerDelete(t *testing.T) {
 	t.Parallel()
 	t.Run("SuccessByID", func(t *testing.T) {

--- a/internal/handlers/secret_handler_test.go
+++ b/internal/handlers/secret_handler_test.go
@@ -189,6 +189,31 @@ func TestSecretHandlerGetByShortID(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestSecretHandlerGetByShortID_Ambiguous(t *testing.T) {
+	t.Parallel()
+	svc, handler, r := setupSecretHandlerTest(t)
+	defer svc.AssertExpectations(t)
+
+	r.GET(secretsPath+"/:id", handler.Get)
+
+	idA := uuid.MustParse("11111111-0000-0000-0000-000000000001")
+	idB := uuid.MustParse("11111111-0000-0000-0000-000000000002")
+	secretA := &domain.Secret{ID: idA, Name: "sec-a"}
+	secretB := &domain.Secret{ID: idB, Name: "sec-b"}
+	shortPrefix := idA.String()[:8]
+
+	svc.On("GetSecretByName", mock.Anything, shortPrefix).Return(nil, errors.New(errors.NotFound, "not found"))
+	svc.On("ListSecrets", mock.Anything).Return([]*domain.Secret{secretA, secretB}, nil)
+
+	req, err := http.NewRequest(http.MethodGet, secretsPath+"/"+shortPrefix, nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "ambiguous")
+}
+
 func TestSecretHandlerDeleteByShortID(t *testing.T) {
 	t.Parallel()
 	svc, handler, r := setupSecretHandlerTest(t)
@@ -209,6 +234,31 @@ func TestSecretHandlerDeleteByShortID(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSecretHandlerDeleteByShortID_Ambiguous(t *testing.T) {
+	t.Parallel()
+	svc, handler, r := setupSecretHandlerTest(t)
+	defer svc.AssertExpectations(t)
+
+	r.DELETE(secretsPath+"/:id", handler.Delete)
+
+	idA := uuid.MustParse("22222222-0000-0000-0000-000000000001")
+	idB := uuid.MustParse("22222222-0000-0000-0000-000000000002")
+	secretA := &domain.Secret{ID: idA, Name: "sec-a"}
+	secretB := &domain.Secret{ID: idB, Name: "sec-b"}
+	shortPrefix := idA.String()[:8]
+
+	svc.On("GetSecretByName", mock.Anything, shortPrefix).Return(nil, errors.New(errors.NotFound, "not found"))
+	svc.On("ListSecrets", mock.Anything).Return([]*domain.Secret{secretA, secretB}, nil)
+
+	req, err := http.NewRequest(http.MethodDelete, secretsPath+"/"+shortPrefix, nil)
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "ambiguous")
 }
 
 func TestSecretHandlerDelete(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `resolveShortID` helper in `SecretHandler` that resolves short IDs to full UUIDs via prefix matching
- The helper tries: (1) UUID parse, (2) name lookup, (3) short ID prefix match via `ListSecrets`
- Update `Get` and `Delete` handlers to use `resolveShortID` instead of direct UUID/name parsing

## Root Cause
The `Get` and `Delete` handlers only supported full UUID and name lookups. Short IDs like `78ee1b39` were rejected because they're neither valid UUIDs nor names.

## Test Plan
- [x] `go build ./internal/handlers/...` — passes
- [x] `go test -v ./internal/handlers/... -run Secret` — all tests pass

## Fixes
Fixes #474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Get and Delete now accept UUIDs, exact names, or short prefixes when identifying secrets, with improved case-insensitive name matching.

* **Bug Fixes**
  * Clearer errors for ambiguous or missing identifiers and consistent resolution across request paths.

* **Tests**
  * Expanded test coverage for name/short-prefix resolution, ambiguous matches, and error cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/519)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->