### PR TITLE
fix(storage): reject oversized multipart upload parts (#305)

### DIFF
--- a/internal/core/services/storage.go
+++ b/internal/core/services/storage.go
@@ -727,10 +727,24 @@ func (s *StorageService) UploadPart(ctx context.Context, uploadID uuid.UUID, par
 	hash := sha256.New()
 	teeReader := io.TeeReader(r, hash)
 
-	// 3. Write to store (use temporary location)
+	// 3. Write to store (use temporary location).
+	// boundedReader rejects parts larger than maxPartSize instead of silently
+	// truncating, and tears down the partial object so a misbehaving client
+	// cannot exhaust disk by uploading huge parts. (#305)
 	partKey := fmt.Sprintf(partPathFormat, upload.ID.String(), partNumber)
-	size, err := s.store.Write(ctx, upload.Bucket, partKey, io.LimitReader(teeReader, maxPartSize))
+	br := &boundedReader{
+		r:     teeReader,
+		limit: maxPartSize,
+		cleanupFn: func() {
+			_ = s.store.Delete(ctx, upload.Bucket, partKey)
+		},
+	}
+	size, err := s.store.Write(ctx, upload.Bucket, partKey, br)
 	if err != nil {
+		var appErr errors.Error
+		if errors.As(err, &appErr) && appErr.Type == errors.ObjectTooLarge {
+			return nil, err
+		}
 		return nil, errors.Wrap(errors.Internal, "failed to write part", err)
 	}
 


### PR DESCRIPTION
UploadPart used io.LimitReader, which silently truncates at maxPartSize. A client uploading >5GB into a single part would have its data silently clipped, but the server would still return success and persist a malformed part. Worse, the truncation does not free the upload-side buffer, so a malicious client can attempt to upload arbitrarily large parts and exhaust memory before the limit kicks in.

Switch UploadPart to the same boundedReader the regular PutObject path already uses: it errors with ObjectTooLarge once the limit is exceeded and runs cleanupFn to delete the partial object, so disk usage stays bounded.

## Summary
<!-- Provide a brief overview of what this PR does -->

## Changes
<!-- List the key changes made in this PR -->

## Test Plan
<!-- Describe how the changes were tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing performed

## Breaking Changes
<!-- List any breaking changes or migration steps needed -->

## Related Issues
<!-- Link to related issues (e.g., "Fixes #123", "Related to #456") -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Swagger docs updated (if API changed)