### PR TITLE
fix(docker): bounds-check bindSpec parse in AttachVolume (#234)

### DIFF
--- a/internal/repositories/docker/adapter.go
+++ b/internal/repositories/docker/adapter.go
@@ -792,6 +792,9 @@ func (a *DockerAdapter) AttachVolume(ctx context.Context, id string, volumePath 
 	// Return the container-side mount path and the new container ID
 	// bindSpec format: "devicePath:containerPath[:mode]"
 	parts := strings.Split(bindSpec, ":")
+	if len(parts) < 2 {
+		return "", createResp.ID, fmt.Errorf("invalid bind spec %q: expected hostPath:containerPath[:mode]", bindSpec)
+	}
 	containerPath := parts[1]
 	return containerPath, createResp.ID, nil
 }


### PR DESCRIPTION
fix(docker): bounds-check bindSpec parse in AttachVolume (#234)

Accessing parts[1] without checking len(parts) >= 2 risks a panic if a caller passes a malformed bind spec or volumePath. Return a clear error instead so the new container (already created at this point) can be reported back to the caller for cleanup.

## Summary

## Changes

## Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing performed

## Breaking Changes

## Related Issues

## Checklist

- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] All tests pass (\`make test\`)
- [ ] Swagger docs updated (if API changed)

Closes #234