### PR TITLE
fix(database): validate AllocatedStorage > 0 before resize/create (#2…

### DIFF
--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -372,6 +372,9 @@ func (s *DatabaseService) ModifyDatabase(ctx context.Context, req ports.ModifyDa
 	}
 
 	if req.AllocatedStorage != nil {
+		if *req.AllocatedStorage <= 0 {
+			return nil, errors.New(errors.InvalidInput, "allocated storage must be a positive integer (GB)")
+		}
 		if *req.AllocatedStorage < db.AllocatedStorage {
 			return nil, errors.New(errors.InvalidInput, "cannot decrease allocated storage")
 		}
@@ -942,6 +945,9 @@ func (s *DatabaseService) doRotateCredentials(ctx context.Context, id uuid.UUID,
 func (s *DatabaseService) validateCreationRequest(req ports.CreateDatabaseRequest, engine domain.DatabaseEngine) error {
 	if !s.isValidEngine(engine) {
 		return errors.New(errors.InvalidInput, "unsupported database engine")
+	}
+	if req.AllocatedStorage <= 0 {
+		return errors.New(errors.InvalidInput, "allocated storage must be a positive integer (GB)")
 	}
 	if req.AllocatedStorage < 10 {
 		return errors.New(errors.InvalidInput, "allocated storage must be at least 10GB")


### PR DESCRIPTION
…35, #236)

CreateDatabase and ResizeStorage trusted JSON binding to reject non-positive AllocatedStorage values, but the value type (int) accepts zero and negatives. With those, the downstream volume provision/resize call failed deep in the storage layer with a confusing error.

Reject AllocatedStorage <= 0 with a clear InvalidInput message at the service boundary in both the create-time validator and the ResizeStorage path.

## Summary
<!-- Provide a brief overview of what this PR does -->

## Changes
<!-- List the key changes made in this PR -->

## Test Plan
<!-- Describe how the changes were tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing performed

## Breaking Changes
<!-- List any breaking changes or migration steps needed -->

## Related Issues
<!-- Link to related issues (e.g., "Fixes #123", "Related to #456") -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Swagger docs updated (if API changed)