### PR TITLE
feat(iam): allow policies to be attached to RBAC roles

### DIFF
--- a/internal/core/domain/iam.go
+++ b/internal/core/domain/iam.go
@@ -39,3 +39,9 @@ type UserPolicy struct {
 	UserID   uuid.UUID `json:"user_id"`
 	PolicyID uuid.UUID `json:"policy_id"`
 }
+
+// RolePolicy maps a policy to an RBAC role.
+type RolePolicy struct {
+	RoleName string    `json:"role_name"`
+	PolicyID uuid.UUID `json:"policy_id"`
+}

--- a/internal/core/ports/iam.go
+++ b/internal/core/ports/iam.go
@@ -16,10 +16,15 @@ type IAMRepository interface {
 	UpdatePolicy(ctx context.Context, tenantID uuid.UUID, policy *domain.Policy) error
 	DeletePolicy(ctx context.Context, tenantID uuid.UUID, id uuid.UUID) error
 
-	// Policy Assignment
+	// User Policy Assignment
 	AttachPolicyToUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, policyID uuid.UUID) error
 	DetachPolicyFromUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, policyID uuid.UUID) error
 	GetPoliciesForUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID) ([]*domain.Policy, error)
+
+	// Role Policy Assignment
+	AttachPolicyToRole(ctx context.Context, tenantID uuid.UUID, roleName string, policyID uuid.UUID) error
+	DetachPolicyFromRole(ctx context.Context, tenantID uuid.UUID, roleName string, policyID uuid.UUID) error
+	GetPoliciesForRole(ctx context.Context, tenantID uuid.UUID, roleName string) ([]*domain.Policy, error)
 }
 
 // IAMService defines the business logic for IAM management.
@@ -33,6 +38,10 @@ type IAMService interface {
 	AttachPolicyToUser(ctx context.Context, userID uuid.UUID, policyID uuid.UUID) error
 	DetachPolicyFromUser(ctx context.Context, userID uuid.UUID, policyID uuid.UUID) error
 	GetPoliciesForUser(ctx context.Context, userID uuid.UUID) ([]*domain.Policy, error)
+
+	AttachPolicyToRole(ctx context.Context, roleName string, policyID uuid.UUID) error
+	DetachPolicyFromRole(ctx context.Context, roleName string, policyID uuid.UUID) error
+	GetPoliciesForRole(ctx context.Context, roleName string) ([]*domain.Policy, error)
 }
 
 // PolicyEvaluator defines the logic for evaluating access based on a set of policies.

--- a/internal/core/ports/mocks/iam_mocks.go
+++ b/internal/core/ports/mocks/iam_mocks.go
@@ -56,6 +56,22 @@ func (m *IAMRepository) GetPoliciesForUser(ctx context.Context, tenantID uuid.UU
 	return r0, args.Error(1)
 }
 
+func (m *IAMRepository) AttachPolicyToRole(ctx context.Context, tenantID uuid.UUID, roleName string, policyID uuid.UUID) error {
+	args := m.Called(ctx, tenantID, roleName, policyID)
+	return args.Error(0)
+}
+
+func (m *IAMRepository) DetachPolicyFromRole(ctx context.Context, tenantID uuid.UUID, roleName string, policyID uuid.UUID) error {
+	args := m.Called(ctx, tenantID, roleName, policyID)
+	return args.Error(0)
+}
+
+func (m *IAMRepository) GetPoliciesForRole(ctx context.Context, tenantID uuid.UUID, roleName string) ([]*domain.Policy, error) {
+	args := m.Called(ctx, tenantID, roleName)
+	r0, _ := args.Get(0).([]*domain.Policy)
+	return r0, args.Error(1)
+}
+
 // IAMService is a mock for ports.IAMService
 type IAMService struct {
 	mock.Mock
@@ -100,6 +116,22 @@ func (m *IAMService) DetachPolicyFromUser(ctx context.Context, userID uuid.UUID,
 
 func (m *IAMService) GetPoliciesForUser(ctx context.Context, userID uuid.UUID) ([]*domain.Policy, error) {
 	args := m.Called(ctx, userID)
+	r0, _ := args.Get(0).([]*domain.Policy)
+	return r0, args.Error(1)
+}
+
+func (m *IAMService) AttachPolicyToRole(ctx context.Context, roleName string, policyID uuid.UUID) error {
+	args := m.Called(ctx, roleName, policyID)
+	return args.Error(0)
+}
+
+func (m *IAMService) DetachPolicyFromRole(ctx context.Context, roleName string, policyID uuid.UUID) error {
+	args := m.Called(ctx, roleName, policyID)
+	return args.Error(0)
+}
+
+func (m *IAMService) GetPoliciesForRole(ctx context.Context, roleName string) ([]*domain.Policy, error) {
+	args := m.Called(ctx, roleName)
 	r0, _ := args.Get(0).([]*domain.Policy)
 	return r0, args.Error(1)
 }

--- a/internal/core/services/iam.go
+++ b/internal/core/services/iam.go
@@ -105,3 +105,30 @@ func (s *iamService) GetPoliciesForUser(ctx context.Context, userID uuid.UUID) (
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	return s.repo.GetPoliciesForUser(ctx, tenantID, userID)
 }
+
+func (s *iamService) AttachPolicyToRole(ctx context.Context, roleName string, policyID uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.repo.AttachPolicyToRole(ctx, tenantID, roleName, policyID); err != nil {
+		return err
+	}
+	if err := s.eventSvc.RecordEvent(ctx, "IAM_POLICY_ATTACH_ROLE", policyID.String(), "POLICY", map[string]interface{}{"role_name": roleName}); err != nil {
+		s.logger.Warn("failed to record event", "action", "IAM_POLICY_ATTACH_ROLE", "policy_id", policyID, "error", err)
+	}
+	return nil
+}
+
+func (s *iamService) DetachPolicyFromRole(ctx context.Context, roleName string, policyID uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.repo.DetachPolicyFromRole(ctx, tenantID, roleName, policyID); err != nil {
+		return err
+	}
+	if err := s.eventSvc.RecordEvent(ctx, "IAM_POLICY_DETACH_ROLE", policyID.String(), "POLICY", map[string]interface{}{"role_name": roleName}); err != nil {
+		s.logger.Warn("failed to record event", "action", "IAM_POLICY_DETACH_ROLE", "policy_id", policyID, "error", err)
+	}
+	return nil
+}
+
+func (s *iamService) GetPoliciesForRole(ctx context.Context, roleName string) ([]*domain.Policy, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	return s.repo.GetPoliciesForRole(ctx, tenantID, roleName)
+}

--- a/internal/core/services/mock_iam_test.go
+++ b/internal/core/services/mock_iam_test.go
@@ -110,6 +110,19 @@ func (m *MockIAMRepository) GetPoliciesForUser(ctx context.Context, tenantID, us
 	}
 	return args.Get(0).([]*domain.Policy), args.Error(1)
 }
+func (m *MockIAMRepository) AttachPolicyToRole(ctx context.Context, tenantID uuid.UUID, roleName string, policyID uuid.UUID) error {
+	return m.Called(ctx, tenantID, roleName, policyID).Error(0)
+}
+func (m *MockIAMRepository) DetachPolicyFromRole(ctx context.Context, tenantID uuid.UUID, roleName string, policyID uuid.UUID) error {
+	return m.Called(ctx, tenantID, roleName, policyID).Error(0)
+}
+func (m *MockIAMRepository) GetPoliciesForRole(ctx context.Context, tenantID uuid.UUID, roleName string) ([]*domain.Policy, error) {
+	args := m.Called(ctx, tenantID, roleName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Policy), args.Error(1)
+}
 
 // MockIdentityService
 type MockIdentityService struct {

--- a/internal/core/services/rbac.go
+++ b/internal/core/services/rbac.go
@@ -160,7 +160,11 @@ func (s *rbacService) HasPermission(ctx context.Context, userID uuid.UUID, tenan
 // Returns (allowed, stop) where stop=true means decision is final.
 func (s *rbacService) checkIAMPolicies(ctx context.Context, tenantID, userID uuid.UUID, permission domain.Permission, resource string, evalCtx map[string]interface{}) (bool, bool) {
 	policies, err := s.iamRepo.GetPoliciesForUser(ctx, tenantID, userID)
-	if err != nil || len(policies) == 0 {
+	if err != nil {
+		s.logger.Error("RBAC: failed to get user IAM policies, falling through to role policies", "user_id", userID, "tenant_id", tenantID, "error", err)
+		return false, false
+	}
+	if len(policies) == 0 {
 		return false, false
 	}
 	return s.evaluatePolicies(ctx, policies, permission, resource, evalCtx)
@@ -170,7 +174,11 @@ func (s *rbacService) checkIAMPolicies(ctx context.Context, tenantID, userID uui
 // Returns (allowed, stop) where stop=true means decision is final.
 func (s *rbacService) checkRoleIAMPolicies(ctx context.Context, tenantID uuid.UUID, roleName string, permission domain.Permission, resource string, evalCtx map[string]interface{}) (bool, bool) {
 	policies, err := s.iamRepo.GetPoliciesForRole(ctx, tenantID, roleName)
-	if err != nil || len(policies) == 0 {
+	if err != nil {
+		s.logger.Error("RBAC: failed to get role IAM policies, falling through to RBAC fallback", "role", roleName, "tenant_id", tenantID, "error", err)
+		return false, false
+	}
+	if len(policies) == 0 {
 		return false, false
 	}
 	return s.evaluatePolicies(ctx, policies, permission, resource, evalCtx)
@@ -178,9 +186,11 @@ func (s *rbacService) checkRoleIAMPolicies(ctx context.Context, tenantID uuid.UU
 
 // evaluatePolicies evaluates a set of policies and returns (allowed, stop).
 // stop=true means a final decision (Allow or Deny) was reached.
+// If evaluation fails, returns an error via the logger and (false, false) to continue to next policy source.
 func (s *rbacService) evaluatePolicies(ctx context.Context, policies []*domain.Policy, permission domain.Permission, resource string, evalCtx map[string]interface{}) (bool, bool) {
 	effect, err := s.evaluator.Evaluate(ctx, policies, string(permission), resource, evalCtx)
 	if err != nil {
+		s.logger.Error("RBAC: IAM policy evaluation failed, falling through to next policy source", "error", err, "permission", permission, "resource", resource)
 		return false, false
 	}
 	if effect == domain.EffectAllow {

--- a/internal/core/services/rbac.go
+++ b/internal/core/services/rbac.go
@@ -125,6 +125,23 @@ func (s *rbacService) HasPermission(ctx context.Context, userID uuid.UUID, tenan
 				}
 			}
 		}
+
+		// 2b. Check IAM Policies attached to the user's role
+		if roleName != "" {
+			rolePolicies, err := s.iamRepo.GetPoliciesForRole(ctx, tenantID, roleName)
+			if err == nil && len(rolePolicies) > 0 {
+				evalCtx := s.buildEvalCtx(ctx, tenantID)
+				effect, evalErr := s.evaluator.Evaluate(ctx, rolePolicies, string(permission), resource, evalCtx)
+				if evalErr == nil {
+					if effect == domain.EffectAllow {
+						return true, nil
+					}
+					if effect == domain.EffectDeny {
+						return false, nil
+					}
+				}
+			}
+		}
 	}
 	// 3. Fallback to Role-based logic
 	if roleName == domain.RoleAdmin {

--- a/internal/core/services/rbac.go
+++ b/internal/core/services/rbac.go
@@ -111,35 +111,17 @@ func (s *rbacService) HasPermission(ctx context.Context, userID uuid.UUID, tenan
 
 	// 2. Check Attached IAM Policies (if IAMRepo and Evaluator are provided)
 	if s.iamRepo != nil && s.evaluator != nil {
-		policies, err := s.iamRepo.GetPoliciesForUser(ctx, tenantID, userID)
-		if err == nil && len(policies) > 0 {
-			// Build evaluation context for IAM condition evaluation
-			evalCtx := s.buildEvalCtx(ctx, tenantID)
-			effect, evalErr := s.evaluator.Evaluate(ctx, policies, string(permission), resource, evalCtx)
-			if evalErr == nil {
-				if effect == domain.EffectAllow {
-					return true, nil
-				}
-				if effect == domain.EffectDeny {
-					return false, nil
-				}
-			}
+		evalCtx := s.buildEvalCtx(ctx, tenantID)
+
+		// Check user-attached policies
+		if allowed, stop := s.checkIAMPolicies(ctx, tenantID, userID, permission, resource, evalCtx); allowed || stop {
+			return allowed, nil
 		}
 
-		// 2b. Check IAM Policies attached to the user's role
+		// Check role-attached policies
 		if roleName != "" {
-			rolePolicies, err := s.iamRepo.GetPoliciesForRole(ctx, tenantID, roleName)
-			if err == nil && len(rolePolicies) > 0 {
-				evalCtx := s.buildEvalCtx(ctx, tenantID)
-				effect, evalErr := s.evaluator.Evaluate(ctx, rolePolicies, string(permission), resource, evalCtx)
-				if evalErr == nil {
-					if effect == domain.EffectAllow {
-						return true, nil
-					}
-					if effect == domain.EffectDeny {
-						return false, nil
-					}
-				}
+			if allowed, stop := s.checkRoleIAMPolicies(ctx, tenantID, roleName, permission, resource, evalCtx); allowed || stop {
+				return allowed, nil
 			}
 		}
 	}
@@ -172,6 +154,42 @@ func (s *rbacService) HasPermission(ctx context.Context, userID uuid.UUID, tenan
 
 	s.logger.Warn("RBAC: permission denied (role in DB but permission not listed)", "role", role.Name, "permission", permission, "resource", resource)
 	return false, nil
+}
+
+// checkIAMPolicies evaluates IAM policies attached directly to a user.
+// Returns (allowed, stop) where stop=true means decision is final.
+func (s *rbacService) checkIAMPolicies(ctx context.Context, tenantID, userID uuid.UUID, permission domain.Permission, resource string, evalCtx map[string]interface{}) (bool, bool) {
+	policies, err := s.iamRepo.GetPoliciesForUser(ctx, tenantID, userID)
+	if err != nil || len(policies) == 0 {
+		return false, false
+	}
+	return s.evaluatePolicies(ctx, policies, permission, resource, evalCtx)
+}
+
+// checkRoleIAMPolicies evaluates IAM policies attached to a user's role.
+// Returns (allowed, stop) where stop=true means decision is final.
+func (s *rbacService) checkRoleIAMPolicies(ctx context.Context, tenantID uuid.UUID, roleName string, permission domain.Permission, resource string, evalCtx map[string]interface{}) (bool, bool) {
+	policies, err := s.iamRepo.GetPoliciesForRole(ctx, tenantID, roleName)
+	if err != nil || len(policies) == 0 {
+		return false, false
+	}
+	return s.evaluatePolicies(ctx, policies, permission, resource, evalCtx)
+}
+
+// evaluatePolicies evaluates a set of policies and returns (allowed, stop).
+// stop=true means a final decision (Allow or Deny) was reached.
+func (s *rbacService) evaluatePolicies(ctx context.Context, policies []*domain.Policy, permission domain.Permission, resource string, evalCtx map[string]interface{}) (bool, bool) {
+	effect, err := s.evaluator.Evaluate(ctx, policies, string(permission), resource, evalCtx)
+	if err != nil {
+		return false, false
+	}
+	if effect == domain.EffectAllow {
+		return true, true
+	}
+	if effect == domain.EffectDeny {
+		return false, true
+	}
+	return false, false
 }
 
 func (s *rbacService) buildEvalCtx(ctx context.Context, tenantID uuid.UUID) map[string]interface{} {

--- a/internal/core/services/rbac_iam_test.go
+++ b/internal/core/services/rbac_iam_test.go
@@ -84,4 +84,63 @@ func TestRBACService_IAMIntegration(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, allowed)
 	})
+
+	t.Run("RolePolicyAllowsWhenRBPermissionsDeny", func(t *testing.T) {
+		// User has a custom role with limited permissions, but role-attached IAM policy grants access
+		tenantRepo.On("GetMembership", ctx, tenantID, userID).Return(&domain.TenantMember{UserID: userID, TenantID: tenantID, Role: "limited-user"}, nil).Once()
+		iamRepo.On("GetPoliciesForUser", ctx, tenantID, userID).Return([]*domain.Policy{}, nil).Once()
+		rolePolicies := []*domain.Policy{
+			{
+				Statements: []domain.Statement{
+					{Effect: domain.EffectAllow, Action: []string{"instance:launch"}, Resource: []string{"*"}},
+				},
+			},
+		}
+		iamRepo.On("GetPoliciesForRole", ctx, tenantID, "limited-user").Return(rolePolicies, nil).Once()
+		roleRepo.On("GetRoleByName", ctx, "limited-user").Return(&domain.Role{ID: uuid.New(), Name: "limited-user", Permissions: []domain.Permission{domain.PermissionInstanceRead}}, nil).Once()
+
+		// RBAC would deny (only read permission), but role IAM policy allows
+		allowed, err := svc.HasPermission(ctx, userID, tenantID, domain.PermissionInstanceLaunch, "*")
+		require.NoError(t, err)
+		assert.True(t, allowed)
+	})
+
+	t.Run("RolePolicyDenyOverridesRolePermission", func(t *testing.T) {
+		// User has admin role, but role-attached IAM policy denies instance:terminate
+		tenantRepo.On("GetMembership", ctx, tenantID, userID).Return(&domain.TenantMember{UserID: userID, TenantID: tenantID, Role: domain.RoleAdmin}, nil).Once()
+		iamRepo.On("GetPoliciesForUser", ctx, tenantID, userID).Return([]*domain.Policy{}, nil).Once()
+		rolePolicies := []*domain.Policy{
+			{
+				Statements: []domain.Statement{
+					{Effect: domain.EffectDeny, Action: []string{"instance:terminate"}, Resource: []string{"*"}},
+				},
+			},
+		}
+		iamRepo.On("GetPoliciesForRole", ctx, tenantID, domain.RoleAdmin).Return(rolePolicies, nil).Once()
+		roleRepo.On("GetRoleByName", mock.Anything, domain.RoleAdmin).Return(nil, nil).Once() // admin has hardcoded fallback
+
+		// RBAC would allow (admin), but role IAM policy denies
+		allowed, err := svc.HasPermission(ctx, userID, tenantID, domain.PermissionInstanceTerminate, "*")
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
+
+	t.Run("UserPolicyShortCircuitsBeforeRolePolicy", func(t *testing.T) {
+		// User has deny policy, role has allow policy - user policy should win (short-circuit)
+		tenantRepo.On("GetMembership", ctx, tenantID, userID).Return(&domain.TenantMember{UserID: userID, TenantID: tenantID, Role: "some-role"}, nil).Once()
+		userPolicies := []*domain.Policy{
+			{
+				Statements: []domain.Statement{
+					{Effect: domain.EffectDeny, Action: []string{"instance:launch"}, Resource: []string{"*"}},
+				},
+			},
+		}
+		iamRepo.On("GetPoliciesForUser", ctx, tenantID, userID).Return(userPolicies, nil).Once()
+		// GetPoliciesForRole should NOT be called because user policy already short-circuits
+
+		// User policy denies, so should be denied (role policy not evaluated due to short-circuit)
+		allowed, err := svc.HasPermission(ctx, userID, tenantID, domain.PermissionInstanceLaunch, "*")
+		require.NoError(t, err)
+		assert.False(t, allowed)
+	})
 }

--- a/internal/core/services/rbac_iam_test.go
+++ b/internal/core/services/rbac_iam_test.go
@@ -76,6 +76,7 @@ func TestRBACService_IAMIntegration(t *testing.T) {
 		// Use a custom role name like "custom-dev" so it doesn't match defaultRoleAdmin/Viewer fallbacks
 		tenantRepo.On("GetMembership", ctx, tenantID, userID).Return(&domain.TenantMember{UserID: userID, TenantID: tenantID, Role: "custom-dev"}, nil).Once()
 		iamRepo.On("GetPoliciesForUser", ctx, tenantID, userID).Return([]*domain.Policy{}, nil).Once()
+		iamRepo.On("GetPoliciesForRole", ctx, tenantID, "custom-dev").Return([]*domain.Policy{}, nil).Once()
 		roleRepo.On("GetRoleByName", ctx, "custom-dev").Return(&domain.Role{ID: uuid.New(), Name: "custom-dev", Permissions: []domain.Permission{domain.PermissionInstanceLaunch}}, nil).Once()
 
 		// Fallback logic for custom role

--- a/internal/core/services/rbac_unit_test.go
+++ b/internal/core/services/rbac_unit_test.go
@@ -46,6 +46,7 @@ func TestRBACService_Unit(t *testing.T) {
 	t.Run("HasPermission_AdminRole", func(t *testing.T) {
 		mockTenantRepo.On("GetMembership", mock.Anything, tenantID, userID).Return(&domain.TenantMember{Role: domain.RoleAdmin}, nil).Once()
 		mockIAMRepo.On("GetPoliciesForUser", mock.Anything, tenantID, userID).Return([]*domain.Policy{}, nil).Once()
+		mockIAMRepo.On("GetPoliciesForRole", mock.Anything, tenantID, domain.RoleAdmin).Return([]*domain.Policy{}, nil).Once()
 		mockRoleRepo.On("GetRoleByName", mock.Anything, domain.RoleAdmin).Return(nil, errors.New(errors.NotFound, "not found")).Once() // Fallback to hardcoded
 
 		allowed, err := svc.HasPermission(ctx, userID, tenantID, domain.PermissionInstanceRead, "*")
@@ -68,6 +69,7 @@ func TestRBACService_Unit(t *testing.T) {
 	t.Run("Authorize_Denied", func(t *testing.T) {
 		mockTenantRepo.On("GetMembership", mock.Anything, tenantID, userID).Return(&domain.TenantMember{Role: domain.RoleViewer}, nil).Once()
 		mockIAMRepo.On("GetPoliciesForUser", mock.Anything, tenantID, userID).Return([]*domain.Policy{}, nil).Once()
+		mockIAMRepo.On("GetPoliciesForRole", mock.Anything, tenantID, domain.RoleViewer).Return([]*domain.Policy{}, nil).Once()
 		mockRoleRepo.On("GetRoleByName", mock.Anything, domain.RoleViewer).Return(&domain.Role{
 			Name:        domain.RoleViewer,
 			Permissions: []domain.Permission{domain.PermissionInstanceRead},

--- a/internal/repositories/postgres/iam_repo.go
+++ b/internal/repositories/postgres/iam_repo.go
@@ -166,3 +166,57 @@ func (r *iamRepository) GetPoliciesForUser(ctx context.Context, tenantID uuid.UU
 	}
 	return policies, nil
 }
+
+func (r *iamRepository) AttachPolicyToRole(ctx context.Context, tenantID uuid.UUID, roleName string, policyID uuid.UUID) error {
+	// Verify policy belongs to tenant
+	if _, err := r.GetPolicyByID(ctx, tenantID, policyID); err != nil {
+		return err
+	}
+
+	query := `INSERT INTO role_policies (role_name, policy_id, tenant_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
+	_, err := r.db.Exec(ctx, query, roleName, policyID, tenantID)
+	return err
+}
+
+func (r *iamRepository) DetachPolicyFromRole(ctx context.Context, tenantID uuid.UUID, roleName string, policyID uuid.UUID) error {
+	query := `DELETE FROM role_policies WHERE role_name = $1 AND policy_id = $2 AND tenant_id = $3`
+	result, err := r.db.Exec(ctx, query, roleName, policyID, tenantID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "policy assignment not found")
+	}
+	return nil
+}
+
+func (r *iamRepository) GetPoliciesForRole(ctx context.Context, tenantID uuid.UUID, roleName string) ([]*domain.Policy, error) {
+	query := `
+		SELECT p.id, p.tenant_id, p.name, p.description, p.statements
+		FROM policies p
+		JOIN role_policies rp ON p.id = rp.policy_id
+		WHERE rp.role_name = $1 AND rp.tenant_id = $2
+	`
+	rows, err := r.db.Query(ctx, query, roleName, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var policies []*domain.Policy
+	for rows.Next() {
+		var p domain.Policy
+		var statementsJSON []byte
+		if err := rows.Scan(&p.ID, &p.TenantID, &p.Name, &p.Description, &statementsJSON); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(statementsJSON, &p.Statements); err != nil {
+			return nil, err
+		}
+		policies = append(policies, &p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return policies, nil
+}

--- a/internal/repositories/postgres/migrations/100_create_role_policies.down.sql
+++ b/internal/repositories/postgres/migrations/100_create_role_policies.down.sql
@@ -1,1 +1,2 @@
+-- +goose Down
 DROP TABLE IF EXISTS role_policies;

--- a/internal/repositories/postgres/migrations/100_create_role_policies.down.sql
+++ b/internal/repositories/postgres/migrations/100_create_role_policies.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS role_policies;

--- a/internal/repositories/postgres/migrations/100_create_role_policies.up.sql
+++ b/internal/repositories/postgres/migrations/100_create_role_policies.up.sql
@@ -1,0 +1,12 @@
+-- Allow IAM policies to be attached to RBAC roles
+CREATE TABLE IF NOT EXISTS role_policies (
+    role_name VARCHAR(255) NOT NULL,
+    policy_id UUID NOT NULL,
+    tenant_id UUID NOT NULL,
+    attached_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (role_name, policy_id),
+    FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_role_policies_role_name ON role_policies(role_name);
+CREATE INDEX idx_role_policies_tenant_id ON role_policies(tenant_id);

--- a/internal/repositories/postgres/migrations/100_create_role_policies.up.sql
+++ b/internal/repositories/postgres/migrations/100_create_role_policies.up.sql
@@ -1,3 +1,4 @@
+-- +goose Up
 -- Allow IAM policies to be attached to RBAC roles
 CREATE TABLE IF NOT EXISTS role_policies (
     role_name VARCHAR(255) NOT NULL,
@@ -8,5 +9,5 @@ CREATE TABLE IF NOT EXISTS role_policies (
     FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE
 );
 
-CREATE INDEX idx_role_policies_role_name ON role_policies(role_name);
-CREATE INDEX idx_role_policies_tenant_id ON role_policies(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_role_policies_role_name ON role_policies(role_name);
+CREATE INDEX IF NOT EXISTS idx_role_policies_tenant_id ON role_policies(tenant_id);


### PR DESCRIPTION
## Summary
- Add `role_policies` table to attach IAM policies to RBAC roles
- Add `AttachPolicyToRole`, `DetachPolicyFromRole`, `GetPoliciesForRole` methods
- Modify `HasPermission` to check role-attached IAM policies after user policies

## Changes
- **migrations/100_create_role_policies**: New table for role-policy bindings
- **domain/iam.go**: Add `RolePolicy` struct
- **ports/iam.go**: Add role policy methods to IAMRepository and IAMService interfaces
- **repositories/postgres/iam_repo.go**: Implement role policy methods
- **services/iam.go**: Add role policy service methods
- **services/rbac.go**: Check role-attached policies in HasPermission

## How it Works
1. User has direct IAM policies (via `user_policies`) - checked first
2. User's role has IAM policies (via `role_policies`) - checked second ← NEW
3. Fallback to role-based permissions

This allows roles like `developer` to have IAM policies with conditions attached directly to the role.