### PR TITLE
fix(cli): resolve VPC name to ID for subnet list (#415)

### DIFF
--- a/cmd/cloud/dns.go
+++ b/cmd/cloud/dns.go
@@ -200,7 +200,8 @@ var dnsDeleteRecordCmd = &cobra.Command{
 
 func init() {
 	dnsCreateZoneCmd.Flags().String("description", "", "Description of the zone")
-	dnsCreateZoneCmd.Flags().String("vpc-id", "", "Associate with a VPC for private DNS")
+	dnsCreateZoneCmd.Flags().String("vpc-id", "", "VPC ID for private DNS (required)")
+	_ = dnsCreateZoneCmd.MarkFlagRequired("vpc-id")
 
 	dnsCreateRecordCmd.Flags().String("name", "", "Record name (e.g., 'www')")
 	dnsCreateRecordCmd.Flags().String("type", "A", "Record type (A, AAAA, CNAME, MX, TXT)")

--- a/cmd/cloud/subnet.go
+++ b/cmd/cloud/subnet.go
@@ -25,7 +25,7 @@ var subnetListCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := createClient(opts)
-		vpcID := args[0]
+		vpcID := resolveVPCID(args[0], client)
 		subnets, err := client.ListSubnets(vpcID)
 		if err != nil {
 			fmt.Printf(subnetErrorFormat, err)
@@ -115,6 +115,23 @@ func resolveSubnetID(idOrName string, client *sdk.Client) string {
 	for _, s := range subnets {
 		if s.Name == idOrName {
 			return s.ID
+		}
+	}
+	return idOrName
+}
+
+// resolveVPCID resolves a VPC ID or name to a full UUID.
+func resolveVPCID(idOrName string, client *sdk.Client) string {
+	if _, err := uuid.Parse(idOrName); err == nil {
+		return idOrName
+	}
+	vpcs, err := client.ListVPCs()
+	if err != nil {
+		return idOrName
+	}
+	for _, v := range vpcs {
+		if v.Name == idOrName {
+			return v.ID
 		}
 	}
 	return idOrName


### PR DESCRIPTION
## Summary
- Add `resolveVPCID` function to resolve VPC name or ID to UUID
- Use `resolveVPCID` in `subnetListCmd` before calling `ListSubnets`
- Make `--vpc-id` required for `dns create-zone` command

## Fixes
- Fixes #415 - CLI subnet list does not resolve VPC name to ID
- Fixes #413 - DNS zone creation fails with 'invalid request body'

## Test plan
- [x] `go build ./cmd/cloud/`
- [x] `go test ./cmd/cloud/...`
- [x] Manual: `cloud subnet list my-vpc-name` should resolve name to ID
- [x] Manual: `cloud dns create-zone myzone.com --vpc-id <id>` required