### PR TITLE
fix: enforce read quorum in Coordinator.Read

### DIFF
--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -31,6 +31,7 @@ type Coordinator struct {
 	clients      map[string]pb.StorageNodeClient
 	replicaCount int
 	writeQuorum  int
+	readQuorum   int
 	stopCh       chan struct{}
 	lastStatus   *domain.StorageCluster
 	mu           sync.RWMutex
@@ -46,6 +47,7 @@ func NewCoordinator(ctx context.Context, ring *ConsistentHashRing, clients map[s
 		clients:      clients,
 		replicaCount: replicaCount,
 		writeQuorum:  (replicaCount / 2) + 1,
+		readQuorum:   (replicaCount / 2) + 1,
 		stopCh:       make(chan struct{}),
 	}
 	go c.startSyncLoop(ctx)
@@ -296,9 +298,9 @@ func (c *Coordinator) Read(ctx context.Context, bucket, key string) (io.ReadClos
 	results := c.collectReadResults(ctx, bucket, key, nodes)
 	winner, repairNodes, foundCount := c.processReadResults(results)
 
-	if foundCount == 0 {
-		platform.StorageOperations.WithLabelValues("cluster_read", bucket, "not_found").Inc()
-		return nil, fmt.Errorf("object not found")
+	if foundCount < c.readQuorum {
+		platform.StorageOperations.WithLabelValues("cluster_read", bucket, "quorum_failure").Inc()
+		return nil, fmt.Errorf("read quorum failed (%d/%d)", foundCount, c.readQuorum)
 	}
 
 	// Wrapper to handle streaming read and async repair

--- a/internal/storage/coordinator/service_test.go
+++ b/internal/storage/coordinator/service_test.go
@@ -403,3 +403,80 @@ func TestCoordinatorRepairStreamFailureContinues(t *testing.T) {
 	smRepair3.AssertNumberOfCalls(t, "Send", 2)
 	smRepair3.AssertCalled(t, "CloseAndRecv")
 }
+
+func TestCoordinatorReadQuorum(t *testing.T) {
+	ts := time.Now().UnixNano()
+
+	tests := []struct {
+		name          string
+		replicaCount  int
+		setupMocks    func(c1, c2, c3 *MockStorageNodeClient) []*MockStoreClient
+		expectedError string
+	}{
+		{
+			name:         "Failure_OnlyOneNodeResponds",
+			replicaCount: 3,
+			setupMocks: func(c1, c2, c3 *MockStorageNodeClient) []*MockStoreClient {
+				// Node 1: has data (counted in foundCount)
+				rm1 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+					{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: ts}}},
+					{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("data")}},
+				}}
+				c1.On("Retrieve", mock.Anything, mock.Anything).Return(rm1, nil)
+				// Node 2: Retrieve error
+				c2.On("Retrieve", mock.Anything, mock.Anything).Return(nil, errors.New("node down"))
+				// Node 3: Retrieve error
+				c3.On("Retrieve", mock.Anything, mock.Anything).Return(nil, errors.New("node down"))
+				return nil
+			},
+			expectedError: "read quorum failed (1/2)",
+		},
+		{
+			name:         "Success_TwoOfThreeRespond",
+			replicaCount: 3,
+			setupMocks: func(c1, c2, c3 *MockStorageNodeClient) []*MockStoreClient {
+				rm1 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+					{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: ts}}},
+					{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("data")}},
+				}}
+				c1.On("Retrieve", mock.Anything, mock.Anything).Return(rm1, nil)
+				rm2 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+					{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: ts}}},
+					{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("data")}},
+				}}
+				c2.On("Retrieve", mock.Anything, mock.Anything).Return(rm2, nil)
+				c3.On("Retrieve", mock.Anything, mock.Anything).Return(nil, errors.New("node down"))
+				return nil
+			},
+			expectedError: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ring := NewConsistentHashRing(10)
+			ring.AddNode(node1)
+			ring.AddNode(node2)
+			ring.AddNode(node3)
+
+			c1, c2, c3 := new(MockStorageNodeClient), new(MockStorageNodeClient), new(MockStorageNodeClient)
+			tt.setupMocks(c1, c2, c3)
+
+			clients := map[string]pb.StorageNodeClient{node1: c1, node2: c2, node3: c3}
+			coord := NewCoordinator(context.Background(), ring, clients, tt.replicaCount)
+			defer coord.Stop()
+
+			r, err := coord.Read(context.Background(), "b", "k")
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+				data, readErr := io.ReadAll(r)
+				require.NoError(t, readErr)
+				assert.Equal(t, "data", string(data))
+				require.NoError(t, r.Close())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add read quorum enforcement to `Coordinator.Read()`. Before this fix, reads would succeed if even 1 replica responded. Now require at least `(replicaCount/2)+1` replicas to respond, matching the write quorum formula.

## Changes

- `service.go`: Add `readQuorum` field to `Coordinator` struct
- `service.go`: Initialize `readQuorum` in `NewCoordinator` with same formula as `writeQuorum`  
- `service.go`: Replace `foundCount == 0` check with `foundCount < c.readQuorum` in `Read()`
- `service_test.go`: Add `TestCoordinatorReadQuorum` table-driven test

## Why

The `Read` operation read from multiple replicas but only failed if ALL replicas were down. With `replicaCount=3`, reads would succeed with only 1 of 3 replicas responding — violating the quorum guarantee that writes already enforce.

## Test plan

- [x] `go test ./internal/storage/coordinator/...` — all tests pass
- [x] New test verifies reads fail with quorum error when only 1 of 3 nodes responds
- [x] New test verifies reads succeed when 2 of 3 nodes respond

## Related Issues

Fixes #504