### PR TITLE
fix: reject cache/DB operations when COMPUTE_BACKEND=libvirt (Issue #432)

### DIFF
--- a/internal/core/services/cache.go
+++ b/internal/core/services/cache.go
@@ -82,6 +82,10 @@ func (s *CacheService) CreateCache(ctx context.Context, name, version string, me
 		return nil, err
 	}
 
+	if s.compute.Type() == "libvirt" {
+		return nil, errors.New(errors.InvalidInput, "managed cache requires docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
+	}
+
 	password, err := util.GenerateRandomPassword(16)
 	if err != nil {
 		return nil, errors.Wrap(errors.Internal, "failed to generate password", err)
@@ -329,6 +333,10 @@ func (s *CacheService) FlushCache(ctx context.Context, idOrName string) error {
 		return errors.New(errors.InstanceNotRunning, "cache is not running")
 	}
 
+	if s.compute.Type() == "libvirt" {
+		return errors.New(errors.InvalidInput, "cache flush requires docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
+	}
+
 	// Exec FLUSHALL inside the container
 	// We need to pass the password if set.
 	cmd := []string{"redis-cli"}
@@ -372,6 +380,10 @@ func (s *CacheService) GetCacheStats(ctx context.Context, idOrName string) (*por
 
 	if cache.Status != domain.CacheStatusRunning {
 		return nil, errors.New(errors.InstanceNotRunning, "cache is not running")
+	}
+
+	if s.compute.Type() == "libvirt" {
+		return nil, errors.New(errors.InvalidInput, "cache stats requires docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
 	}
 
 	stream, err := s.compute.GetInstanceStats(ctx, cache.ContainerID)

--- a/internal/core/services/cache_unit_test.go
+++ b/internal/core/services/cache_unit_test.go
@@ -75,6 +75,7 @@ func testCacheServiceUnitExtended(t *testing.T) {
 	ctx = appcontext.WithTenantID(ctx, tenantID)
 
 	t.Run("CreateCache_Success", func(t *testing.T) {
+		compute.On("Type").Return("docker").Maybe()
 		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
 		compute.On("LaunchInstanceWithOptions", mock.Anything, mock.Anything).Return("cid", []string{"30001:6379"}, nil).Once()
 		repo.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
@@ -88,6 +89,7 @@ func testCacheServiceUnitExtended(t *testing.T) {
 	})
 
 	t.Run("CreateCache_LaunchFailure", func(t *testing.T) {
+		compute.On("Type").Return("docker").Maybe()
 		repo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
 		compute.On("LaunchInstanceWithOptions", mock.Anything, mock.Anything).Return("", nil, fmt.Errorf("launch fail")).Once()
 		repo.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -136,6 +136,11 @@ func (s *DatabaseService) CreateDatabase(ctx context.Context, req ports.CreateDa
 		span.RecordError(err)
 		return nil, err
 	}
+
+	if s.compute.Type() == "libvirt" {
+		return nil, errors.New(errors.InvalidInput, "managed databases require docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
+	}
+
 	dbEngine := domain.DatabaseEngine(req.Engine)
 
 	if err := s.validateCreationRequest(req, dbEngine); err != nil {
@@ -168,6 +173,10 @@ func (s *DatabaseService) CreateReplica(ctx context.Context, primaryID uuid.UUID
 	tenantID := appcontext.TenantIDFromContext(ctx)
 	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionDBCreate, "*"); err != nil {
 		return nil, err
+	}
+
+	if s.compute.Type() == "libvirt" {
+		return nil, errors.New(errors.InvalidInput, "database replicas require docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
 	}
 
 	primary, err := s.repo.GetByID(ctx, primaryID)
@@ -222,6 +231,11 @@ func (s *DatabaseService) RestoreDatabase(ctx context.Context, req ports.Restore
 		span.RecordError(err)
 		return nil, err
 	}
+
+	if s.compute.Type() == "libvirt" {
+		return nil, errors.New(errors.InvalidInput, "database restore requires docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
+	}
+
 	snap, err := s.snapshotSvc.GetSnapshot(ctx, req.SnapshotID)
 	if err != nil {
 		return nil, err
@@ -369,6 +383,10 @@ func (s *DatabaseService) ModifyDatabase(ctx context.Context, req ports.ModifyDa
 
 	if req.Parameters != nil {
 		db.Parameters = req.Parameters
+	}
+
+	if s.compute.Type() == "libvirt" && (req.MetricsEnabled != nil && *req.MetricsEnabled) {
+		return nil, errors.New(errors.InvalidInput, "database metrics require docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
 	}
 
 	if req.AllocatedStorage != nil {
@@ -537,6 +555,11 @@ func (s *DatabaseService) PromoteToPrimary(ctx context.Context, id uuid.UUID) er
 	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionDBUpdate, id.String()); err != nil {
 		return err
 	}
+
+	if s.compute.Type() == "libvirt" {
+		return errors.New(errors.InvalidInput, "database promotion requires docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
+	}
+
 	db, err := s.repo.GetByID(ctx, id)
 	if err != nil {
 		return err
@@ -846,6 +869,10 @@ func (s *DatabaseService) doRotateCredentials(ctx context.Context, id uuid.UUID,
 	db, err := s.repo.GetByID(ctx, id)
 	if err != nil {
 		return err
+	}
+
+	if s.compute.Type() == "libvirt" {
+		return errors.New(errors.InvalidInput, "credential rotation requires docker compute backend (COMPUTE_BACKEND=libvirt is not supported)")
 	}
 
 	newPassword, err := util.GenerateRandomPassword(16)

--- a/internal/core/services/database_unit_test.go
+++ b/internal/core/services/database_unit_test.go
@@ -94,6 +94,7 @@ func testDatabaseServiceUnitExtended(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("CreateDatabase_Success", func(t *testing.T) {
+		mockCompute.On("Type").Return("docker").Maybe()
 		mockVolumeSvc.On("CreateVolume", mock.Anything, mock.Anything, 20).
 			Return(&domain.Volume{ID: uuid.New(), Name: "db-vol"}, nil).Once()
 
@@ -949,6 +950,7 @@ func testDatabaseServiceUnitRepoErrors(t *testing.T) {
 
 	t.Run("PromoteToPrimary_NotFound", func(t *testing.T) {
 		dbID := uuid.New()
+		mockCompute.On("Type").Return("docker").Maybe()
 		mockRepo.On("GetByID", mock.Anything, dbID).Return(nil, errors.New(errors.NotFound, "not found")).Once()
 
 		err := svc.PromoteToPrimary(ctx, dbID)
@@ -957,6 +959,7 @@ func testDatabaseServiceUnitRepoErrors(t *testing.T) {
 
 	t.Run("PromoteToPrimary_AlreadyPrimary", func(t *testing.T) {
 		dbID := uuid.New()
+		mockCompute.On("Type").Return("docker").Maybe()
 		db := &domain.Database{ID: dbID, Role: domain.RolePrimary, Engine: domain.EnginePostgres, ContainerID: "cid"}
 		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
 
@@ -967,6 +970,7 @@ func testDatabaseServiceUnitRepoErrors(t *testing.T) {
 
 	t.Run("PromoteToPrimary_UnsupportedEngine", func(t *testing.T) {
 		dbID := uuid.New()
+		mockCompute.On("Type").Return("docker").Maybe()
 		db := &domain.Database{ID: dbID, Role: domain.RoleReplica, Engine: domain.DatabaseEngine("oracle"), ContainerID: "cid"}
 		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
 
@@ -977,6 +981,7 @@ func testDatabaseServiceUnitRepoErrors(t *testing.T) {
 
 	t.Run("PromoteToPrimary_ExecError", func(t *testing.T) {
 		dbID := uuid.New()
+		mockCompute.On("Type").Return("docker").Maybe()
 		db := &domain.Database{ID: dbID, Role: domain.RoleReplica, Engine: domain.EnginePostgres, ContainerID: "cid", Username: "user"}
 		mockRepo.On("GetByID", mock.Anything, dbID).Return(db, nil).Once()
 		mockCompute.On("Exec", mock.Anything, "cid", []string{"touch", "/var/lib/postgresql/data/promote"}).Return("", fmt.Errorf("exec error")).Once()
@@ -1156,10 +1161,13 @@ func testDatabaseServiceUnitValidationErrors(t *testing.T) {
 	mockRBAC.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 	defer mock.AssertExpectationsForObjects(t, mockRBAC)
 
+	mockCompute := new(MockComputeBackend)
+	mockCompute.On("Type").Return("docker").Maybe()
+
 	svc := services.NewDatabaseService(services.DatabaseServiceParams{
 		Repo:         new(DatabaseUnitMockRepo),
 		RBAC:         mockRBAC,
-		Compute:      new(MockComputeBackend),
+		Compute:      mockCompute,
 		VpcRepo:      new(MockVpcRepo),
 		VolumeSvc:    new(MockVolumeService),
 		SnapshotSvc:  new(mockSnapshotService),

--- a/internal/core/services/database_vault_test.go
+++ b/internal/core/services/database_vault_test.go
@@ -86,6 +86,7 @@ func TestDatabaseService_RotateCredentials(t *testing.T) {
 		}
 		mockRepo.On("GetByID", mock.Anything, dbID).Return(testDB, nil).Once()
 		mockSecrets.On("GetSecret", mock.Anything, testDB.CredentialPath).Return(map[string]interface{}{"password": "old-pass"}, nil).Once()
+		mockCompute.On("Type").Return("docker").Maybe()
 
 		// 1. Store new credential at versioned path in Vault FIRST (version 2 since db starts at version 1)
 		versionedPath := testDB.CredentialPath + "/v2"
@@ -129,6 +130,7 @@ func TestDatabaseService_RotateCredentials(t *testing.T) {
 		}
 		mockRepo.On("GetByID", mock.Anything, dbID).Return(testDB, nil).Once()
 		mockSecrets.On("GetSecret", mock.Anything, testDB.CredentialPath).Return(map[string]interface{}{"password": "old-pass"}, nil).Once()
+		mockCompute.On("Type").Return("docker").Maybe()
 		// Vault store fails at step 1 (versioned path) - DB is NOT changed
 		versionedPath := testDB.CredentialPath + "/v2"
 		mockSecrets.On("StoreSecret", mock.Anything, versionedPath, mock.Anything).Return(fmt.Errorf("vault error")).Once()
@@ -166,6 +168,7 @@ func TestDatabaseService_VaultIntegration_CreateDatabase(t *testing.T) {
 		Logger:         slog.Default(),
 		VaultMountPath: "secret/rds",
 	})
+	mockCompute.On("Type").Return("docker").Maybe()
 
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- Reject managed cache (Redis) and database (Postgres/MySQL) operations when `COMPUTE_BACKEND=libvirt` with clear error messages
- These services are Docker-native and fail fast rather than attempting Docker-specific operations on libvirt

## Changes

### CacheService (`cache.go`)
- `CreateCache`: reject if libvirt backend
- `FlushCache`: reject if libvirt (Exec not supported on libvirt)
- `GetCacheStats`: reject if libvirt (stats format is Docker-specific)

### DatabaseService (`database.go`)
- `CreateDatabase`: reject if libvirt backend
- `CreateReplica`: reject if libvirt backend
- `RestoreDatabase`: reject if libvirt backend
- `ModifyDatabase`: reject if enabling metrics on libvirt
- `PromoteToPrimary`: reject if libvirt (Exec not supported on libvirt)
- `doRotateCredentials`: reject if libvirt (Exec not supported on libvirt)

### Unit tests
- Updated mocks to handle `compute.Type()` calls in `cache_unit_test.go` and `database_unit_test.go`

## Test Plan
- [x] `go test ./internal/core/services/... -run "TestCacheService_Unit|TestDatabaseService_Unit" -v` — all tests pass
- [x] Unit tests updated to mock `compute.Type()` calls

## Breaking Changes
None — behavior unchanged when `COMPUTE_BACKEND=docker`

## Related Issues
Fixes #432