### PR TITLE
fix(cli): support positional [name] [value] for secrets create (#449)

### DIFF
--- a/cmd/cloud/secrets.go
+++ b/cmd/cloud/secrets.go
@@ -50,11 +50,12 @@ var secretsListCmd = &cobra.Command{
 }
 
 var secretsCreateCmd = &cobra.Command{
-	Use:   "create",
+	Use:   "create [name] [value]",
 	Short: "Store a new encrypted secret",
+	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		name, _ := cmd.Flags().GetString("name")
-		value, _ := cmd.Flags().GetString("value")
+		name := args[0]
+		value := args[1]
 		desc, _ := cmd.Flags().GetString("description")
 
 		client := createClient(opts)
@@ -121,9 +122,7 @@ func init() {
 	secretsCmd.AddCommand(secretsGetCmd)
 	secretsCmd.AddCommand(secretsRmCmd)
 
-	secretsCreateCmd.Flags().StringP("name", "n", "", "Unique name of the secret (required)")
-	secretsCreateCmd.Flags().StringP("value", "v", "", "Value to encrypt (required)")
+	secretsCreateCmd.Flags().StringP("name", "n", "", "Unique name of the secret")
+	secretsCreateCmd.Flags().StringP("value", "v", "", "Value to encrypt")
 	secretsCreateCmd.Flags().StringP("description", "d", "", "Optional description")
-	_ = secretsCreateCmd.MarkFlagRequired("name")
-	_ = secretsCreateCmd.MarkFlagRequired("value")
 }

--- a/cmd/cloud/secrets_cli_test.go
+++ b/cmd/cloud/secrets_cli_test.go
@@ -85,12 +85,10 @@ func TestSecretsCreateCmd(t *testing.T) {
 		opts.APIKey = oldKey
 	}()
 
-	_ = secretsCreateCmd.Flags().Set("name", secretsTestName)
-	_ = secretsCreateCmd.Flags().Set("value", "secret-value")
 	_ = secretsCreateCmd.Flags().Set("description", "token")
 
 	out := captureStdout(t, func() {
-		secretsCreateCmd.Run(secretsCreateCmd, nil)
+		secretsCreateCmd.Run(secretsCreateCmd, []string{secretsTestName, "secret-value"})
 	})
 	if !strings.Contains(out, "Secret") || !strings.Contains(out, secretsTestName) {
 		t.Fatalf("expected success output, got: %s", out)


### PR DESCRIPTION
## Summary

Fix `cloud secrets create` to accept `name` and `value` as positional arguments instead of requiring `-n` and `-v` flags. This matches the behavior of `secrets get` and `secrets rm` which already use positional args.

**Before:** `cloud secrets create --name mysecret --value myvalue`  
**After:** `cloud secrets create mysecret myvalue`

## Changes

- Changed `Use: "create"` to `Use: "create [name] [value]"` and added `Args: cobra.ExactArgs(2)`
- Updated `Run` function to read `name` and `value` from positional args instead of flags
- Removed `MarkFlagRequired` for `name` and `value` flags since they are now positional
- Updated test to pass positional args instead of setting flags

## Test Plan

- [x] `go build ./cmd/cloud/...`
- [x] `go test ./cmd/cloud/... -v -run "Secret"`

## Related Issues

- Fixes #449