### PR TITLE
fix: specific error messages for DNS zone creation

### DIFF
--- a/internal/handlers/dns_handler.go
+++ b/internal/handlers/dns_handler.go
@@ -1,6 +1,7 @@
 package httphandlers
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -39,14 +40,34 @@ type CreateZoneRequest struct {
 // @Failure 400,401,500 {object} httputil.Response
 // @Router /dns/zones [post]
 func (h *DNSHandler) CreateZone(c *gin.Context) {
-	var req CreateZoneRequest
+	var raw struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		VpcID       string `json:"vpc_id"`
+	}
 
-	if err := c.ShouldBindJSON(&req); err != nil {
-		httputil.Error(c, errs.New(errs.InvalidInput, errInvalidRequestBody))
+	if err := c.ShouldBindJSON(&raw); err != nil {
+		httputil.Error(c, errs.New(errs.InvalidInput, fmt.Sprintf("invalid request body: %s", err.Error())))
 		return
 	}
 
-	zone, err := h.svc.CreateZone(c.Request.Context(), req.VpcID, req.Name, req.Description)
+	if raw.Name == "" {
+		httputil.Error(c, errs.New(errs.InvalidInput, "field 'name' is required"))
+		return
+	}
+
+	if raw.VpcID == "" {
+		httputil.Error(c, errs.New(errs.InvalidInput, "field 'vpc_id' is required"))
+		return
+	}
+
+	vpcID, err := uuid.Parse(raw.VpcID)
+	if err != nil {
+		httputil.Error(c, errs.New(errs.InvalidInput, "field 'vpc_id' must be a valid UUID"))
+		return
+	}
+
+	zone, err := h.svc.CreateZone(c.Request.Context(), vpcID, raw.Name, raw.Description)
 	if err != nil {
 		httputil.Error(c, err)
 		return

--- a/internal/handlers/dns_handler_test.go
+++ b/internal/handlers/dns_handler_test.go
@@ -61,62 +61,49 @@ func TestCreateZoneHandler(t *testing.T) {
 		assert.Equal(t, testZoneName, response.Name)
 	})
 
-	t.Run("invalid input - missing name", func(t *testing.T) {
+	t.Run("invalid input", func(t *testing.T) {
 		svc := mocks.NewDNSService(t)
 		handler := NewDNSHandler(svc)
 		r := gin.New()
 		r.POST(zonesPath, handler.CreateZone)
 
-		reqBody := map[string]interface{}{
-			"vpc_id": uuid.New().String(),
+		testCases := []struct {
+			name    string
+			payload map[string]interface{}
+			code    int
+			msg     string
+		}{
+			{
+				name:    "missing name",
+				payload: map[string]interface{}{"vpc_id": uuid.New().String()},
+				code:    http.StatusBadRequest,
+				msg:     "field 'name' is required",
+			},
+			{
+				name:    "missing vpc_id",
+				payload: map[string]interface{}{"name": testZoneName},
+				code:    http.StatusBadRequest,
+				msg:     "field 'vpc_id' is required",
+			},
+			{
+				name:    "invalid vpc_id format",
+				payload: map[string]interface{}{"name": testZoneName, "vpc_id": "not-a-valid-uuid"},
+				code:    http.StatusBadRequest,
+				msg:     "field 'vpc_id' must be a valid UUID",
+			},
 		}
-		body, _ := json.Marshal(reqBody)
 
-		req, _ := http.NewRequest(http.MethodPost, zonesPath, bytes.NewBuffer(body))
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				body, _ := json.Marshal(tc.payload)
+				req, _ := http.NewRequest(http.MethodPost, zonesPath, bytes.NewBuffer(body))
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-		assert.Contains(t, w.Body.String(), "field 'name' is required")
-	})
-
-	t.Run("invalid input - missing vpc_id", func(t *testing.T) {
-		svc := mocks.NewDNSService(t)
-		handler := NewDNSHandler(svc)
-		r := gin.New()
-		r.POST(zonesPath, handler.CreateZone)
-
-		reqBody := map[string]interface{}{
-			"name": testZoneName,
+				assert.Equal(t, tc.code, w.Code)
+				assert.Contains(t, w.Body.String(), tc.msg)
+			})
 		}
-		body, _ := json.Marshal(reqBody)
-
-		req, _ := http.NewRequest(http.MethodPost, zonesPath, bytes.NewBuffer(body))
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-		assert.Contains(t, w.Body.String(), "field 'vpc_id' is required")
-	})
-
-	t.Run("invalid input - invalid vpc_id format", func(t *testing.T) {
-		svc := mocks.NewDNSService(t)
-		handler := NewDNSHandler(svc)
-		r := gin.New()
-		r.POST(zonesPath, handler.CreateZone)
-
-		reqBody := map[string]interface{}{
-			"name":   testZoneName,
-			"vpc_id": "not-a-valid-uuid",
-		}
-		body, _ := json.Marshal(reqBody)
-
-		req, _ := http.NewRequest(http.MethodPost, zonesPath, bytes.NewBuffer(body))
-		w := httptest.NewRecorder()
-		r.ServeHTTP(w, req)
-
-		assert.Equal(t, http.StatusBadRequest, w.Code)
-		assert.Contains(t, w.Body.String(), "field 'vpc_id' must be a valid UUID")
 	})
 }
 

--- a/internal/handlers/dns_handler_test.go
+++ b/internal/handlers/dns_handler_test.go
@@ -61,7 +61,7 @@ func TestCreateZoneHandler(t *testing.T) {
 		assert.Equal(t, testZoneName, response.Name)
 	})
 
-	t.Run("invalid input", func(t *testing.T) {
+	t.Run("invalid input - missing name", func(t *testing.T) {
 		svc := mocks.NewDNSService(t)
 		handler := NewDNSHandler(svc)
 		r := gin.New()
@@ -77,6 +77,46 @@ func TestCreateZoneHandler(t *testing.T) {
 		r.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "field 'name' is required")
+	})
+
+	t.Run("invalid input - missing vpc_id", func(t *testing.T) {
+		svc := mocks.NewDNSService(t)
+		handler := NewDNSHandler(svc)
+		r := gin.New()
+		r.POST(zonesPath, handler.CreateZone)
+
+		reqBody := map[string]interface{}{
+			"name": testZoneName,
+		}
+		body, _ := json.Marshal(reqBody)
+
+		req, _ := http.NewRequest(http.MethodPost, zonesPath, bytes.NewBuffer(body))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "field 'vpc_id' is required")
+	})
+
+	t.Run("invalid input - invalid vpc_id format", func(t *testing.T) {
+		svc := mocks.NewDNSService(t)
+		handler := NewDNSHandler(svc)
+		r := gin.New()
+		r.POST(zonesPath, handler.CreateZone)
+
+		reqBody := map[string]interface{}{
+			"name":   testZoneName,
+			"vpc_id": "not-a-valid-uuid",
+		}
+		body, _ := json.Marshal(reqBody)
+
+		req, _ := http.NewRequest(http.MethodPost, zonesPath, bytes.NewBuffer(body))
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		assert.Contains(t, w.Body.String(), "field 'vpc_id' must be a valid UUID")
 	})
 }
 


### PR DESCRIPTION
## Summary
- Return specific error messages for DNS zone creation failures instead of generic "invalid request body"
- "field 'name' is required" when name is missing
- "field 'vpc_id' is required" when vpc_id is missing
- "field 'vpc_id' must be a valid UUID" when vpc_id is not a valid UUID

Fixes #434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for DNS zone creation requests with clearer, more specific error messages for missing or invalid fields.
  * Users now receive detailed feedback on what's required and what validation constraints apply.

* **Tests**
  * Expanded test coverage for DNS zone creation validation scenarios, including missing required fields and invalid input formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/555)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: coderabbitai -->

Closes #434