### PR TITLE
fix(sshutil): default to known_hosts verification (#227)

### DIFF
--- a/pkg/sshutil/client.go
+++ b/pkg/sshutil/client.go
@@ -6,11 +6,21 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
 	"time"
 
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
+
+// envInsecureHostKey, when set to "1"/"true", makes NewClientWithKey accept any host key.
+// This exists only as an explicit escape hatch for tests and one-shot bootstrap flows.
+// Production callers should provide their own HostKeyCallback (e.g. via known_hosts).
+const envInsecureHostKey = "THECLOUD_SSH_INSECURE_IGNORE_HOSTKEY"
+
+// envKnownHostsPath overrides the default ~/.ssh/known_hosts lookup.
+const envKnownHostsPath = "THECLOUD_SSH_KNOWN_HOSTS"
 
 // Client represents an SSH client for remote execution.
 type Client struct {
@@ -21,10 +31,22 @@ type Client struct {
 }
 
 // NewClientWithKey constructs an SSH client using a private key.
+// The HostKeyCallback is derived in order from:
+//  1. THECLOUD_SSH_INSECURE_IGNORE_HOSTKEY=1 → ssh.InsecureIgnoreHostKey() (test/bootstrap only)
+//  2. THECLOUD_SSH_KNOWN_HOSTS → known_hosts file at that path
+//  3. ~/.ssh/known_hosts if it exists
+//
+// If none of the above yield a callback, an error is returned so callers cannot
+// silently fall back to InsecureIgnoreHostKey.
 func NewClientWithKey(host, user, privateKey string) (*Client, error) {
 	signer, err := ssh.ParsePrivateKey([]byte(privateKey))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	cb, err := resolveHostKeyCallback()
+	if err != nil {
+		return nil, err
 	}
 
 	return &Client{
@@ -33,8 +55,53 @@ func NewClientWithKey(host, user, privateKey string) (*Client, error) {
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: cb,
 	}, nil
+}
+
+// NewClientWithKeyAndCallback is the explicit constructor for callers that
+// already have a HostKeyCallback (e.g. a known_hosts-backed callback they
+// share with other SSH consumers).
+func NewClientWithKeyAndCallback(host, user, privateKey string, cb ssh.HostKeyCallback) (*Client, error) {
+	if cb == nil {
+		return nil, fmt.Errorf("host key callback is required")
+	}
+	signer, err := ssh.ParsePrivateKey([]byte(privateKey))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+	return &Client{
+		Host:            host,
+		User:            user,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: cb,
+	}, nil
+}
+
+func resolveHostKeyCallback() (ssh.HostKeyCallback, error) {
+	if v := os.Getenv(envInsecureHostKey); v == "1" || v == "true" {
+		return ssh.InsecureIgnoreHostKey(), nil
+	}
+
+	candidates := make([]string, 0, 2)
+	if p := os.Getenv(envKnownHostsPath); p != "" {
+		candidates = append(candidates, p)
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		candidates = append(candidates, filepath.Join(home, ".ssh", "known_hosts"))
+	}
+	for _, p := range candidates {
+		if _, statErr := os.Stat(p); statErr != nil {
+			continue
+		}
+		cb, err := knownhosts.New(p)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load known_hosts %q: %w", p, err)
+		}
+		return cb, nil
+	}
+
+	return nil, fmt.Errorf("ssh host key verification not configured: set %s to a known_hosts file or %s=1 to bypass (insecure)", envKnownHostsPath, envInsecureHostKey)
 }
 
 // Run executes a command and returns its output.

--- a/pkg/sshutil/client_test.go
+++ b/pkg/sshutil/client_test.go
@@ -71,6 +71,46 @@ func TestNewClientWithKey(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestNewClientWithKey_NoHostKeyVerification(t *testing.T) {
+	// When THECLOUD_SSH_INSECURE_IGNORE_HOSTKEY is NOT set and no known_hosts
+	// file exists, NewClientWithKey must return an error (not silently use insecure defaults).
+	// Use a temp dir as HOME so there's no ~/.ssh/known_hosts fallback.
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv(envInsecureHostKey, "")
+	t.Setenv(envKnownHostsPath, "")
+
+	privKey := generateTestKey(t)
+	_, err := NewClientWithKey(testLocalhostSSH, "user", privKey)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ssh host key verification not configured")
+}
+
+func TestNewClientWithKeyAndCallback(t *testing.T) {
+	privKey := generateTestKey(t)
+
+	t.Run("NilCallback", func(t *testing.T) {
+		_, err := NewClientWithKeyAndCallback(testLocalhostSSH, "user", privKey, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "host key callback is required")
+	})
+
+	t.Run("ValidCallback", func(t *testing.T) {
+		cb := ssh.InsecureIgnoreHostKey()
+		client, err := NewClientWithKeyAndCallback(testLocalhostSSH, "user", privKey, cb)
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.Equal(t, testLocalhostSSH, client.Host)
+	})
+
+	t.Run("InvalidKey", func(t *testing.T) {
+		cb := ssh.InsecureIgnoreHostKey()
+		_, err := NewClientWithKeyAndCallback(testLocalhostSSH, "user", "invalid-key", cb)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse private key")
+	})
+}
+
 func TestWaitForSSH(t *testing.T) {
 	// Start a dummy TCP server
 	l, err := net.Listen("tcp", testLoopbackAddr)

--- a/pkg/sshutil/client_test.go
+++ b/pkg/sshutil/client_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -19,6 +20,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 )
+
+// TestMain switches the package into insecure-host-key mode for the duration
+// of the tests. The library itself refuses to skip verification by default.
+func TestMain(m *testing.M) {
+	if err := os.Setenv(envInsecureHostKey, "1"); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to set %s: %v\n", envInsecureHostKey, err)
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}
 
 // generateTestKey generates a private key for testing
 func generateTestKey(t *testing.T) string {


### PR DESCRIPTION
NewClientWithKey previously hard-coded ssh.InsecureIgnoreHostKey(), which disables host key verification entirely and enables man-in-the-middle attacks against any consumer of the helper. The behavior now is:

1. THECLOUD_SSH_INSECURE_IGNORE_HOSTKEY=1 → explicit opt-in to the old InsecureIgnoreHostKey behavior. Documented as test/bootstrap only.
2. THECLOUD_SSH_KNOWN_HOSTS → load and verify against that known_hosts file.
3. ~/.ssh/known_hosts when present.
4. Otherwise NewClientWithKey returns an error so the caller cannot silently regress to insecure defaults.

A NewClientWithKeyAndCallback constructor is added for callers that already manage their own HostKeyCallback. The test suite uses TestMain to opt into the insecure bypass since it dials throwaway test servers.

---

Closes #227