### PR TITLE
fix(sdk): use Response[T] wrapper for snapshot methods (#423)

### DIFF
--- a/cmd/cloud/snapshot_cli_test.go
+++ b/cmd/cloud/snapshot_cli_test.go
@@ -67,12 +67,14 @@ func TestSnapshotCreateCmd(t *testing.T) {
 			return
 		}
 		payload := map[string]interface{}{
-			"id":          snapshotTestID,
-			"volume_id":   volID.String(),
-			"volume_name": "data",
-			"size_gb":     10,
-			"status":      "CREATING",
-			"created_at":  time.Now().UTC().Format(time.RFC3339),
+			"data": map[string]interface{}{
+				"id":          snapshotTestID,
+				"volume_id":   volID.String(),
+				"volume_name": "data",
+				"size_gb":     10,
+				"status":      "CREATING",
+				"created_at":  time.Now().UTC().Format(time.RFC3339),
+			},
 		}
 		_ = json.NewEncoder(w).Encode(payload)
 	}))
@@ -105,12 +107,14 @@ func TestSnapshotRestoreCmd(t *testing.T) {
 			return
 		}
 		payload := map[string]interface{}{
-			"id":         uuid.New().String(),
-			"name":       "restore-vol",
-			"size_gb":    10,
-			"status":     "AVAILABLE",
-			"created_at": time.Now().UTC().Format(time.RFC3339),
-			"updated_at": time.Now().UTC().Format(time.RFC3339),
+			"data": map[string]interface{}{
+				"id":         uuid.New().String(),
+				"name":       "restore-vol",
+				"size_gb":    10,
+				"status":     "AVAILABLE",
+				"created_at": time.Now().UTC().Format(time.RFC3339),
+				"updated_at": time.Now().UTC().Format(time.RFC3339),
+			},
 		}
 		_ = json.NewEncoder(w).Encode(payload)
 	}))

--- a/pkg/sdk/snapshot.go
+++ b/pkg/sdk/snapshot.go
@@ -21,12 +21,12 @@ func (c *Client) CreateSnapshot(ctx context.Context, volumeIDOrName string, desc
 		"description": description,
 	}
 
-	var snapshot domain.Snapshot
-	err = c.postWithContext(ctx, "/snapshots", req, &snapshot)
+	var res Response[domain.Snapshot]
+	err = c.postWithContext(ctx, "/snapshots", req, &res)
 	if err != nil {
 		return nil, err
 	}
-	return &snapshot, nil
+	return &res.Data, nil
 }
 
 func (c *Client) ListSnapshots() ([]*domain.Snapshot, error) {
@@ -46,12 +46,12 @@ func (c *Client) GetSnapshot(idOrName string) (*domain.Snapshot, error) {
 	if err != nil {
 		return nil, err
 	}
-	var snapshot domain.Snapshot
-	err = c.get(fmt.Sprintf("/snapshots/%s", id), &snapshot)
+	var res Response[domain.Snapshot]
+	err = c.get(fmt.Sprintf("/snapshots/%s", id), &res)
 	if err != nil {
 		return nil, err
 	}
-	return &snapshot, nil
+	return &res.Data, nil
 }
 
 func (c *Client) DeleteSnapshot(idOrName string) error {
@@ -77,10 +77,10 @@ func (c *Client) RestoreSnapshot(idOrName string, newVolumeName string) (*domain
 		"new_volume_name": newVolumeName,
 	}
 
-	var vol domain.Volume
-	err = c.post(fmt.Sprintf("/snapshots/%s/restore", id), req, &vol)
+	var res Response[domain.Volume]
+	err = c.post(fmt.Sprintf("/snapshots/%s/restore", id), req, &res)
 	if err != nil {
 		return nil, err
 	}
-	return &vol, nil
+	return &res.Data, nil
 }

--- a/pkg/sdk/snapshot_test.go
+++ b/pkg/sdk/snapshot_test.go
@@ -57,7 +57,7 @@ func TestClientCreateSnapshot(t *testing.T) {
 		assert.Equal(t, expectedSnapshot.Description, req["description"])
 
 		w.Header().Set(snapshotContentType, snapshotApplicationJSON)
-		_ = json.NewEncoder(w).Encode(expectedSnapshot)
+		_ = json.NewEncoder(w).Encode(Response[domain.Snapshot]{Data: expectedSnapshot})
 	}))
 	defer server.Close()
 
@@ -102,7 +102,7 @@ func TestClientGetSnapshot(t *testing.T) {
 		assert.Equal(t, http.MethodGet, r.Method)
 
 		w.Header().Set(snapshotContentType, snapshotApplicationJSON)
-		_ = json.NewEncoder(w).Encode(expectedSnapshot)
+		_ = json.NewEncoder(w).Encode(Response[domain.Snapshot]{Data: expectedSnapshot})
 	}))
 	defer server.Close()
 
@@ -149,7 +149,7 @@ func TestClientRestoreSnapshot(t *testing.T) {
 		assert.Equal(t, newVolumeName, req["new_volume_name"])
 
 		w.Header().Set(snapshotContentType, snapshotApplicationJSON)
-		_ = json.NewEncoder(w).Encode(expectedVolume)
+		_ = json.NewEncoder(w).Encode(Response[domain.Volume]{Data: expectedVolume})
 	}))
 	defer server.Close()
 


### PR DESCRIPTION
## Summary
- Fix `CreateSnapshot`, `GetSnapshot`, and `RestoreSnapshot` in the SDK to unmarshal API responses using `Response[T]` wrapper instead of direct struct unmarshalling
- Fix test mock servers to encode responses in `{"data": ...}` format, matching the actual API

## Problem
The SDK's snapshot methods unmarshalled the API response directly into `domain.Snapshot` at the root level. But the API returns `{"data": {...}}` via `httputil.Success`. This caused all struct fields to remain at zero values — including the ID, which showed as `00000000-0000-0000-0000-000000000000`.

## Changes
- `pkg/sdk/snapshot.go`: Use `Response[T]` wrapper for `CreateSnapshot`, `GetSnapshot`, `RestoreSnapshot`
- `pkg/sdk/snapshot_test.go`: Fix mock server encoding to use `Response[T]` format

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./pkg/sdk/...` passes

## Fixes
Fixes #423