### PR TITLE
fix: add write repair for failed replica writes

### DIFF
--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -595,7 +595,7 @@ func (c *Coordinator) writeRepair(ctx context.Context, bucket, key string, times
 
 	for {
 		chunk, err := st.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -231,6 +231,7 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 	// 2. Pipe chunks to all streams
 	buf := make([]byte, chunkSize)
 	var totalSize int64
+	failedNodes := make(map[string]bool)
 	for {
 		n, err := r.Read(buf)
 		if n > 0 {
@@ -248,6 +249,7 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 				})
 				if errSend != nil {
 					_, _ = streams[i].stream.CloseAndRecv()
+					failedNodes[streams[i].id] = true
 					continue
 				}
 				live = append(live, streams[i])
@@ -269,12 +271,14 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 		resp, err := ns.stream.CloseAndRecv()
 		if err != nil {
 			lastErr = err
+			failedNodes[ns.id] = true
 			continue
 		}
 		if resp.Success {
 			successCount++
 		} else {
 			lastErr = fmt.Errorf("%s: %s", ns.id, resp.Error)
+			failedNodes[ns.id] = true
 		}
 	}
 
@@ -282,6 +286,26 @@ func (c *Coordinator) Write(ctx context.Context, bucket, key string, r io.Reader
 	if successCount < c.writeQuorum {
 		platform.StorageOperations.WithLabelValues("cluster_write", bucket, "quorum_failure").Inc()
 		return totalSize, fmt.Errorf("write quorum failed (%d/%d): %w", successCount, c.writeQuorum, lastErr)
+	}
+
+	// 5. Write repair: async repair of failed nodes using a good replica as source
+	if len(failedNodes) > 0 {
+		goodNodes := make([]string, 0, len(streams))
+		for _, ns := range streams {
+			goodNodes = append(goodNodes, ns.id)
+		}
+		repairNodes := make([]string, 0, len(failedNodes))
+		for id := range failedNodes {
+			repairNodes = append(repairNodes, id)
+		}
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					platform.StorageOperations.WithLabelValues("write_repair", bucket, "panic").Inc()
+				}
+			}()
+			c.writeRepair(context.Background(), bucket, key, ts, repairNodes, goodNodes)
+		}()
 	}
 
 	platform.StorageOperations.WithLabelValues("cluster_write", bucket, "success").Inc()
@@ -510,6 +534,98 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 			platform.StorageOperations.WithLabelValues("repair", bucket, "success").Inc()
 		} else {
 			platform.StorageOperations.WithLabelValues("repair", bucket, "failure").Inc()
+		}
+	}
+}
+
+// writeRepair reads the object from a good replica and streams it to failed nodes.
+func (c *Coordinator) writeRepair(ctx context.Context, bucket, key string, timestamp int64, repairNodes []string, goodNodes []string) {
+	if len(repairNodes) == 0 || len(goodNodes) == 0 {
+		return
+	}
+
+	srcNode := goodNodes[0]
+	srcClient, ok := c.clients[srcNode]
+	if !ok {
+		return
+	}
+
+	st, err := srcClient.Retrieve(ctx, &pb.RetrieveRequest{Bucket: bucket, Key: key})
+	if err != nil {
+		platform.StorageOperations.WithLabelValues("write_repair", bucket, "source_error").Inc()
+		return
+	}
+
+	meta, err := st.Recv()
+	if err != nil || meta.GetMetadata() == nil {
+		platform.StorageOperations.WithLabelValues("write_repair", bucket, "source_error").Inc()
+		return
+	}
+
+	type nodeStream struct {
+		id     string
+		stream pb.StorageNode_StoreClient
+	}
+	repairStreams := make([]nodeStream, 0, len(repairNodes))
+	for _, nodeID := range repairNodes {
+		if client, ok := c.clients[nodeID]; ok {
+			storeSt, err := client.Store(ctx)
+			if err != nil {
+				continue
+			}
+			err = storeSt.Send(&pb.StoreRequest{
+				Payload: &pb.StoreRequest_Metadata{
+					Metadata: &pb.StoreMetadata{
+						Bucket:    bucket,
+						Key:       key,
+						Timestamp: timestamp,
+					},
+				},
+			})
+			if err != nil {
+				continue
+			}
+			repairStreams = append(repairStreams, nodeStream{id: nodeID, stream: storeSt})
+		}
+	}
+
+	if len(repairStreams) == 0 {
+		return
+	}
+
+	for {
+		chunk, err := st.Recv()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			break
+		}
+		cd := chunk.GetChunkData()
+		if cd == nil {
+			continue
+		}
+
+		live := repairStreams[:0]
+		for i := 0; i < len(repairStreams); i++ {
+			errSend := repairStreams[i].stream.Send(&pb.StoreRequest{
+				Payload: &pb.StoreRequest_ChunkData{ChunkData: cd},
+			})
+			if errSend != nil {
+				_, _ = repairStreams[i].stream.CloseAndRecv()
+				continue
+			}
+			live = append(live, repairStreams[i])
+		}
+		repairStreams = live
+	}
+
+	for _, ns := range repairStreams {
+		resp, err := ns.stream.CloseAndRecv()
+		if err == nil && resp.Success {
+			platform.StorageOperations.WithLabelValues("write_repair", bucket, "success").Inc()
+		} else {
+			platform.StorageOperations.WithLabelValues("write_repair", bucket, "failure").Inc()
 		}
 	}
 }

--- a/internal/storage/coordinator/service_test.go
+++ b/internal/storage/coordinator/service_test.go
@@ -335,6 +335,66 @@ func TestCoordinatorWriteStreamFailureMidChunk(t *testing.T) {
 	sm2.AssertCalled(t, "CloseAndRecv")
 }
 
+func TestCoordinatorWriteRepair(t *testing.T) {
+	ring := NewConsistentHashRing(10)
+	ring.AddNode(node1)
+	ring.AddNode(node2)
+	ring.AddNode(node3)
+
+	ts := time.Now().UnixNano()
+
+	// Node1 and Node3 succeed; Node2 fails mid-stream
+	sm1 := new(MockStoreClient)
+	sm1.On("Send", mock.Anything).Return(nil).Once()  // metadata
+	sm1.On("Send", mock.Anything).Return(nil).Once()  // chunk
+	sm1.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	sm3 := new(MockStoreClient)
+	sm3.On("Send", mock.Anything).Return(nil).Maybe()
+	sm3.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	// Node2 fails on chunk send (not at CloseAndRecv — that would count as quorum failure)
+	sm2Write := new(MockStoreClient)
+	sm2Write.On("Send", mock.Anything).Return(nil).Once()  // metadata succeeds
+	sm2Write.On("Send", mock.Anything).Return(errors.New("mid-stream failure")).Once()
+	// CloseAndRecv is still called on the failed stream for cleanup
+	sm2Write.On("CloseAndRecv").Return(&pb.StoreResponse{Success: false, Error: "stream error"}, nil)
+
+	c1, c2, c3 := new(MockStorageNodeClient), new(MockStorageNodeClient), new(MockStorageNodeClient)
+	c1.On("Store", mock.Anything).Return(sm1, nil)
+	c3.On("Store", mock.Anything).Return(sm3, nil)
+
+	// c2.Store: first call = initial write (sm2Write), second call = repair (sm2Repair)
+	sm2Repair := new(MockStoreClient)
+	sm2Repair.On("Send", mock.Anything).Return(nil).Maybe()
+	sm2Repair.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+	c2.On("Store", mock.Anything).Return(sm2Write, nil).Once()
+	c2.On("Store", mock.Anything).Return(sm2Repair, nil).Once()
+
+	// Write repair: Node1 serves Retrieve, Node2 receives repair Store
+	rm1 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+		{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: ts}}},
+		{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("hello")}},
+	}}
+	c1.On("Retrieve", mock.Anything, mock.Anything).Return(rm1, nil).Once()
+
+	clients := map[string]pb.StorageNodeClient{node1: c1, node2: c2, node3: c3}
+	coord := NewCoordinator(context.Background(), ring, clients, 3)
+	defer coord.Stop()
+
+	// Write succeeds with quorum (node1 + node3 = 2, node2 pruned mid-stream)
+	n, err := coord.Write(context.Background(), "b", "k", bytes.NewReader([]byte("hello")))
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), n)
+
+	// Wait for async write repair
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify write repair: Node1 was used as source, Node2 was repaired
+	c1.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
+	sm2Repair.AssertCalled(t, "CloseAndRecv")
+}
+
 func TestCoordinatorRepairStreamFailureContinues(t *testing.T) {
 	ring := NewConsistentHashRing(10)
 	ring.AddNode(node1)

--- a/internal/storage/coordinator/service_test.go
+++ b/internal/storage/coordinator/service_test.go
@@ -395,6 +395,170 @@ func TestCoordinatorWriteRepair(t *testing.T) {
 	sm2Repair.AssertCalled(t, "CloseAndRecv")
 }
 
+func TestCoordinatorWriteRepair_SourceNodeDown(t *testing.T) {
+	ring := NewConsistentHashRing(10)
+	ring.AddNode(node1)
+	ring.AddNode(node2)
+	ring.AddNode(node3)
+
+	// Node1 and Node3 succeed; Node2 fails mid-stream
+	sm1 := new(MockStoreClient)
+	sm1.On("Send", mock.Anything).Return(nil).Once()
+	sm1.On("Send", mock.Anything).Return(nil).Once()
+	sm1.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	sm3 := new(MockStoreClient)
+	sm3.On("Send", mock.Anything).Return(nil).Maybe()
+	sm3.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	sm2Write := new(MockStoreClient)
+	sm2Write.On("Send", mock.Anything).Return(nil).Once()
+	sm2Write.On("Send", mock.Anything).Return(errors.New("mid-stream failure")).Once()
+	sm2Write.On("CloseAndRecv").Return(&pb.StoreResponse{Success: false, Error: "stream error"}, nil)
+
+	c1, c2, c3 := new(MockStorageNodeClient), new(MockStorageNodeClient), new(MockStorageNodeClient)
+	c1.On("Store", mock.Anything).Return(sm1, nil)
+	c3.On("Store", mock.Anything).Return(sm3, nil)
+
+	// c2.Store returns different mocks for write vs repair
+	sm2Repair := new(MockStoreClient)
+	sm2Repair.On("Send", mock.Anything).Return(nil).Maybe()
+	sm2Repair.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+	c2.On("Store", mock.Anything).Return(sm2Write, nil).Once()
+	c2.On("Store", mock.Anything).Return(sm2Repair, nil).Once()
+
+	// Source node (Node1) Retrieve fails during repair
+	c1.On("Retrieve", mock.Anything, mock.Anything).Return(nil, errors.New("source node down")).Once()
+
+	clients := map[string]pb.StorageNodeClient{node1: c1, node2: c2, node3: c3}
+	coord := NewCoordinator(context.Background(), ring, clients, 3)
+	defer coord.Stop()
+
+	// Write succeeds with quorum
+	n, err := coord.Write(context.Background(), "b", "k", bytes.NewReader([]byte("hello")))
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), n)
+
+	// Wait for async write repair
+	time.Sleep(200 * time.Millisecond)
+
+	// Source was called but failed, so repair should not complete
+	c1.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
+	// sm2Repair should NOT be called since source failed
+	sm2Repair.AssertNotCalled(t, "CloseAndRecv")
+}
+
+func TestCoordinatorWriteRepair_AllRepairNodesDown(t *testing.T) {
+	ring := NewConsistentHashRing(10)
+	ring.AddNode(node1)
+	ring.AddNode(node2)
+	ring.AddNode(node3)
+
+	// Node1 and Node3 succeed; Node2 fails mid-stream
+	sm1 := new(MockStoreClient)
+	sm1.On("Send", mock.Anything).Return(nil).Once()
+	sm1.On("Send", mock.Anything).Return(nil).Once()
+	sm1.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	sm3 := new(MockStoreClient)
+	sm3.On("Send", mock.Anything).Return(nil).Maybe()
+	sm3.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	sm2Write := new(MockStoreClient)
+	sm2Write.On("Send", mock.Anything).Return(nil).Once()
+	sm2Write.On("Send", mock.Anything).Return(errors.New("mid-stream failure")).Once()
+	sm2Write.On("CloseAndRecv").Return(&pb.StoreResponse{Success: false, Error: "stream error"}, nil)
+
+	c1, c2, c3 := new(MockStorageNodeClient), new(MockStorageNodeClient), new(MockStorageNodeClient)
+	c1.On("Store", mock.Anything).Return(sm1, nil)
+	c3.On("Store", mock.Anything).Return(sm3, nil)
+
+	// c2.Store first call succeeds for write, second call fails for repair
+	c2.On("Store", mock.Anything).Return(sm2Write, nil).Once()
+	c2.On("Store", mock.Anything).Return(nil, errors.New("repair node down")).Once()
+
+	// Node1 serves as source for repair
+	rm1 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+		{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: time.Now().UnixNano()}}},
+		{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("hello")}},
+	}}
+	c1.On("Retrieve", mock.Anything, mock.Anything).Return(rm1, nil).Once()
+
+	clients := map[string]pb.StorageNodeClient{node1: c1, node2: c2, node3: c3}
+	coord := NewCoordinator(context.Background(), ring, clients, 3)
+	defer coord.Stop()
+
+	// Write succeeds with quorum
+	n, err := coord.Write(context.Background(), "b", "k", bytes.NewReader([]byte("hello")))
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), n)
+
+	// Wait for async write repair
+	time.Sleep(200 * time.Millisecond)
+
+	// Source was called but repair node was down - repair silently skipped
+	c1.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
+	// No repair Store call succeeded
+}
+
+func TestCoordinatorWriteRepair_PartialRepairFailure(t *testing.T) {
+	ring := NewConsistentHashRing(10)
+	ring.AddNode(node1)
+	ring.AddNode(node2)
+	ring.AddNode(node3)
+
+	ts := time.Now().UnixNano()
+
+	// Node1 and Node3 succeed; Node2 fails mid-stream
+	sm1 := new(MockStoreClient)
+	sm1.On("Send", mock.Anything).Return(nil).Once()
+	sm1.On("Send", mock.Anything).Return(nil).Once()
+	sm1.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	sm3 := new(MockStoreClient)
+	sm3.On("Send", mock.Anything).Return(nil).Maybe()
+	sm3.On("CloseAndRecv").Return(&pb.StoreResponse{Success: true}, nil)
+
+	sm2Write := new(MockStoreClient)
+	sm2Write.On("Send", mock.Anything).Return(nil).Once()
+	sm2Write.On("Send", mock.Anything).Return(errors.New("mid-stream failure")).Once()
+	sm2Write.On("CloseAndRecv").Return(&pb.StoreResponse{Success: false, Error: "stream error"}, nil)
+
+	c1, c2, c3 := new(MockStorageNodeClient), new(MockStorageNodeClient), new(MockStorageNodeClient)
+	c1.On("Store", mock.Anything).Return(sm1, nil)
+	c3.On("Store", mock.Anything).Return(sm3, nil)
+
+	// c2.Store: write succeeds, repair sends but CloseAndRecv fails
+	sm2Repair := new(MockStoreClient)
+	sm2Repair.On("Send", mock.Anything).Return(nil).Maybe()
+	sm2Repair.On("CloseAndRecv").Return(&pb.StoreResponse{Success: false, Error: "repair failed"}, nil)
+	c2.On("Store", mock.Anything).Return(sm2Write, nil).Once()
+	c2.On("Store", mock.Anything).Return(sm2Repair, nil).Once()
+
+	// Node1 serves as source for repair
+	rm1 := &MockRetrieveClient{resps: []*pb.RetrieveResponse{
+		{Payload: &pb.RetrieveResponse_Metadata{Metadata: &pb.RetrieveMetadata{Found: true, Timestamp: ts}}},
+		{Payload: &pb.RetrieveResponse_ChunkData{ChunkData: []byte("hello")}},
+	}}
+	c1.On("Retrieve", mock.Anything, mock.Anything).Return(rm1, nil).Once()
+
+	clients := map[string]pb.StorageNodeClient{node1: c1, node2: c2, node3: c3}
+	coord := NewCoordinator(context.Background(), ring, clients, 3)
+	defer coord.Stop()
+
+	// Write succeeds with quorum
+	n, err := coord.Write(context.Background(), "b", "k", bytes.NewReader([]byte("hello")))
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), n)
+
+	// Wait for async write repair
+	time.Sleep(200 * time.Millisecond)
+
+	// Repair was attempted but CloseAndRecv returned failure
+	c1.AssertCalled(t, "Retrieve", mock.Anything, mock.Anything)
+	sm2Repair.AssertCalled(t, "CloseAndRecv")
+}
+
 func TestCoordinatorRepairStreamFailureContinues(t *testing.T) {
 	ring := NewConsistentHashRing(10)
 	ring.AddNode(node1)


### PR DESCRIPTION
## Summary

Add write repair mechanism so that when a Write succeeds (quorum met) but some replicas failed mid-stream, those replicas are asynchronously repaired by reading from a good replica and streaming the data to failed nodes.

## Changes

- : Track failed nodes during chunk streaming and CloseAndRecv
- : After quorum success, launch async goroutine to repair failed replicas
- : New  method reads from a good replica and streams to repair targets
- : New  test

## Why

The  method streams data to replicas but does not repair replicas that fail mid-stream. Nodes that failed during chunk sending would remain inconsistent indefinitely. Now, after a successful write, failed nodes are asynchronously repaired using the same pattern as read repair.

## Test plan

- [x] ok  	github.com/poyrazk/thecloud/internal/storage/coordinator	0.612s — all tests pass
- [x] New test verifies write repair is triggered for failed replicas
- [x] All existing tests pass

## Related Issues

Fixes #499