### PR TITLE
fix(cli): add --size flag to db create command

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-version: 2
-
 run:
   timeout: 5m
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
-
 version: 2
 
 run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 
+version: 2
+
 run:
   timeout: 5m
 

--- a/cmd/cloud/db.go
+++ b/cmd/cloud/db.go
@@ -68,7 +68,7 @@ var dbCreateCmd = &cobra.Command{
 		size, _ := cmd.Flags().GetInt("size")
 
 		if size < 10 {
-			fmt.Printf("Error: --size must be at least 10GB\n")
+			fmt.Printf(errorFormat, "--size must be at least 10GB")
 			return
 		}
 

--- a/cmd/cloud/db.go
+++ b/cmd/cloud/db.go
@@ -60,11 +60,17 @@ var dbListCmd = &cobra.Command{
 var dbCreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create a new managed database instance",
-	Run: func(cmd *cobra.Command, args []string) {
+	Run: func(cmd *cobra.Command, _ []string) {
 		name, _ := cmd.Flags().GetString("name")
 		engine, _ := cmd.Flags().GetString("engine")
 		version, _ := cmd.Flags().GetString("version")
 		vpc, _ := cmd.Flags().GetString("vpc")
+		size, _ := cmd.Flags().GetInt("size")
+
+		if size < 10 {
+			fmt.Printf("Error: --size must be at least 10GB\n")
+			return
+		}
 
 		var vpcPtr *string
 		if vpc != "" {
@@ -72,7 +78,7 @@ var dbCreateCmd = &cobra.Command{
 		}
 
 		client := createClient(opts)
-		db, err := client.CreateDatabase(name, engine, version, vpcPtr)
+		db, err := client.CreateDatabase(name, engine, version, vpcPtr, size)
 		if err != nil {
 			fmt.Printf(errorFormat, err)
 			return
@@ -189,5 +195,6 @@ func init() {
 	dbCreateCmd.Flags().StringP("engine", "e", "postgres", "Database engine (postgres/mysql)")
 	dbCreateCmd.Flags().StringP("version", "v", "16", "Engine version")
 	dbCreateCmd.Flags().StringP("vpc", "V", "", "VPC ID to attach to")
+	dbCreateCmd.Flags().Int("size", 10, "Allocated storage in GB (minimum 10GB)")
 	_ = dbCreateCmd.MarkFlagRequired("name")
 }

--- a/cmd/cloud/db.go
+++ b/cmd/cloud/db.go
@@ -44,16 +44,22 @@ var dbListCmd = &cobra.Command{
 		for _, db := range databases {
 			id := truncateID(db.ID)
 
-			table.Append([]string{
+			if err := table.Append([]string{
 				id,
 				db.Name,
 				db.Engine,
 				db.Version,
 				db.Status,
 				fmt.Sprintf("%d", db.Port),
-			})
+			}); err != nil {
+				fmt.Printf(errorFormat, err)
+				return
+			}
 		}
-		table.Render()
+		if err := table.Render(); err != nil {
+			fmt.Printf(errorFormat, err)
+			return
+		}
 	},
 }
 

--- a/cmd/cloud/db_cli_test.go
+++ b/cmd/cloud/db_cli_test.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/poyrazk/thecloud/pkg/sdk"
 )
 
 const (
@@ -139,5 +142,84 @@ func TestDBConnectionCmd(t *testing.T) {
 	})
 	if !strings.Contains(out, "Connection String") {
 		t.Fatalf("expected connection string output, got: %s", out)
+	}
+}
+
+func TestDBCreateSizeValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		size        int
+		wantErr     bool
+		errContains string
+	}{
+		{name: "size too small", size: 5, wantErr: true, errContains: "--size must be at least 10GB"},
+		{name: "size at minimum", size: 10, wantErr: false},
+		{name: "size above minimum", size: 100, wantErr: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotReq sdk.CreateDatabaseInput
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path != "/databases" || r.Method != http.MethodPost {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				payload := map[string]interface{}{
+					"data": map[string]interface{}{
+						"id":         dbTestID,
+						"name":       dbTestName,
+						"engine":     "postgres",
+						"version":    "16",
+						"status":     "available",
+						"port":       5432,
+						"username":   "admin",
+						"password":   "secret",
+						"created_at": time.Now().UTC().Format(time.RFC3339),
+						"updated_at": time.Now().UTC().Format(time.RFC3339),
+					},
+				}
+				_ = json.NewEncoder(w).Encode(payload)
+			}))
+			defer server.Close()
+
+			oldURL := opts.APIURL
+			oldKey := opts.APIKey
+			opts.APIURL = server.URL
+			opts.APIKey = dbTestAPIKey
+			defer func() {
+				opts.APIURL = oldURL
+				opts.APIKey = oldKey
+			}()
+
+			_ = dbCreateCmd.Flags().Set("name", dbTestName)
+			_ = dbCreateCmd.Flags().Set("engine", "postgres")
+			_ = dbCreateCmd.Flags().Set("version", "16")
+			_ = dbCreateCmd.Flags().Set("size", fmt.Sprintf("%d", tt.size))
+
+			out := captureStdout(t, func() {
+				dbCreateCmd.Run(dbCreateCmd, nil)
+			})
+
+			if tt.wantErr {
+				if !strings.Contains(out, tt.errContains) {
+					t.Fatalf("expected error containing %q, got: %s", tt.errContains, out)
+				}
+			} else {
+				if !strings.Contains(out, "[SUCCESS]") {
+					t.Fatalf("expected success, got: %s", out)
+				}
+				if gotReq.AllocatedStorage != tt.size {
+					t.Fatalf("expected AllocatedStorage %d, got %d", tt.size, gotReq.AllocatedStorage)
+				}
+			}
+
+			_ = dbCreateCmd.Flags().Set("size", "10")
+		})
 	}
 }

--- a/cmd/cloud/db_cli_test.go
+++ b/cmd/cloud/db_cli_test.go
@@ -184,7 +184,9 @@ func TestDBCreateSizeValidation(t *testing.T) {
 						"updated_at": time.Now().UTC().Format(time.RFC3339),
 					},
 				}
-				_ = json.NewEncoder(w).Encode(payload)
+				if err := json.NewEncoder(w).Encode(payload); err != nil {
+					t.Fatalf("failed to encode response: %v", err)
+				}
 			}))
 			defer server.Close()
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -933,8 +933,16 @@ cloud db list
 Create a new managed database.
 
 ```bash
-cloud db create --name my-db --engine postgres --version 16
+cloud db create --name my-db --engine postgres --version 16 --size 20
 ```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--name` | `-n` | | Database name (required) |
+| `--engine` | `-e` | `postgres` | Database engine (postgres/mysql) |
+| `--version` | `-v` | `16` | Engine version |
+| `--vpc` | `-V` | | VPC ID to attach to |
+| `--size` | | `10` | Allocated storage in GB (minimum 10GB) |
 
 ### `db connection <id>`
 

--- a/docs/guides/rds.md
+++ b/docs/guides/rds.md
@@ -17,8 +17,12 @@ The Cloud provides managed database instances, allowing you to launch PostgreSQL
 To create a new PostgreSQL 16 instance:
 
 ```bash
-cloud db create --name my-postgres --engine postgres --version 16
+cloud db create --name my-postgres --engine postgres --version 16 --size 20
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--size` | Storage in GB (default 10, minimum 10GB) |
 
 Output:
 ```

--- a/pkg/sdk/database.go
+++ b/pkg/sdk/database.go
@@ -22,20 +22,22 @@ type Database struct {
 
 // CreateDatabaseInput defines parameters for creating a database.
 type CreateDatabaseInput struct {
-	Name    string  `json:"name"`
-	Engine  string  `json:"engine"`
-	Version string  `json:"version"`
-	VpcID   *string `json:"vpc_id,omitempty"`
+	Name             string  `json:"name"`
+	Engine           string  `json:"engine"`
+	Version          string  `json:"version"`
+	VpcID            *string `json:"vpc_id,omitempty"`
+	AllocatedStorage int     `json:"allocated_storage_gb,omitempty"`
 }
 
 const databasesPath = "/databases/"
 
-func (c *Client) CreateDatabase(name, engine, version string, vpcID *string) (*Database, error) {
+func (c *Client) CreateDatabase(name, engine, version string, vpcID *string, allocatedStorageGB int) (*Database, error) {
 	input := CreateDatabaseInput{
-		Name:    name,
-		Engine:  engine,
-		Version: version,
-		VpcID:   vpcID,
+		Name:             name,
+		Engine:           engine,
+		Version:          version,
+		VpcID:            vpcID,
+		AllocatedStorage: allocatedStorageGB,
 	}
 	var resp Response[Database]
 	if err := c.post("/databases", input, &resp); err != nil {

--- a/pkg/sdk/database_test.go
+++ b/pkg/sdk/database_test.go
@@ -39,6 +39,7 @@ func TestClientCreateDatabase(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, expectedDB.Name, req.Name)
 		assert.Equal(t, expectedDB.Engine, req.Engine)
+		assert.Equal(t, 10, req.AllocatedStorage)
 
 		w.Header().Set(dbContentType, dbApplicationJSON)
 		resp := Response[Database]{Data: expectedDB}

--- a/pkg/sdk/database_test.go
+++ b/pkg/sdk/database_test.go
@@ -47,7 +47,7 @@ func TestClientCreateDatabase(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(server.URL, dbAPIKey)
-	db, err := client.CreateDatabase(dbTestName, "postgres", "14", &vpcID)
+	db, err := client.CreateDatabase(dbTestName, "postgres", "14", &vpcID, 10)
 
 	require.NoError(t, err)
 	assert.NotNil(t, db)
@@ -166,7 +166,7 @@ func TestClientDatabaseErrors(t *testing.T) {
 
 	client := NewClient(server.URL, dbAPIKey)
 
-	_, err := client.CreateDatabase("db", "postgres", "14", nil)
+	_, err := client.CreateDatabase("db", "postgres", "14", nil, 10)
 	require.Error(t, err)
 
 	_, err = client.ListDatabases()


### PR DESCRIPTION
## Summary
- Add `--size` flag to `db create` command with default 10GB
- Add minimum size validation (10GB)
- Update SDK `CreateDatabase` to accept `allocatedStorageGB` parameter
- Add `AllocatedStorage` field to `CreateDatabaseInput` struct
- Fix unused-parameter lint issue in db.go

## Fixes
Fixes #419 - CLI db create has no --size flag

## Test plan
- [x] `go build ./cmd/cloud/`
- [x] `go test ./pkg/sdk/... ./cmd/cloud/...`
- [x] Manual test: `cloud db create --name test --size 20`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a --size flag to set database storage in GB (minimum 10GB; default 10GB).

* **SDK / API**
  * Database creation now forwards an allocated-storage value when provisioning databases.

* **Tests**
  * Added validation and integration tests to ensure size enforcement and correct storage allocation.

* **Chores**
  * Linter/configuration version updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/532)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->