### PR TITLE
fix(sg): support name-based lookup for add-rule and optional --vpc-id for list

### DIFF
--- a/cmd/cloud/sg.go
+++ b/cmd/cloud/sg.go
@@ -58,10 +58,6 @@ var sgListCmd = &cobra.Command{
 	Short: "List security groups",
 	Run: func(cmd *cobra.Command, args []string) {
 		vpcID, _ := cmd.Flags().GetString(flagVPCID)
-		if vpcID == "" {
-			fmt.Printf("Error: --%s is required\n", flagVPCID)
-			return
-		}
 
 		client := createClient(opts)
 		groups, err := client.ListSecurityGroups(vpcID)

--- a/internal/core/ports/security_group.go
+++ b/internal/core/ports/security_group.go
@@ -16,6 +16,8 @@ type SecurityGroupRepository interface {
 	GetByID(ctx context.Context, id uuid.UUID) (*domain.SecurityGroup, error)
 	// GetByName retrieves a security group by name within a specific VPC.
 	GetByName(ctx context.Context, vpcID uuid.UUID, name string) (*domain.SecurityGroup, error)
+	// GetByNameAcrossVPCs retrieves a security group by name across all VPCs in the tenant.
+	GetByNameAcrossVPCs(ctx context.Context, name string) (*domain.SecurityGroup, error)
 	// ListByVPC returns all security groups belonging to a VPC.
 	ListByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.SecurityGroup, error)
 	// AddRule appends a new traffic filtering rule to an existing group.
@@ -49,7 +51,7 @@ type SecurityGroupService interface {
 	DeleteGroup(ctx context.Context, id uuid.UUID) error
 
 	// AddRule adds an ingress or egress firewall rule to a group.
-	AddRule(ctx context.Context, groupID uuid.UUID, rule domain.SecurityRule) (*domain.SecurityRule, error)
+	AddRule(ctx context.Context, idOrName string, rule domain.SecurityRule) (*domain.SecurityRule, error)
 	// RemoveRule deletes an existing firewall rule.
 	RemoveRule(ctx context.Context, ruleID uuid.UUID) error
 

--- a/internal/core/services/mock_network_test.go
+++ b/internal/core/services/mock_network_test.go
@@ -251,6 +251,13 @@ func (m *MockSecurityGroupRepo) GetByName(ctx context.Context, vpcID uuid.UUID, 
 	}
 	return args.Get(0).(*domain.SecurityGroup), args.Error(1)
 }
+func (m *MockSecurityGroupRepo) GetByNameAcrossVPCs(ctx context.Context, name string) (*domain.SecurityGroup, error) {
+	args := m.Called(ctx, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.SecurityGroup), args.Error(1)
+}
 func (m *MockSecurityGroupRepo) ListByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.SecurityGroup, error) {
 	args := m.Called(ctx, vpcID)
 	if args.Get(0) == nil {

--- a/internal/core/services/security_group.go
+++ b/internal/core/services/security_group.go
@@ -174,12 +174,17 @@ func (s *SecurityGroupService) DeleteGroup(ctx context.Context, id uuid.UUID) er
 	return nil
 }
 
-func (s *SecurityGroupService) AddRule(ctx context.Context, groupID uuid.UUID, rule domain.SecurityRule) (*domain.SecurityRule, error) {
+func (s *SecurityGroupService) AddRule(ctx context.Context, idOrName string, rule domain.SecurityRule) (*domain.SecurityRule, error) {
 	ctx, span := otel.Tracer(securityGroupTracer).Start(ctx, "AddRule")
 	defer span.End()
 
 	userID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	groupID, err := s.resolveGroupID(ctx, idOrName)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionSgUpdate, groupID.String()); err != nil {
 		return nil, err
@@ -218,6 +223,18 @@ func (s *SecurityGroupService) AddRule(ctx context.Context, groupID uuid.UUID, r
 	}
 
 	return &rule, nil
+}
+
+func (s *SecurityGroupService) resolveGroupID(ctx context.Context, idOrName string) (uuid.UUID, error) {
+	id, err := uuid.Parse(idOrName)
+	if err == nil {
+		return id, nil
+	}
+	sg, err := s.repo.GetByNameAcrossVPCs(ctx, idOrName)
+	if err != nil {
+		return uuid.Nil, errors.Wrap(errors.NotFound, "security group not found", err)
+	}
+	return sg.ID, nil
 }
 
 func (s *SecurityGroupService) RemoveRule(ctx context.Context, ruleID uuid.UUID) error {

--- a/internal/core/services/security_group.go
+++ b/internal/core/services/security_group.go
@@ -232,7 +232,10 @@ func (s *SecurityGroupService) resolveGroupID(ctx context.Context, idOrName stri
 	}
 	sg, err := s.repo.GetByNameAcrossVPCs(ctx, idOrName)
 	if err != nil {
-		return uuid.Nil, errors.Wrap(errors.NotFound, "security group not found", err)
+		if errors.Is(err, errors.NotFound) {
+			return uuid.Nil, errors.Wrap(errors.NotFound, "security group not found", err)
+		}
+		return uuid.Nil, err
 	}
 	return sg.ID, nil
 }

--- a/internal/core/services/security_group_unit_test.go
+++ b/internal/core/services/security_group_unit_test.go
@@ -57,6 +57,23 @@ func TestSecurityGroupService_Unit(t *testing.T) {
 		assert.NotNil(t, res)
 	})
 
+	t.Run("AddRule_ByName", func(t *testing.T) {
+		sgID := uuid.New()
+		sg := &domain.SecurityGroup{ID: sgID, UserID: userID, VPCID: vpcID, Name: "my-sg"}
+		rule := domain.SecurityRule{Protocol: "tcp", PortMin: 80, PortMax: 80, Direction: domain.RuleIngress}
+
+		mockRepo.On("GetByNameAcrossVPCs", mock.Anything, "my-sg").Return(sg, nil).Once()
+		mockRepo.On("GetByID", mock.Anything, sgID).Return(sg, nil).Once()
+		mockRepo.On("AddRule", mock.Anything, mock.Anything).Return(nil).Once()
+		mockVpcRepo.On("GetByID", mock.Anything, vpcID).Return(&domain.VPC{ID: vpcID, NetworkID: "net-1"}, nil).Maybe()
+		mockNetwork.On("AddFlowRule", mock.Anything, "net-1", mock.Anything).Return(nil).Maybe()
+		mockAuditSvc.On("Log", mock.Anything, userID, "security_group.add_rule", "security_group", sgID.String(), mock.Anything).Return(nil).Maybe()
+
+		res, err := svc.AddRule(ctx, "my-sg", rule)
+		require.NoError(t, err)
+		assert.NotNil(t, res)
+	})
+
 	t.Run("GetGroup_ByID", func(t *testing.T) {
 		sgID := uuid.New()
 		sg := &domain.SecurityGroup{ID: sgID, UserID: userID, VPCID: vpcID, Name: "test-sg"}

--- a/internal/core/services/security_group_unit_test.go
+++ b/internal/core/services/security_group_unit_test.go
@@ -52,7 +52,7 @@ func TestSecurityGroupService_Unit(t *testing.T) {
 		mockNetwork.On("AddFlowRule", mock.Anything, "net-1", mock.Anything).Return(nil).Maybe()
 		mockAuditSvc.On("Log", mock.Anything, userID, "security_group.add_rule", "security_group", sgID.String(), mock.Anything).Return(nil).Maybe()
 
-		res, err := svc.AddRule(ctx, sgID, rule)
+		res, err := svc.AddRule(ctx, sgID.String(), rule)
 		require.NoError(t, err)
 		assert.NotNil(t, res)
 	})

--- a/internal/handlers/security_group_handler.go
+++ b/internal/handlers/security_group_handler.go
@@ -167,12 +167,7 @@ func (h *SecurityGroupHandler) Delete(c *gin.Context) {
 // @Failure 500 {object} httputil.Response
 // @Router /security-groups/{id}/rules [post]
 func (h *SecurityGroupHandler) AddRule(c *gin.Context) {
-	groupIDStr := c.Param("id")
-	groupID, err := uuid.Parse(groupIDStr)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid group_id"})
-		return
-	}
+	idOrName := c.Param("id")
 
 	var req domain.SecurityRule
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -180,7 +175,7 @@ func (h *SecurityGroupHandler) AddRule(c *gin.Context) {
 		return
 	}
 
-	rule, err := h.svc.AddRule(c.Request.Context(), groupID, req)
+	rule, err := h.svc.AddRule(c.Request.Context(), idOrName, req)
 	if err != nil {
 		httputil.Error(c, err)
 		return

--- a/internal/handlers/security_group_handler.go
+++ b/internal/handlers/security_group_handler.go
@@ -169,6 +169,13 @@ func (h *SecurityGroupHandler) Delete(c *gin.Context) {
 func (h *SecurityGroupHandler) AddRule(c *gin.Context) {
 	idOrName := c.Param("id")
 
+	if idOrName != "" {
+		if _, err := uuid.Parse(idOrName); err != nil && isUUIDLike(idOrName) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid group_id"})
+			return
+		}
+	}
+
 	var req domain.SecurityRule
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -182,6 +189,18 @@ func (h *SecurityGroupHandler) AddRule(c *gin.Context) {
 	}
 
 	httputil.Success(c, http.StatusCreated, rule)
+}
+
+func isUUIDLike(s string) bool {
+	if len(s) < 8 || len(s) > 36 {
+		return false
+	}
+	for _, c := range s {
+		if c != '-' && (c < '0' || c > '9') && (c < 'a' || c > 'f') && (c < 'A' || c > 'F') {
+			return false
+		}
+	}
+	return true
 }
 
 // Attach attaches a security group to an instance

--- a/internal/handlers/security_group_handler_test.go
+++ b/internal/handlers/security_group_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/core/domain"
+	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -60,8 +61,8 @@ func (m *mockSecurityGroupService) DeleteGroup(ctx context.Context, id uuid.UUID
 	return args.Error(0)
 }
 
-func (m *mockSecurityGroupService) AddRule(ctx context.Context, groupID uuid.UUID, rule domain.SecurityRule) (*domain.SecurityRule, error) {
-	args := m.Called(ctx, groupID, rule)
+func (m *mockSecurityGroupService) AddRule(ctx context.Context, idOrName string, rule domain.SecurityRule) (*domain.SecurityRule, error) {
+	args := m.Called(ctx, idOrName, rule)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
@@ -180,7 +181,7 @@ func TestSecurityGroupHandlerAddRule(t *testing.T) {
 	groupID := uuid.New()
 	rule := domain.SecurityRule{Protocol: "tcp", PortMin: 80, PortMax: 80}
 
-	svc.On("AddRule", mock.Anything, groupID, rule).Return(&rule, nil)
+	svc.On("AddRule", mock.Anything, groupID.String(), rule).Return(&rule, nil)
 
 	body, _ := json.Marshal(rule)
 	w := httptest.NewRecorder()
@@ -393,12 +394,14 @@ func TestSecurityGroupHandlerErrorPaths(t *testing.T) {
 	})
 
 	t.Run("AddRuleInvalidID", func(t *testing.T) {
-		_, handler, _ := setupSecurityGroupHandlerTest(t)
+		svc, handler, _ := setupSecurityGroupHandlerTest(t)
+		svc.On("AddRule", mock.Anything, "invalid", mock.Anything).Return(nil, errors.New(errors.NotFound, "not found"))
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
 		c.Params = gin.Params{{Key: "id", Value: "invalid"}}
+		c.Request = httptest.NewRequest("POST", "/", bytes.NewBufferString("{}"))
 		handler.AddRule(c)
-		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
 
 	t.Run("AddRuleInvalidJSON", func(t *testing.T) {
@@ -414,7 +417,7 @@ func TestSecurityGroupHandlerErrorPaths(t *testing.T) {
 	t.Run("AddRuleServiceError", func(t *testing.T) {
 		svc, handler, _ := setupSecurityGroupHandlerTest(t)
 		groupID := uuid.New()
-		svc.On("AddRule", mock.Anything, groupID, mock.Anything).Return(nil, context.DeadlineExceeded)
+		svc.On("AddRule", mock.Anything, groupID.String(), mock.Anything).Return(nil, context.DeadlineExceeded)
 		r := domain.SecurityRule{}
 		body, _ := json.Marshal(r)
 		w := httptest.NewRecorder()

--- a/internal/repositories/k8s/kubeadm_provisioner_test.go
+++ b/internal/repositories/k8s/kubeadm_provisioner_test.go
@@ -163,8 +163,8 @@ func (m *MockSecurityGroupService) ListGroups(ctx context.Context, vpcID uuid.UU
 func (m *MockSecurityGroupService) DeleteGroup(ctx context.Context, id uuid.UUID) error {
 	return m.Called(ctx, id).Error(0)
 }
-func (m *MockSecurityGroupService) AddRule(ctx context.Context, groupID uuid.UUID, rule domain.SecurityRule) (*domain.SecurityRule, error) {
-	args := m.Called(ctx, groupID, rule)
+func (m *MockSecurityGroupService) AddRule(ctx context.Context, idOrName string, rule domain.SecurityRule) (*domain.SecurityRule, error) {
+	args := m.Called(ctx, idOrName, rule)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/internal/repositories/k8s/provisioner_unit_test.go
+++ b/internal/repositories/k8s/provisioner_unit_test.go
@@ -46,7 +46,7 @@ func (m *mockSGSvc) ListGroups(ctx context.Context, v uuid.UUID) ([]*domain.Secu
 	return nil, nil
 }
 func (m *mockSGSvc) DeleteGroup(ctx context.Context, id uuid.UUID) error { return nil }
-func (m *mockSGSvc) AddRule(ctx context.Context, sgID uuid.UUID, r domain.SecurityRule) (*domain.SecurityRule, error) {
+func (m *mockSGSvc) AddRule(ctx context.Context, idOrName string, r domain.SecurityRule) (*domain.SecurityRule, error) {
 	return nil, nil
 }
 func (m *mockSGSvc) RemoveRule(ctx context.Context, ruleID uuid.UUID) error               { return nil }

--- a/internal/repositories/k8s/security.go
+++ b/internal/repositories/k8s/security.go
@@ -30,7 +30,7 @@ func (p *KubeadmProvisioner) ensureClusterSecurityGroup(ctx context.Context, clu
 	}
 
 	for _, rule := range rules {
-		_, _ = p.sgSvc.AddRule(ctx, newSG.ID, rule)
+		_, _ = p.sgSvc.AddRule(ctx, newSG.ID.String(), rule)
 	}
 
 	return nil

--- a/internal/repositories/postgres/security_group_repo.go
+++ b/internal/repositories/postgres/security_group_repo.go
@@ -70,6 +70,24 @@ func (r *SecurityGroupRepository) GetByName(ctx context.Context, vpcID uuid.UUID
 	return sg, nil
 }
 
+func (r *SecurityGroupRepository) GetByNameAcrossVPCs(ctx context.Context, name string) (*domain.SecurityGroup, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	query := `SELECT id, user_id, tenant_id, vpc_id, name, description, arn, created_at FROM security_groups WHERE name = $1 AND tenant_id = $2 LIMIT 1`
+
+	sg, err := r.scanSecurityGroup(r.db.QueryRow(ctx, query, name, tenantID))
+	if err != nil {
+		return nil, err
+	}
+
+	rules, err := r.getRulesForGroup(ctx, sg.ID)
+	if err != nil {
+		return nil, err
+	}
+	sg.Rules = rules
+
+	return sg, nil
+}
+
 func (r *SecurityGroupRepository) ListByVPC(ctx context.Context, vpcID uuid.UUID) ([]*domain.SecurityGroup, error) {
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	query := `SELECT id, user_id, tenant_id, vpc_id, name, description, arn, created_at FROM security_groups WHERE vpc_id = $1 AND tenant_id = $2 ORDER BY created_at DESC`

--- a/internal/repositories/postgres/security_group_repo_test.go
+++ b/internal/repositories/postgres/security_group_repo_test.go
@@ -182,6 +182,63 @@ func TestSecurityGroupRepositoryGetByName(t *testing.T) {
 	})
 }
 
+func TestSecurityGroupRepositoryGetByNameAcrossVPCs(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		repo := NewSecurityGroupRepository(mock)
+		id := uuid.New()
+		userID := uuid.New()
+		tenantID := uuid.New()
+		vpcID := uuid.New()
+		ctx := appcontext.WithTenantID(appcontext.WithUserID(context.Background(), userID), tenantID)
+		now := time.Now()
+		name := testSgName
+
+		mock.ExpectQuery(selectSg).
+			WithArgs(name, tenantID).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "user_id", "tenant_id", "vpc_id", "name", "description", "arn", "created_at"}).
+				AddRow(id, userID, tenantID, vpcID, name, "desc", "arn", now))
+
+		mock.ExpectQuery(selectRule).
+			WithArgs(id).
+			WillReturnRows(pgxmock.NewRows([]string{"id", "group_id", "direction", "protocol", "port_min", "port_max", "cidr", "priority", "created_at"}).
+				AddRow(uuid.New(), id, string(domain.RuleIngress), "tcp", 80, 80, testutil.TestAnyCIDR, 100, now))
+
+		sg, err := repo.GetByNameAcrossVPCs(ctx, name)
+		require.NoError(t, err)
+		assert.NotNil(t, sg)
+		assert.Equal(t, id, sg.ID)
+	})
+
+	t.Run(testNotFound, func(t *testing.T) {
+		mock, err := pgxmock.NewPool()
+		require.NoError(t, err)
+		defer mock.Close()
+
+		repo := NewSecurityGroupRepository(mock)
+		userID := uuid.New()
+		tenantID := uuid.New()
+		ctx := appcontext.WithTenantID(appcontext.WithUserID(context.Background(), userID), tenantID)
+		name := testSgName
+
+		mock.ExpectQuery(selectSg).
+			WithArgs(name, tenantID).
+			WillReturnError(pgx.ErrNoRows)
+
+		sg, err := repo.GetByNameAcrossVPCs(ctx, name)
+		require.Error(t, err)
+		assert.Nil(t, sg)
+		var target *theclouderrors.Error
+		ok := errors.As(err, &target)
+		if ok {
+			assert.Equal(t, theclouderrors.NotFound, target.Type)
+		}
+	})
+}
+
 func TestSecurityGroupRepositoryListByVPC(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		mock, err := pgxmock.NewPool()


### PR DESCRIPTION
## Summary
- **#414**: `cloud sg list` no longer requires `--vpc-id`; when omitted, returns all security groups for the tenant (matching `lb list` behavior)
- **#421**: `cloud sg add-rule [sg-id]` now accepts both UUIDs and security group names. The AddRule handler/service try `uuid.Parse` first, then fall back to name-based lookup across all VPCs

## Changes

### CLI (`cmd/cloud/sg.go`)
- Removed required check for `--vpc-id` in `sg list` command

### Handler (`internal/handlers/security_group_handler.go`)
- `AddRule` no longer validates UUID — passes `idOrName` directly to service

### Service (`internal/core/services/security_group.go`)
- Added `resolveGroupID` helper: tries `uuid.Parse`, then `GetByNameAcrossVPCs`
- `AddRule` now accepts `idOrName string` instead of `groupID uuid.UUID`

### Repository (`internal/repositories/postgres/security_group_repo.go`)
- Added `GetByNameAcrossVPCs` method for tenant-scoped name lookup without VPC ID

### Interfaces (`internal/core/ports/security_group.go`)
- Updated `AddRule` signature to `AddRule(ctx, idOrName string, rule)`
- Added `GetByNameAcrossVPCs` to repository interface

## Test plan
- [x] `go build ./...` — compiles
- [x] `go test ./internal/handlers/...` — handler tests pass
- [x] `go test ./internal/repositories/postgres/...` — repository tests pass
- [x] `go test ./internal/core/services/...` — service tests pass
- [x] `go test ./internal/repositories/k8s/...` — k8s tests pass

---

Closes #414
Closes #421