### PR TITLE
chore(lint): remove errcheck exclusions for cmd/thecloud and pkg/sdk

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,12 +49,6 @@ linters-settings:
 
 issues:
   exclude-rules:
-    - path: cmd/thecloud
-      linters:
-        - errcheck
-    - path: pkg/sdk
-      linters:
-        - errcheck
     - path: internal/handlers/ws
       linters:
         - errcheck


### PR DESCRIPTION
## Summary
- Remove overly broad `errcheck` exclusions for `cmd/thecloud` and `pkg/sdk` paths
- Lint passes cleanly with these exclusions removed, confirming they weren't masking real issues
- Kept gosec G101/G106 excludes for legitimate false positives (SSH configs, test constants, string formatting patterns)
- Kept `_test\.go` gosec exclusion for test files

## Test plan
- [x] `golangci-lint run ./cmd/... ./pkg/...` passes with exit 0
- [x] `golangci-lint run ./...` passes with exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened error handling requirements in the codebase by removing specific linter exclusions, ensuring more rigorous code quality checks across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/560)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->