### PR TITLE
fix: wrap service errors with meaningful messages (#436, #437, #438)

### DIFF
--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -433,7 +433,7 @@ func (s *FunctionService) failInvocation(i *domain.Invocation, logMsg string, er
 	i.Status = "FAILED"
 	i.Logs = logMsg
 	_ = s.repo.CreateInvocation(context.Background(), i)
-	return i, err
+	return i, errors.Wrap(errors.Internal, logMsg, err)
 }
 
 func (s *FunctionService) prepareCode(ctx context.Context, f *domain.Function) (string, error) {

--- a/internal/core/services/function.go
+++ b/internal/core/services/function.go
@@ -311,7 +311,7 @@ func (s *FunctionService) runInvocation(ctx context.Context, f *domain.Function,
 
 	tmpDir, err := s.prepareCode(ctx, f)
 	if err != nil {
-		return s.failInvocation(i, fmt.Sprintf("Error preparing code: %v", err), err)
+		return s.failInvocation(i, "function invocation failed", err)
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
@@ -319,7 +319,7 @@ func (s *FunctionService) runInvocation(ctx context.Context, f *domain.Function,
 
 	containerID, _, err := s.compute.RunTask(ctx, opts)
 	if err != nil {
-		return s.failInvocation(i, fmt.Sprintf("Error running task: %v", err), err)
+		return s.failInvocation(i, "function invocation failed", err)
 	}
 	defer func() { _ = s.compute.DeleteInstance(ctx, containerID) }()
 

--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -817,7 +817,7 @@ func (s *InstanceService) GetInstanceLogs(ctx context.Context, idOrName string) 
 
 	stream, err := s.compute.GetInstanceLogs(ctx, inst.ContainerID)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(errors.Internal, "failed to get instance logs", err)
 	}
 	defer func() { _ = stream.Close() }()
 
@@ -854,7 +854,11 @@ func (s *InstanceService) GetConsoleURL(ctx context.Context, idOrName string) (s
 		id = inst.ContainerID
 	}
 
-	return s.compute.GetConsoleURL(ctx, id)
+	url, err := s.compute.GetConsoleURL(ctx, id)
+	if err != nil {
+		return "", errors.Wrap(errors.Internal, "failed to get console URL", err)
+	}
+	return url, nil
 }
 
 func (s *InstanceService) ResizeInstance(ctx context.Context, idOrName, newInstanceType string) (*domain.Instance, error) {

--- a/internal/core/services/instance_unit_test.go
+++ b/internal/core/services/instance_unit_test.go
@@ -1675,6 +1675,26 @@ func testInstanceServiceUnitRepoErrors(t *testing.T) {
 		assert.Contains(t, err.Error(), "stats unavailable")
 	})
 
+	t.Run("GetInstanceLogs_ComputeError", func(t *testing.T) {
+		repo.On("GetByName", mock.Anything, "test-inst").Return(inst, nil).Once()
+		compute.On("GetInstanceLogs", mock.Anything, "cid-1").Return(nil, fmt.Errorf("log stream error")).Once()
+
+		_, err := svc.GetInstanceLogs(ctx, "test-inst")
+		require.Error(t, err)
+		assert.True(t, svcerrors.Is(err, svcerrors.Internal))
+		assert.Contains(t, err.Error(), "failed to get instance logs")
+	})
+
+	t.Run("GetConsoleURL_ComputeError", func(t *testing.T) {
+		repo.On("GetByName", mock.Anything, "test-inst").Return(inst, nil).Once()
+		compute.On("GetConsoleURL", mock.Anything, "cid-1").Return("", fmt.Errorf("console unavailable")).Once()
+
+		_, err := svc.GetConsoleURL(ctx, "test-inst")
+		require.Error(t, err)
+		assert.True(t, svcerrors.Is(err, svcerrors.Internal))
+		assert.Contains(t, err.Error(), "failed to get console URL")
+	})
+
 	t.Run("Exec_NotFound", func(t *testing.T) {
 		repo.On("GetByName", mock.Anything, mock.Anything).Return(nil, svcerrors.New(svcerrors.NotFound, "not found")).Once()
 		repo.On("GetByID", mock.Anything, mock.Anything).Return(nil, svcerrors.New(svcerrors.NotFound, "not found")).Once()

--- a/internal/repositories/docker/adapter.go
+++ b/internal/repositories/docker/adapter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/docker/go-connections/nat"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/poyrazk/thecloud/internal/platform"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -500,7 +501,7 @@ func (a *DockerAdapter) GetInstanceStats(ctx context.Context, containerID string
 	// Stream: false = get one snapshot
 	stats, err := a.cli.ContainerStats(ctx, containerID, false)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(errors.Internal, "failed to get container stats", err)
 	}
 	return stats.Body, nil
 }
@@ -892,7 +893,7 @@ func (a *DockerAdapter) DetachVolume(ctx context.Context, id string, volumePath 
 }
 
 func (a *DockerAdapter) GetConsoleURL(ctx context.Context, id string) (string, error) {
-	return "", fmt.Errorf("console not supported for docker instances")
+	return "", errors.Wrap(errors.Internal, "console not supported for docker instances", nil)
 }
 
 func (a *DockerAdapter) GetInstanceIP(ctx context.Context, id string) (string, error) {

--- a/internal/repositories/docker/adapter.go
+++ b/internal/repositories/docker/adapter.go
@@ -893,7 +893,7 @@ func (a *DockerAdapter) DetachVolume(ctx context.Context, id string, volumePath 
 }
 
 func (a *DockerAdapter) GetConsoleURL(ctx context.Context, id string) (string, error) {
-	return "", errors.Wrap(errors.Internal, "console not supported for docker instances", nil)
+	return "", errors.New(errors.NotImplemented, "console not supported for docker instances")
 }
 
 func (a *DockerAdapter) GetInstanceIP(ctx context.Context, id string) (string, error) {

--- a/internal/repositories/docker/adapter_unit_test.go
+++ b/internal/repositories/docker/adapter_unit_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	apierrors "github.com/poyrazk/thecloud/internal/errors"
 	"github.com/poyrazk/thecloud/pkg/testutil"
 )
 
@@ -75,6 +76,13 @@ func TestDockerAdapterGetInstanceStatsReturnsBody(t *testing.T) {
 	rc, err := a.GetInstanceStats(context.Background(), "cid")
 	require.NoError(t, err)
 	defer func() { _ = rc.Close() }()
+}
+
+func TestDockerAdapterGetInstanceStatsError(t *testing.T) {
+	a := &DockerAdapter{cli: &fakeDockerClient{statsErr: apierrors.New("Internal", "docker stats failed")}}
+	_, err := a.GetInstanceStats(context.Background(), "cid")
+	require.Error(t, err)
+	require.True(t, apierrors.Is(err, apierrors.Internal))
 }
 
 func TestDockerAdapterExecNonZeroExit(t *testing.T) {


### PR DESCRIPTION
## Summary

Wrap service method errors with `errors.Error` type so CLI returns meaningful messages instead of generic "An unexpected error occurred". Also addresses Copilot review feedback by using `errors.NotImplemented` for unsupported Docker console access and sanitizing error messages to avoid exposing internal details.

## Changes

- `FunctionService.failInvocation`: wrap error with `errors.Wrap(errors.Internal, "function invocation failed", err)` using a generic user-safe message
- `InstanceService.GetInstanceLogs`: wrap compute-backend error with descriptive message
- `InstanceService.GetConsoleURL`: wrap compute-backend error with descriptive message
- `DockerAdapter.GetInstanceStats`: wrap Docker SDK error with descriptive message
- `DockerAdapter.GetConsoleURL`: return `errors.NotImplemented` instead of `errors.Internal` since this is a capability limitation, not a server fault

## Test Plan

- [x] Unit tests added/updated (`GetInstanceStats` error path, `GetInstanceLogs` compute error, `GetConsoleURL` compute error)
- [x] `go build ./...`
- [x] `go test ./internal/core/services/...`
- [x] `go test ./internal/repositories/docker/...`

## Breaking Changes

None.

## Related Issues

- Fixes #436 (Function invocation generic error)
- Fixes #437 (Instance stats "failed to get stats stream")
- Fixes #438 (Instance logs and console generic errors)

## Checklist

- [x] Code follows project style guidelines
- [x] Tests added/updated
- [x] All tests pass