### PR TITLE
fix(cron): bound per-job HTTP request with explicit timeout (#251)

### DIFF
--- a/internal/core/services/cron_worker.go
+++ b/internal/core/services/cron_worker.go
@@ -15,7 +15,15 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-const ClaimTimeout = 5 * time.Minute
+const (
+	ClaimTimeout = 5 * time.Minute
+
+	// perJobTimeout bounds how long a single cron job's HTTP call may run,
+	// independent of the http.Client's idle/read deadlines. Without it a
+	// slow target endpoint could pin a worker goroutine until the surrounding
+	// process context is cancelled.
+	perJobTimeout = 30 * time.Second
+)
 
 // CronWorker executes scheduled jobs and records run results.
 type CronWorker struct {
@@ -71,7 +79,10 @@ func (w *CronWorker) ProcessJobs(ctx context.Context) {
 func (w *CronWorker) runJob(ctx context.Context, job *domain.CronJob) {
 	start := time.Now()
 
-	req, err := http.NewRequestWithContext(ctx, job.TargetMethod, job.TargetURL, bytes.NewBufferString(job.TargetPayload))
+	jobCtx, cancel := context.WithTimeout(ctx, perJobTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(jobCtx, job.TargetMethod, job.TargetURL, bytes.NewBufferString(job.TargetPayload))
 	if err != nil {
 		w.completeRun(ctx, job, "FAILED", 0, err.Error(), time.Since(start))
 		return


### PR DESCRIPTION
CronWorker.runJob passed the long-lived worker context directly to http.NewRequestWithContext. The shared http.Client has a 30s Timeout but that only covers the *initial* request — a target endpoint that slow-trickles a response (Slowloris-style) can keep the worker goroutine pinned for as long as the worker context lives.

Wrap each job in context.WithTimeout(ctx, perJobTimeout) so a single runaway endpoint can never starve the worker pool. The completeRun call that records the run still uses the parent ctx so we can persist the result even if jobCtx fired.

## Summary
<!-- Provide a brief overview of what this PR does -->

## Changes
<!-- List the key changes made in this PR -->

## Test Plan
<!-- Describe how the changes were tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing performed

## Breaking Changes
<!-- List any breaking changes or migration steps needed -->

## Related Issues
<!-- Link to related issues (e.g., "Fixes #123", "Related to #456") -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Swagger docs updated (if API changed)