### PR TITLE
fix(storage): tighten resource cleanup in coordinator and docker adap…

### DIFF
--- a/internal/repositories/docker/adapter.go
+++ b/internal/repositories/docker/adapter.go
@@ -484,7 +484,13 @@ func (a *DockerAdapter) GetInstanceLogs(ctx context.Context, containerID string)
 		return nil, fmt.Errorf("failed to get container logs: %w", err)
 	}
 
-	// Use a pipe to clean the stream asynchronously
+	// Use a pipe to clean the stream asynchronously.
+	// The defers below run on every exit path (including a panic out of
+	// stdcopy.StdCopy), so src is always closed even if StdCopy errors
+	// before consuming the stream. src.Close runs first (LIFO) so the
+	// underlying reader stops producing before the pipe writer closes,
+	// avoiding races where the reader keeps trying to push frames into a
+	// closed writer.
 	r, w := io.Pipe()
 	go func() {
 		defer func() { _ = w.Close() }()

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -313,8 +313,11 @@ func (c *Coordinator) Read(ctx context.Context, bucket, key string) (io.ReadClos
 		repairCtx, cancel := context.WithTimeout(ctx, repairTimeout)
 		go func() {
 			defer cancel()
+			// Ensure the pipe reader is closed on every exit path (panic,
+			// early return inside repairNodes, etc.) so the writer side
+			// upstream can unblock.
+			defer func() { _ = pr.Close() }()
 			c.repairNodes(repairCtx, bucket, key, pr, winner.timestamp, repairNodes)
-			_ = pr.Close()
 		}()
 
 		return &repairingReadCloser{
@@ -453,6 +456,11 @@ func (c *Coordinator) repairNodes(ctx context.Context, bucket, key string, r io.
 				},
 			})
 			if err != nil {
+				// The stream is half-open: it was created on the server side but the
+				// metadata frame failed. Drain it with CloseAndRecv before cancelling
+				// so the server-side goroutine exits cleanly instead of waiting on
+				// context cancellation.
+				_, _ = st.CloseAndRecv()
 				cancel()
 				continue
 			}


### PR DESCRIPTION
…ter (#228, #229, #230)

Three small resource-handling fixes:

* Coordinator.Read: defer pr.Close() so the pipe reader is released on every exit path of the repair goroutine, including panics inside repairNodes. Previously the close ran as a normal statement after repairNodes returned and could be skipped. (#228)

* Coordinator.repairNodes: drain the gRPC store stream with CloseAndRecv when the metadata frame fails. The stream was created on the server but the client just cancelled the context and moved on, leaving the server-side goroutine waiting. (#229)

* DockerAdapter container log pipe: document that src.Close defers before w.Close (LIFO) so the underlying reader stops before the pipe writer closes. The deferred Closes already run on all exit paths; this annotation prevents a future refactor from reordering them. (#230)

## Summary

## Changes

## Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing performed

## Breaking Changes

## Related Issues

## Checklist

- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] All tests pass (\`make test\`)
- [ ] Swagger docs updated (if API changed)

Closes #228
Closes #229
Closes #230