### PR TITLE
fix: harden validation and time handling in handlers/workers (#259, #…

### DIFF
--- a/internal/core/services/autoscaling.go
+++ b/internal/core/services/autoscaling.go
@@ -145,10 +145,17 @@ func (s *AutoScalingService) DeleteGroup(ctx context.Context, id uuid.UUID) erro
 		return err
 	}
 
-	// Mark as DELETING to let worker handle cleanup asynchronously
+	// Mark as DELETING to let worker handle cleanup asynchronously.
+	//
+	// MinInstances and DesiredCount are forced to 0 here as a deletion signal,
+	// NOT to represent "this group is unscaled". Callers must always check
+	// group.Status before interpreting these counts: a group in
+	// ScalingGroupStatusDeleting with zero counts is being torn down by the
+	// scaling worker, not idling. GetGroup returns the Status field so
+	// downstream code can distinguish.
 	group.Status = domain.ScalingGroupStatusDeleting
-	group.MinInstances = 0 // Allow desired to be 0
-	group.DesiredCount = 0 // Stop scaling out immediately
+	group.MinInstances = 0
+	group.DesiredCount = 0
 	if err := s.repo.UpdateGroup(ctx, group); err != nil {
 		return err
 	}

--- a/internal/core/services/autoscaling.go
+++ b/internal/core/services/autoscaling.go
@@ -183,6 +183,10 @@ func (s *AutoScalingService) SetDesiredCapacity(ctx context.Context, groupID uui
 		return err
 	}
 
+	if group.Status == domain.ScalingGroupStatusDeleting {
+		return errors.New(errors.InvalidInput, "cannot set desired capacity: group is being deleted")
+	}
+
 	if desired < group.MinInstances || desired > group.MaxInstances {
 		return errors.New(errors.InvalidInput, fmt.Sprintf("desired must be between %d and %d", group.MinInstances, group.MaxInstances))
 	}

--- a/internal/core/services/loadbalancer.go
+++ b/internal/core/services/loadbalancer.go
@@ -42,6 +42,12 @@ func (s *LBService) Create(ctx context.Context, name string, vpcID uuid.UUID, po
 	userID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)
 
+	// Defence-in-depth: the HTTP handler validates min=1,max=65535, but other
+	// callers (CLI, tests, future internal services) can hit Create directly.
+	if port < 1 || port > 65535 {
+		return nil, errors.New(errors.InvalidInput, "port must be in 1..65535")
+	}
+
 	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionLbCreate, "*"); err != nil {
 		return nil, err
 	}
@@ -150,6 +156,10 @@ func (s *LBService) Delete(ctx context.Context, idOrName string) error {
 func (s *LBService) AddTarget(ctx context.Context, lbID, instanceID uuid.UUID, port int, weight int) error {
 	userID := appcontext.UserIDFromContext(ctx)
 	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if port < 1 || port > 65535 {
+		return errors.New(errors.InvalidInput, "port must be in 1..65535")
+	}
 
 	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionLbUpdate, lbID.String()); err != nil {
 		return err

--- a/internal/handlers/accounting_handler.go
+++ b/internal/handlers/accounting_handler.go
@@ -2,11 +2,13 @@
 package httphandlers
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/poyrazk/thecloud/pkg/httputil"
 )
 
@@ -39,14 +41,20 @@ func (h *AccountingHandler) GetSummary(c *gin.Context) {
 	end := now
 
 	if startStr != "" {
-		if t, err := time.Parse(time.RFC3339, startStr); err == nil {
-			start = t
+		t, err := time.Parse(time.RFC3339, startStr)
+		if err != nil {
+			httputil.Error(c, errors.New(errors.InvalidInput, fmt.Sprintf("invalid start time %q (expected RFC3339)", startStr)))
+			return
 		}
+		start = t
 	}
 	if endStr != "" {
-		if t, err := time.Parse(time.RFC3339, endStr); err == nil {
-			end = t
+		t, err := time.Parse(time.RFC3339, endStr)
+		if err != nil {
+			httputil.Error(c, errors.New(errors.InvalidInput, fmt.Sprintf("invalid end time %q (expected RFC3339)", endStr)))
+			return
 		}
+		end = t
 	}
 
 	summary, err := h.svc.GetSummary(c.Request.Context(), userID, start, end)
@@ -77,14 +85,20 @@ func (h *AccountingHandler) ListUsage(c *gin.Context) {
 	end := now
 
 	if startStr != "" {
-		if t, err := time.Parse(time.RFC3339, startStr); err == nil {
-			start = t
+		t, err := time.Parse(time.RFC3339, startStr)
+		if err != nil {
+			httputil.Error(c, errors.New(errors.InvalidInput, fmt.Sprintf("invalid start time %q (expected RFC3339)", startStr)))
+			return
 		}
+		start = t
 	}
 	if endStr != "" {
-		if t, err := time.Parse(time.RFC3339, endStr); err == nil {
-			end = t
+		t, err := time.Parse(time.RFC3339, endStr)
+		if err != nil {
+			httputil.Error(c, errors.New(errors.InvalidInput, fmt.Sprintf("invalid end time %q (expected RFC3339)", endStr)))
+			return
 		}
+		end = t
 	}
 
 	records, err := h.svc.ListUsage(c.Request.Context(), userID, start, end)

--- a/internal/handlers/accounting_handler_test.go
+++ b/internal/handlers/accounting_handler_test.go
@@ -64,7 +64,6 @@ func TestAccountingHandlerGetSummary(t *testing.T) {
 		c, _ := gin.CreateTestContext(w)
 		c.Request = httptest.NewRequest("GET", "/billing/summary", nil)
 
-		// Create a valid UUID for the user
 		userID := uuid.New()
 		c.Set("userID", userID.String())
 
@@ -78,6 +77,42 @@ func TestAccountingHandlerGetSummary(t *testing.T) {
 		err := json.Unmarshal(w.Body.Bytes(), &resp)
 		require.NoError(t, err)
 		assert.InDelta(t, 10.5, resp.Data.TotalAmount, 0.01)
+	})
+
+	t.Run("invalid_start_time", func(t *testing.T) {
+		svc := new(mockAccountingService)
+		handler := NewAccountingHandler(svc)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/billing/summary?start=not-a-time", nil)
+
+		userID := uuid.New()
+		c.Set("userID", userID.String())
+
+		handler.GetSummary(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid start time")
+		assert.Contains(t, w.Body.String(), "expected RFC3339")
+	})
+
+	t.Run("invalid_end_time", func(t *testing.T) {
+		svc := new(mockAccountingService)
+		handler := NewAccountingHandler(svc)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/billing/summary?end=2026-13-01T00:00:00Z", nil)
+
+		userID := uuid.New()
+		c.Set("userID", userID.String())
+
+		handler.GetSummary(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid end time")
+		assert.Contains(t, w.Body.String(), "expected RFC3339")
 	})
 }
 
@@ -105,5 +140,41 @@ func TestAccountingHandlerListUsage(t *testing.T) {
 		handler.ListUsage(c)
 
 		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("invalid_start_time", func(t *testing.T) {
+		svc := new(mockAccountingService)
+		handler := NewAccountingHandler(svc)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/billing/usage?start=invalid", nil)
+
+		userID := uuid.New()
+		c.Set("userID", userID.String())
+
+		handler.ListUsage(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid start time")
+		assert.Contains(t, w.Body.String(), "expected RFC3339")
+	})
+
+	t.Run("invalid_end_time", func(t *testing.T) {
+		svc := new(mockAccountingService)
+		handler := NewAccountingHandler(svc)
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httptest.NewRequest("GET", "/billing/usage?end=2026-13-01T00:00:00Z", nil)
+
+		userID := uuid.New()
+		c.Set("userID", userID.String())
+
+		handler.ListUsage(c)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "invalid end time")
+		assert.Contains(t, w.Body.String(), "expected RFC3339")
 	})
 }

--- a/internal/workers/lifecycle_worker.go
+++ b/internal/workers/lifecycle_worker.go
@@ -95,8 +95,10 @@ func (w *LifecycleWorker) processRule(ctx context.Context, rule *domain.Lifecycl
 			continue
 		}
 
-		// Check expiration
-		age := now.Sub(obj.CreatedAt)
+		// Check expiration. time.Sub is timezone-agnostic (operates on
+		// absolute instants), but converting CreatedAt to UTC explicitly
+		// keeps log lines and any future Format() calls in a single zone.
+		age := now.Sub(obj.CreatedAt.UTC())
 		if age > expiration {
 			logger.Info("expiring object", "key", obj.Key, "age_days", int(age.Hours()/24))
 			if err := w.storageSvc.DeleteObject(ruleCtx, rule.BucketName, obj.Key); err != nil {


### PR DESCRIPTION
fix: harden validation and time handling in handlers/workers (#259, #264, #265, #266)

* LBService.Create and LBService.AddTarget now reject port outside 1..65535 at the service boundary. The HTTP handler already validates via gin binding, but CLI/internal callers can bypass it. (#259)

* AccountingHandler.GetSummary and ListUsage now return InvalidInput when start or end parse fails, instead of silently falling back to the default 1-month window. The previous behavior could return unintended historical data when the caller mis-typed an RFC3339 string. (#264)

* AutoScalingService.DeleteGroup: document that MinInstances=0 and DesiredCount=0 here are deletion signals, not unscaled state. Callers must check Status. (#265)

* lifecycle_worker: explicitly UTC-normalize obj.CreatedAt during age computation so future format/log calls stay in a single zone. The Sub call itself is timezone-agnostic, but the explicit conversion removes the foot-gun. (#266)

## Summary

## Changes

## Test Plan

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing performed

## Breaking Changes

## Related Issues

## Checklist

- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] All tests pass (\`make test\`)
- [ ] Swagger docs updated (if API changed)

Closes #259
Closes #264
Closes #265
Closes #266