### PR TITLE
fix(pipeline): use cancel-detached context for deferred cleanup (#223)

### DIFF
--- a/internal/workers/pipeline_worker.go
+++ b/internal/workers/pipeline_worker.go
@@ -313,7 +313,13 @@ func (w *PipelineWorker) runTaskForStep(ctx context.Context, buildID uuid.UUID, 
 	if runErr != nil {
 		return 0, "", runErr
 	}
-	defer func() { _ = w.compute.DeleteInstance(ctx, containerID) }()
+	defer func() {
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if err := w.compute.DeleteInstance(cleanupCtx, containerID); err != nil {
+			w.logger.Warn("failed to delete pipeline task container", "container_id", containerID, "build_id", buildID, "error", err)
+		}
+	}()
 
 	exitCode, waitErr := w.compute.WaitTask(ctx, containerID)
 	if waitErr != nil {

--- a/internal/workers/pipeline_worker_test.go
+++ b/internal/workers/pipeline_worker_test.go
@@ -233,4 +233,46 @@ func TestPipelineWorker_processJob(t *testing.T) {
 		compute.AssertExpectations(t)
 		taskQueue.AssertExpectations(t)
 	})
+
+	t.Run("DeleteInstanceCleanupFailure_IsLogged", func(t *testing.T) {
+		build := &domain.Build{ID: buildID, PipelineID: pipelineID, UserID: userID}
+		pipeline := &domain.Pipeline{
+			ID: pipelineID,
+			Config: domain.PipelineConfig{
+				Stages: []domain.PipelineStage{
+					{
+						Name: "Test",
+						Steps: []domain.PipelineStep{
+							{Name: "step1", Image: "alpine", Commands: []string{"echo hi"}},
+						},
+					},
+				},
+			},
+		}
+
+		repo.On("GetBuild", mock.Anything, buildID, userID).Return(build, nil).Once()
+		repo.On("GetPipeline", mock.Anything, pipelineID, userID).Return(pipeline, nil).Once()
+		repo.On("UpdateBuild", mock.Anything, mock.MatchedBy(func(b *domain.Build) bool {
+			return b.Status == domain.BuildStatusRunning
+		})).Return(nil).Once()
+		repo.On("CreateBuildStep", mock.Anything, mock.Anything).Return(nil).Once()
+
+		compute.On("RunTask", mock.Anything, mock.MatchedBy(func(opts ports.RunTaskOptions) bool {
+			return opts.Image == "alpine" && strings.Contains(strings.Join(opts.Command, " "), "echo hi")
+		})).Return("task-1", []string{}, nil).Once()
+		compute.On("WaitTask", mock.Anything, "task-1").Return(int64(0), nil).Once()
+		compute.On("GetInstanceLogs", mock.Anything, "task-1").Return(io.NopCloser(strings.NewReader("logs")), nil).Once()
+		compute.On("DeleteInstance", mock.Anything, "task-1").Return(context.DeadlineExceeded).Once()
+
+		repo.On("AppendBuildLog", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("UpdateBuildStep", mock.Anything, mock.Anything).Return(nil).Once()
+		repo.On("UpdateBuild", mock.Anything, mock.MatchedBy(func(b *domain.Build) bool {
+			return b.Status == domain.BuildStatusSucceeded
+		})).Return(nil).Once()
+		taskQueue.On("Ack", mock.Anything, pipelineQueueName, pipelineGroup, msg.ID).Return(nil).Once()
+
+		// Should not panic — cleanup error is logged, not propagated
+		worker.processJob(context.Background(), msg, job)
+		compute.AssertExpectations(t)
+	})
 }


### PR DESCRIPTION
Replace the deferred DeleteInstance call that used the request context (or context.Background) with a detached context derived via context.WithoutCancel and a bounded 30s timeout. If the request context was cancelled, cleanup with that context would short-circuit before the container is removed, leaking pipeline build containers.

Also surface deletion errors via the worker logger so future cleanup failures are observable instead of swallowed.

## Summary
<!-- Provide a brief overview of what this PR does -->

## Changes
<!-- List the key changes made in this PR -->

## Test Plan
<!-- Describe how the changes were tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing performed

## Breaking Changes
<!-- List any breaking changes or migration steps needed -->

## Related Issues
<!-- Link to related issues (e.g., "Fixes #123", "Related to #456") -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Swagger docs updated (if API changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline task cleanup reliability by ensuring cleanup operations complete within a bounded timeframe and now logs warnings when cleanup failures occur, enhancing system observability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/533)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->