### PR TITLE
fix(database): clean up orphaned vault entry on rotation failure (#224)

### DIFF
--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -890,6 +890,13 @@ func (s *DatabaseService) doRotateCredentials(ctx context.Context, id uuid.UUID,
 		time.Sleep(500 * time.Millisecond)
 	}
 	if execErr != nil {
+		// Roll back the orphaned vault entry. Log rollback failures separately
+		// so the operator can clean up by hand instead of conflating two unrelated errors.
+		if rbErr := s.secrets.DeleteSecret(ctx, versionedPath); rbErr != nil {
+			s.logger.Error("orphaned vault entry left after failed credential rotation",
+				"db_id", db.ID, "vault_path", versionedPath, "rollback_error", rbErr)
+			platform.CredentialCleanupFailures.Inc()
+		}
 		return errors.Wrap(errors.Internal, "failed to execute password rotation in container", execErr)
 	}
 
@@ -898,6 +905,10 @@ func (s *DatabaseService) doRotateCredentials(ctx context.Context, id uuid.UUID,
 	db.CredentialPath = versionedPath
 	db.CredentialVersion = newVersion
 	if err := s.repo.Update(ctx, db); err != nil {
+		// DB password has rotated but our record is out of date. The new password is
+		// still in vault at versionedPath, so the operator can recover; log clearly.
+		s.logger.Error("password rotated on engine but failed to persist credential path; recovery requires manual update",
+			"db_id", db.ID, "vault_path", versionedPath, "version", newVersion, "error", err)
 		return errors.Wrap(errors.Internal, "failed to update DB credential path", err)
 	}
 

--- a/internal/core/services/database_vault_test.go
+++ b/internal/core/services/database_vault_test.go
@@ -115,6 +115,93 @@ func TestDatabaseService_RotateCredentials(t *testing.T) {
 		mockRepo.AssertExpectations(t)
 	})
 
+	t.Run("RotateCredentials_ExecFailure_RollsBackOrphanedVaultEntry", func(t *testing.T) {
+		testDB := &domain.Database{
+			ID:               db.ID,
+			UserID:           db.UserID,
+			Name:             db.Name,
+			Engine:           domain.EnginePostgres,
+			Username:         db.Username,
+			ContainerID:      db.ContainerID,
+			CredentialPath:   "secret/rds/" + dbID.String() + "/credentials",
+			CredentialVersion: 1,
+		}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(testDB, nil).Once()
+		mockSecrets.On("GetSecret", mock.Anything, testDB.CredentialPath).Return(map[string]interface{}{"password": "old-pass"}, nil).Once()
+
+		versionedPath := testDB.CredentialPath + "/v2"
+		mockSecrets.On("StoreSecret", mock.Anything, versionedPath, mock.Anything).Return(nil).Once()
+
+		// ALTER USER fails - rollback of orphaned vault entry should be attempted
+		mockCompute.On("Exec", mock.Anything, testDB.ContainerID, mock.Anything).Return("", fmt.Errorf("exec failed")).Times(10)
+		// Rollback: delete orphaned vault entry
+		mockSecrets.On("DeleteSecret", mock.Anything, versionedPath).Return(nil).Once()
+
+		err := svc.RotateCredentials(ctx, dbID, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to execute password rotation in container")
+		mockSecrets.AssertExpectations(t)
+		mockCompute.AssertExpectations(t)
+	})
+
+	t.Run("RotateCredentials_ExecFailure_RollbackFails_StillReturnsOriginalError", func(t *testing.T) {
+		testDB := &domain.Database{
+			ID:               db.ID,
+			UserID:           db.UserID,
+			Name:             db.Name,
+			Engine:           domain.EnginePostgres,
+			Username:         db.Username,
+			ContainerID:      db.ContainerID,
+			CredentialPath:   "secret/rds/" + dbID.String() + "/credentials",
+			CredentialVersion: 1,
+		}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(testDB, nil).Once()
+		mockSecrets.On("GetSecret", mock.Anything, testDB.CredentialPath).Return(map[string]interface{}{"password": "old-pass"}, nil).Once()
+
+		versionedPath := testDB.CredentialPath + "/v2"
+		mockSecrets.On("StoreSecret", mock.Anything, versionedPath, mock.Anything).Return(nil).Once()
+
+		// ALTER USER fails, rollback also fails
+		mockCompute.On("Exec", mock.Anything, testDB.ContainerID, mock.Anything).Return("", fmt.Errorf("exec failed")).Times(10)
+		mockSecrets.On("DeleteSecret", mock.Anything, versionedPath).Return(fmt.Errorf("rollback failed")).Once()
+
+		err := svc.RotateCredentials(ctx, dbID, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to execute password rotation in container")
+		mockSecrets.AssertExpectations(t)
+		mockCompute.AssertExpectations(t)
+	})
+
+	t.Run("RotateCredentials_RepoUpdateFails_AfterRotation_LogsExplicitRecovery", func(t *testing.T) {
+		testDB := &domain.Database{
+			ID:               db.ID,
+			UserID:           db.UserID,
+			Name:             db.Name,
+			Engine:           domain.EnginePostgres,
+			Username:         db.Username,
+			ContainerID:      db.ContainerID,
+			CredentialPath:   "secret/rds/" + dbID.String() + "/credentials",
+			CredentialVersion: 1,
+		}
+		mockRepo.On("GetByID", mock.Anything, dbID).Return(testDB, nil).Once()
+		mockSecrets.On("GetSecret", mock.Anything, testDB.CredentialPath).Return(map[string]interface{}{"password": "old-pass"}, nil).Once()
+
+		versionedPath := testDB.CredentialPath + "/v2"
+		mockSecrets.On("StoreSecret", mock.Anything, versionedPath, mock.Anything).Return(nil).Once()
+		mockCompute.On("Exec", mock.Anything, testDB.ContainerID, mock.Anything).Return("ALTER ROLE", nil).Once()
+
+		// DB record update fails after password was already rotated in the container
+		mockRepo.On("Update", mock.Anything, mock.MatchedBy(func(d *domain.Database) bool {
+			return d.CredentialPath == versionedPath && d.CredentialVersion == 2
+		})).Return(fmt.Errorf("db update failed")).Once()
+
+		err := svc.RotateCredentials(ctx, dbID, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update DB credential path")
+		mockCompute.AssertExpectations(t)
+		mockRepo.AssertExpectations(t)
+	})
+
 	t.Run("RotateCredentials_VaultFailure_WithoutDBChange", func(t *testing.T) {
 		// Create a fresh db for this test
 		testDB := &domain.Database{


### PR DESCRIPTION
When the new password was stored in vault but the ALTER USER call in the database container failed, the new versioned vault entry was orphaned — the engine kept the old password while vault gained an unused versioned secret. Worse, when the persist step failed AFTER a successful password change, the error wrapped two unrelated failures (DB update + rotation context) into one message, obscuring which side of the transaction needed manual recovery.

This change:
- Deletes the orphaned versioned vault entry on exec failure, and logs rollback failures *separately* with structured fields so they can be reconciled without conflating with the original error.
- Adds an explicit error log when the DB record persist fails after the engine already rotated, including the vault path and version so an operator can update the record manually.

---

Closes #224