### PR TITLE
fix(cli): add standard shorthand flags and positional secret name (#4…

### DIFF
--- a/cmd/cloud/loadbalancer.go
+++ b/cmd/cloud/loadbalancer.go
@@ -135,18 +135,18 @@ var lbRemoveTargetCmd = &cobra.Command{
 }
 
 func init() {
-	lbCreateCmd.Flags().String("name", "", "Name of the load balancer")
+	lbCreateCmd.Flags().StringP("name", "n", "", "Name of the load balancer")
 	cobra.CheckErr(lbCreateCmd.MarkFlagRequired("name"))
-	lbCreateCmd.Flags().String("vpc", "", "VPC ID")
+	lbCreateCmd.Flags().StringP("vpc", "v", "", "VPC ID")
 	cobra.CheckErr(lbCreateCmd.MarkFlagRequired("vpc"))
-	lbCreateCmd.Flags().Int("port", 80, "Public port for the LB")
-	lbCreateCmd.Flags().String("algorithm", "round-robin", "LB algorithm (round-robin or least-conn)")
+	lbCreateCmd.Flags().IntP("port", "p", 80, "Public port for the LB")
+	lbCreateCmd.Flags().StringP("algorithm", "a", "round-robin", "LB algorithm (round-robin or least-conn)")
 
-	lbAddTargetCmd.Flags().String("instance", "", "Target instance ID")
+	lbAddTargetCmd.Flags().StringP("instance", "i", "", "Target instance ID")
 	cobra.CheckErr(lbAddTargetCmd.MarkFlagRequired("instance"))
-	lbAddTargetCmd.Flags().Int("port", 80, "Port on the instance")
+	lbAddTargetCmd.Flags().IntP("port", "p", 80, "Port on the instance")
 	cobra.CheckErr(lbAddTargetCmd.MarkFlagRequired("port"))
-	lbAddTargetCmd.Flags().Int("weight", 1, "Weight for the target (optional)")
+	lbAddTargetCmd.Flags().IntP("weight", "w", 1, "Weight for the target (optional)")
 
 	lbCmd.AddCommand(lbListCmd)
 	lbCmd.AddCommand(lbCreateCmd)

--- a/cmd/cloud/secrets.go
+++ b/cmd/cloud/secrets.go
@@ -50,10 +50,26 @@ var secretsListCmd = &cobra.Command{
 }
 
 var secretsCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   "create [name]",
 	Short: "Store a new encrypted secret",
+	Long: `Store a new encrypted secret.
+
+The name may be given either as a positional argument or with the -n/--name
+flag (whichever is more ergonomic for the caller). The --value flag is
+required either way.`,
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		name, _ := cmd.Flags().GetString("name")
+		// Positional name overrides the -n flag if both are given; this lets
+		// callers do `cloud secrets create mysecret -v hunter2` without having
+		// to remember the flag form.
+		if len(args) == 1 && args[0] != "" {
+			name = args[0]
+		}
+		if name == "" {
+			fmt.Println("Error: secret name required (positional or -n/--name)")
+			return
+		}
 		value, _ := cmd.Flags().GetString("value")
 		desc, _ := cmd.Flags().GetString("description")
 
@@ -121,9 +137,11 @@ func init() {
 	secretsCmd.AddCommand(secretsGetCmd)
 	secretsCmd.AddCommand(secretsRmCmd)
 
-	secretsCreateCmd.Flags().StringP("name", "n", "", "Unique name of the secret (required)")
+	// "name" is optional at the flag layer because the command also accepts a
+	// positional name; the Run function rejects the request if neither is
+	// present. "value" stays required.
+	secretsCreateCmd.Flags().StringP("name", "n", "", "Unique name of the secret (or positional arg)")
 	secretsCreateCmd.Flags().StringP("value", "v", "", "Value to encrypt (required)")
 	secretsCreateCmd.Flags().StringP("description", "d", "", "Optional description")
-	_ = secretsCreateCmd.MarkFlagRequired("name")
 	_ = secretsCreateCmd.MarkFlagRequired("value")
 }

--- a/cmd/cloud/secrets.go
+++ b/cmd/cloud/secrets.go
@@ -67,8 +67,8 @@ required either way.`,
 			name = args[0]
 		}
 		if name == "" {
-			fmt.Println("Error: secret name required (positional or -n/--name)")
-			return
+			fmt.Printf(secretsErrorFormat, "secret name required (use positional argument or -n/--name)")
+			os.Exit(1)
 		}
 		value, _ := cmd.Flags().GetString("value")
 		desc, _ := cmd.Flags().GetString("description")


### PR DESCRIPTION
Closes #10, #449, #545

Users typing the widely-expected one-letter short flags ('-n', '-v', '-p') were getting unknown-flag errors because the cobra command definitions only declared long forms. Add the standard shorthands:

* lb create:    -n name, -v vpc, -p port, -a algorithm
* lb add-target -i instance, -p port, -w weight

For 'secrets create', accept a positional [name] argument as well as the -n flag — cobra rejected `cloud secrets create mysecret -v ...` because it required the flag form. Either form now works; the positional wins if both are given.

## Summary
<!-- Provide a brief overview of what this PR does -->

## Changes
<!-- List the key changes made in this PR -->

## Test Plan
<!-- Describe how the changes were tested -->

- [ ] Unit tests added/updated
- [ ] Integration tests pass
- [ ] Manual testing performed

## Breaking Changes
<!-- List any breaking changes or migration steps needed -->

## Related Issues
<!-- Link to related issues (e.g., "Fixes #123", "Related to #456") -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Documentation updated (if needed)
- [ ] Tests added/updated
- [ ] All tests pass (`make test`)
- [ ] Swagger docs updated (if API changed)