### PR TITLE
fix: return typed errors from queue service (#440)

### DIFF
--- a/internal/core/services/queue.go
+++ b/internal/core/services/queue.go
@@ -11,6 +11,7 @@ import (
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/poyrazk/thecloud/internal/platform"
 )
 
@@ -48,7 +49,7 @@ func (s *QueueService) CreateQueue(ctx context.Context, name string, opts *ports
 		return nil, err
 	}
 	if existing != nil {
-		return nil, fmt.Errorf("queue with name %s already exists", name)
+		return nil, errors.New(errors.Conflict, fmt.Sprintf("queue with name %s already exists", name))
 	}
 
 	qID := uuid.New()
@@ -108,7 +109,7 @@ func (s *QueueService) GetQueue(ctx context.Context, id uuid.UUID) (*domain.Queu
 		return nil, err
 	}
 	if q == nil {
-		return nil, fmt.Errorf("queue not found")
+		return nil, errors.New(errors.NotFound, "queue not found")
 	}
 
 	return q, nil
@@ -138,7 +139,7 @@ func (s *QueueService) DeleteQueue(ctx context.Context, id uuid.UUID) error {
 		return err
 	}
 	if q == nil {
-		return fmt.Errorf("queue not found")
+		return errors.New(errors.NotFound, "queue not found")
 	}
 
 	if err := s.repo.Delete(ctx, q.ID, tenantID); err != nil {
@@ -171,11 +172,11 @@ func (s *QueueService) SendMessage(ctx context.Context, queueID uuid.UUID, body 
 		return nil, err
 	}
 	if q == nil {
-		return nil, fmt.Errorf("queue not found")
+		return nil, errors.New(errors.NotFound, "queue not found")
 	}
 
 	if len(body) > q.MaxMessageSize {
-		return nil, fmt.Errorf("message size exceeds limit of %d bytes", q.MaxMessageSize)
+		return nil, errors.New(errors.InvalidInput, fmt.Sprintf("message size exceeds limit of %d bytes", q.MaxMessageSize))
 	}
 
 	m, err := s.repo.SendMessage(ctx, q.ID, body)
@@ -205,7 +206,7 @@ func (s *QueueService) ReceiveMessages(ctx context.Context, queueID uuid.UUID, m
 		return nil, err
 	}
 	if q == nil {
-		return nil, fmt.Errorf("queue not found")
+		return nil, errors.New(errors.NotFound, "queue not found")
 	}
 
 	if maxMessages <= 0 {
@@ -243,7 +244,7 @@ func (s *QueueService) DeleteMessage(ctx context.Context, queueID uuid.UUID, rec
 		return err
 	}
 	if q == nil {
-		return fmt.Errorf("queue not found")
+		return errors.New(errors.NotFound, "queue not found")
 	}
 
 	if err := s.repo.DeleteMessage(ctx, q.ID, receiptHandle); err != nil {
@@ -272,7 +273,7 @@ func (s *QueueService) PurgeQueue(ctx context.Context, queueID uuid.UUID) error 
 		return err
 	}
 	if q == nil {
-		return fmt.Errorf("queue not found")
+		return errors.New(errors.NotFound, "queue not found")
 	}
 
 	_, err = s.repo.PurgeMessages(ctx, q.ID)

--- a/internal/core/services/queue_unit_test.go
+++ b/internal/core/services/queue_unit_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	apierrors "github.com/poyrazk/thecloud/internal/errors"
 	"log/slog"
 	"testing"
 
@@ -40,6 +41,88 @@ func TestQueueServiceUnit(t *testing.T) {
 		assert.NotNil(t, q)
 		assert.Equal(t, "my-queue", q.Name)
 		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("CreateQueue error types", func(t *testing.T) {
+		t.Run("duplicate returns Conflict", func(t *testing.T) {
+			mockRepo.On("GetByName", mock.Anything, "existing-queue", mock.Anything).Return(&domain.Queue{ID: uuid.New()}, nil).Once()
+
+			_, err := svc.CreateQueue(ctx, "existing-queue", nil)
+			require.Error(t, err)
+
+			var appErr apierrors.Error
+			if apierrors.As(err, &appErr) {
+				assert.Equal(t, apierrors.Conflict, appErr.Type)
+			} else {
+				t.Fatalf("expected apierrors.Error, got %T", err)
+			}
+		})
+	})
+
+	t.Run("GetQueue error types", func(t *testing.T) {
+		t.Run("not found returns NotFound", func(t *testing.T) {
+			qID := uuid.New()
+			mockRepo.On("GetByID", mock.Anything, qID, mock.Anything).Return(nil, nil).Once()
+
+			_, err := svc.GetQueue(ctx, qID)
+			require.Error(t, err)
+
+			var appErr apierrors.Error
+			if apierrors.As(err, &appErr) {
+				assert.Equal(t, apierrors.NotFound, appErr.Type)
+			} else {
+				t.Fatalf("expected apierrors.Error, got %T", err)
+			}
+		})
+	})
+
+	t.Run("DeleteQueue error types", func(t *testing.T) {
+		t.Run("not found returns NotFound", func(t *testing.T) {
+			qID := uuid.New()
+			mockRepo.On("GetByID", mock.Anything, qID, mock.Anything).Return(nil, nil).Once()
+
+			err := svc.DeleteQueue(ctx, qID)
+			require.Error(t, err)
+
+			var appErr apierrors.Error
+			if apierrors.As(err, &appErr) {
+				assert.Equal(t, apierrors.NotFound, appErr.Type)
+			} else {
+				t.Fatalf("expected apierrors.Error, got %T", err)
+			}
+		})
+	})
+
+	t.Run("SendMessage error types", func(t *testing.T) {
+		t.Run("queue not found returns NotFound", func(t *testing.T) {
+			qID := uuid.New()
+			mockRepo.On("GetByID", mock.Anything, qID, mock.Anything).Return(nil, nil).Once()
+
+			_, err := svc.SendMessage(ctx, qID, "hello")
+			require.Error(t, err)
+
+			var appErr apierrors.Error
+			if apierrors.As(err, &appErr) {
+				assert.Equal(t, apierrors.NotFound, appErr.Type)
+			} else {
+				t.Fatalf("expected apierrors.Error, got %T", err)
+			}
+		})
+
+		t.Run("message too large returns InvalidInput", func(t *testing.T) {
+			qID := uuid.New()
+			mockRepo.On("GetByID", mock.Anything, qID, mock.Anything).Return(&domain.Queue{ID: qID, MaxMessageSize: 5}, nil).Once()
+
+			_, err := svc.SendMessage(ctx, qID, "this message is too long")
+			require.Error(t, err)
+
+			var appErr apierrors.Error
+			if apierrors.As(err, &appErr) {
+				assert.Equal(t, apierrors.InvalidInput, appErr.Type)
+			} else {
+				t.Fatalf("expected apierrors.Error, got %T", err)
+			}
+		})
 	})
 
 	t.Run("SendMessage", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Replace `fmt.Errorf` calls in queue service with `errors.New(errors.<Type>, ...)` for typed errors
- Operations now return specific error types (NotFound, Conflict, InvalidInput) instead of generic Internal errors

Fixes #440