### PR TITLE
feat(cli): add resize commands for volume, database, and cache (#442)

### DIFF
--- a/cmd/cloud/cache.go
+++ b/cmd/cloud/cache.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"text/tabwriter"
 	"time"
 
@@ -178,6 +179,22 @@ var flushCacheCmd = &cobra.Command{
 	},
 }
 
+var resizeCacheCmd = &cobra.Command{
+	Use:   "resize [id] [memoryMB]",
+	Short: "Resize cache memory allocation",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := createClient(opts)
+		cacheID := resolveCacheID(args[0], client)
+		memory, _ := strconv.Atoi(args[1])
+		if err := client.ResizeCache(cacheID, memory); err != nil {
+			fmt.Printf("Error resizing cache: %v\n", err)
+			return
+		}
+		fmt.Printf("[SUCCESS] Cache %s resized to %d MB.\n", cacheID, memory)
+	},
+}
+
 // resolveCacheID resolves a cache ID or name to a full UUID.
 func resolveCacheID(idOrName string, client *sdk.Client) string {
 	if _, err := uuid.Parse(idOrName); err == nil {
@@ -212,6 +229,7 @@ func init() {
 	cacheCmd.AddCommand(connectionCacheCmd)
 	cacheCmd.AddCommand(statsCacheCmd)
 	cacheCmd.AddCommand(flushCacheCmd)
+	cacheCmd.AddCommand(resizeCacheCmd)
 }
 
 func formatBytes(b int64) string {

--- a/cmd/cloud/db.go
+++ b/cmd/cloud/db.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/olekukonko/tablewriter"
@@ -189,6 +190,22 @@ var dbRotateCmd = &cobra.Command{
 	},
 }
 
+var dbResizeCmd = &cobra.Command{
+	Use:   "resize [id] [sizeGB]",
+	Short: "Resize database allocated storage",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		size, _ := strconv.Atoi(args[1])
+		client := createClient(opts)
+		if err := client.ResizeDatabase(id, size); err != nil {
+			fmt.Printf(errorFormat, err)
+			return
+		}
+		fmt.Printf("[SUCCESS] Database %s resized to %d GB.\n", id, size)
+	},
+}
+
 func init() {
 	dbCmd.AddCommand(dbListCmd)
 	dbCmd.AddCommand(dbCreateCmd)
@@ -196,6 +213,7 @@ func init() {
 	dbCmd.AddCommand(dbRmCmd)
 	dbCmd.AddCommand(dbConnCmd)
 	dbCmd.AddCommand(dbRotateCmd)
+	dbCmd.AddCommand(dbResizeCmd)
 
 	dbCreateCmd.Flags().StringP("name", "n", "", "Name of the database (required)")
 	dbCreateCmd.Flags().StringP("engine", "e", "postgres", "Database engine (postgres/mysql)")

--- a/cmd/cloud/volume.go
+++ b/cmd/cloud/volume.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
@@ -93,10 +94,27 @@ var volumeDeleteCmd = &cobra.Command{
 	},
 }
 
+var volumeResizeCmd = &cobra.Command{
+	Use:   "resize [id/name] [sizeGB]",
+	Short: "Resize a volume to a larger size",
+	Args:  cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		id := args[0]
+		size, _ := strconv.Atoi(args[1])
+		client := createClient(opts)
+		if err := client.ResizeVolume(id, size); err != nil {
+			fmt.Printf(volumeErrorFormat, err)
+			return
+		}
+		fmt.Printf("[SUCCESS] Volume %s resized to %d GB.\n", id, size)
+	},
+}
+
 func init() {
 	volumeCmd.AddCommand(volumeListCmd)
 	volumeCmd.AddCommand(volumeCreateCmd)
 	volumeCmd.AddCommand(volumeDeleteCmd)
+	volumeCmd.AddCommand(volumeResizeCmd)
 
 	volumeCreateCmd.Flags().StringP("name", "n", "", "Name of the volume (required)")
 	volumeCreateCmd.Flags().IntP("size", "s", 1, "Size in GB")

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -513,6 +513,7 @@ func registerDataRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		volumeGroup.DELETE("/:id", httputil.Permission(svcs.RBAC, domain.PermissionVolumeDelete), handlers.Volume.Delete)
 		volumeGroup.POST("/:id/attach", httputil.Permission(svcs.RBAC, domain.PermissionVolumeUpdate), handlers.Volume.Attach)
 		volumeGroup.POST("/:id/detach", httputil.Permission(svcs.RBAC, domain.PermissionVolumeUpdate), handlers.Volume.Detach)
+		volumeGroup.POST("/:id/resize", httputil.Permission(svcs.RBAC, domain.PermissionVolumeUpdate), handlers.Volume.Resize)
 	}
 
 	dbGroup := r.Group("/databases")
@@ -532,6 +533,7 @@ func registerDataRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		dbGroup.POST("/:id/rotate-credentials", httputil.Permission(svcs.RBAC, domain.PermissionDBUpdate), handlers.Database.RotateCredentials)
 		dbGroup.POST("/:id/stop", httputil.Permission(svcs.RBAC, domain.PermissionDBUpdate), handlers.Database.Stop)
 		dbGroup.POST("/:id/start", httputil.Permission(svcs.RBAC, domain.PermissionDBUpdate), handlers.Database.Start)
+		dbGroup.POST("/:id/resize", httputil.Permission(svcs.RBAC, domain.PermissionDBUpdate), handlers.Database.Resize)
 	}
 
 	cacheGroup := r.Group("/caches")
@@ -544,6 +546,7 @@ func registerDataRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		cacheGroup.GET("/:id/connection", httputil.Permission(svcs.RBAC, domain.PermissionCacheRead), handlers.Cache.GetConnectionString)
 		cacheGroup.POST("/:id/flush", httputil.Permission(svcs.RBAC, domain.PermissionCacheUpdate), handlers.Cache.Flush)
 		cacheGroup.GET("/:id/stats", httputil.Permission(svcs.RBAC, domain.PermissionCacheRead), handlers.Cache.GetStats)
+		cacheGroup.POST("/:id/resize", httputil.Permission(svcs.RBAC, domain.PermissionCacheUpdate), handlers.Cache.Resize)
 	}
 
 	secretGroup := r.Group("/secrets")

--- a/internal/core/ports/cache.go
+++ b/internal/core/ports/cache.go
@@ -32,6 +32,8 @@ type CacheService interface {
 	FlushCache(ctx context.Context, idOrName string) error
 	// GetCacheStats retrieves real-time performance metrics from the engine.
 	GetCacheStats(ctx context.Context, idOrName string) (*CacheStats, error)
+	// ResizeCache changes the memory allocation of a running cache instance.
+	ResizeCache(ctx context.Context, idOrName string, newMemoryMB int) error
 }
 
 // CacheRepository handles the persistence of cache metadata.

--- a/internal/core/ports/database.go
+++ b/internal/core/ports/database.go
@@ -89,4 +89,6 @@ type DatabaseService interface {
 	StopDatabase(ctx context.Context, id uuid.UUID) error
 	// StartDatabase starts a stopped database instance.
 	StartDatabase(ctx context.Context, id uuid.UUID) error
+	// ResizeDatabase resizes the allocated storage for a database instance.
+	ResizeDatabase(ctx context.Context, id uuid.UUID, newSizeGB int) error
 }

--- a/internal/core/services/cache.go
+++ b/internal/core/services/cache.go
@@ -460,6 +460,82 @@ func parseRedisClients(info string) int {
 	return 0
 }
 
+func (s *CacheService) ResizeCache(ctx context.Context, idOrName string, newMemoryMB int) error {
+	tracer := otel.Tracer(tracerNameCache)
+	_, span := tracer.Start(ctx, "CacheService.ResizeCache",
+		trace.WithAttributes(
+			attribute.String("cache.id_or_name", idOrName),
+			attribute.Int("cache.new_memory_mb", newMemoryMB),
+		))
+	defer span.End()
+
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionCacheUpdate, idOrName); err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	cache, err := s.getCacheByIDOrName(ctx, idOrName)
+	if err != nil {
+		span.RecordError(err)
+		return err
+	}
+
+	if newMemoryMB <= cache.MemoryMB {
+		return errors.New(errors.InvalidInput, "new memory must be larger than current memory")
+	}
+
+	if s.compute.Type() != "docker" {
+		return errors.New(errors.InvalidInput, "cache memory resize requires docker compute backend")
+	}
+
+	networkID, err := s.resolveNetworkID(ctx, cache.VpcID)
+	if err != nil {
+		return err
+	}
+
+	// Stop and delete old container
+	if cache.ContainerID != "" {
+		if err := s.compute.StopInstance(ctx, cache.ContainerID); err != nil {
+			s.logger.Warn("failed to stop cache container for resize", "container_id", cache.ContainerID, "error", err)
+		}
+		if err := s.compute.DeleteInstance(ctx, cache.ContainerID); err != nil {
+			s.logger.Warn("failed to delete cache container for resize", "container_id", cache.ContainerID, "error", err)
+		}
+	}
+
+	// Relaunch with new memory limit
+	containerID, allocatedPorts, err := s.launchCacheContainer(ctx, cache, networkID)
+	if err != nil {
+		return errors.Wrap(errors.Internal, "failed to relaunch cache with new memory", err)
+	}
+
+	port, _ := s.parseAllocatedPort(allocatedPorts, defaultRedisPort)
+	if port == 0 {
+		port, _ = s.compute.GetInstancePort(ctx, containerID, defaultRedisPort)
+	}
+
+	cache.ContainerID = containerID
+	cache.Port = port
+	cache.MemoryMB = newMemoryMB
+	cache.UpdatedAt = time.Now()
+	if err := s.repo.Update(ctx, cache); err != nil {
+		return err
+	}
+
+	if err := s.auditSvc.Log(ctx, cache.UserID, "cache.resize", "cache", cache.ID.String(), map[string]interface{}{
+		"name":         cache.Name,
+		"old_memory_mb": cache.MemoryMB,
+		"new_memory_mb": newMemoryMB,
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "cache_id", cache.ID, "error", err)
+	}
+
+	return nil
+}
+
 func parseRedisKeys(info string) int64 {
 	var total int64
 	lines := strings.Split(info, "\r\n")

--- a/internal/core/services/database.go
+++ b/internal/core/services/database.go
@@ -786,6 +786,48 @@ func (s *DatabaseService) StartDatabase(ctx context.Context, id uuid.UUID) error
 	return nil
 }
 
+func (s *DatabaseService) ResizeDatabase(ctx context.Context, id uuid.UUID, newSizeGB int) error {
+	userID := appcontext.UserIDFromContext(ctx)
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.rbacSvc.Authorize(ctx, userID, tenantID, domain.PermissionDBUpdate, id.String()); err != nil {
+		return err
+	}
+
+	db, err := s.repo.GetByID(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if newSizeGB <= db.AllocatedStorage {
+		return errors.New(errors.InvalidInput, "new size must be larger than current allocated storage")
+	}
+
+	vol, err := s.getVolumeForDatabase(ctx, db)
+	if err != nil {
+		return err
+	}
+
+	if err := s.volumeSvc.ResizeVolume(ctx, vol.ID.String(), newSizeGB); err != nil {
+		return err
+	}
+
+	db.AllocatedStorage = newSizeGB
+	db.UpdatedAt = time.Now()
+	if err := s.repo.Update(ctx, db); err != nil {
+		return err
+	}
+
+	if err := s.auditSvc.Log(ctx, db.UserID, "database.resize", "database", db.ID.String(), map[string]interface{}{
+		"name":        db.Name,
+		"old_size_gb": vol.SizeGB,
+		"new_size_gb": newSizeGB,
+	}); err != nil {
+		s.logger.Warn("failed to log audit event", "database_id", db.ID, "error", err)
+	}
+
+	return nil
+}
+
 func (s *DatabaseService) waitForDatabaseReady(ctx context.Context, db *domain.Database) error {
 	ticker := time.NewTicker(1 * time.Second)
 	defer ticker.Stop()

--- a/internal/handlers/cache_handler.go
+++ b/internal/handlers/cache_handler.go
@@ -102,3 +102,36 @@ func (h *CacheHandler) GetStats(c *gin.Context) {
 	}
 	httputil.Success(c, http.StatusOK, stats)
 }
+
+// ResizeCacheRequest is the payload for resizing cache memory.
+type ResizeCacheRequest struct {
+	MemoryMB int `json:"memory_mb" binding:"required,min=64"`
+}
+
+// Resize resizes a cache instance's memory allocation
+// @Summary Resize cache memory
+// @Description Changes the memory allocation of a running Redis cache instance (requires restart)
+// @Tags caches
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Cache ID or name"
+// @Param request body ResizeCacheRequest true "Resize request"
+// @Success 200 {object} httputil.Response
+// @Failure 400 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /caches/{id}/resize [post]
+func (h *CacheHandler) Resize(c *gin.Context) {
+	idOrName := c.Param("id")
+	var req ResizeCacheRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid request body"))
+		return
+	}
+	if err := h.svc.ResizeCache(c.Request.Context(), idOrName, req.MemoryMB); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, gin.H{"message": "cache resized", "memory_mb": req.MemoryMB})
+}

--- a/internal/handlers/cache_handler_test.go
+++ b/internal/handlers/cache_handler_test.go
@@ -76,6 +76,10 @@ func (m *mockCacheService) GetCacheStats(ctx context.Context, idOrName string) (
 	return r0, args.Error(1)
 }
 
+func (m *mockCacheService) ResizeCache(ctx context.Context, idOrName string, newMemoryMB int) error {
+	return m.Called(ctx, idOrName, newMemoryMB).Error(0)
+}
+
 func setupCacheHandlerTest(_ *testing.T) (*mockCacheService, *CacheHandler, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockCacheService)

--- a/internal/handlers/database_handler.go
+++ b/internal/handlers/database_handler.go
@@ -175,6 +175,43 @@ func (h *DatabaseHandler) Start(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, gin.H{"message": "database started"})
 }
 
+// ResizeDatabaseRequest is the payload for resizing database storage.
+type ResizeDatabaseRequest struct {
+	AllocatedStorage int `json:"allocated_storage" binding:"required,min=1"`
+}
+
+// Resize resizes the allocated storage for a database
+// @Summary Resize database storage
+// @Description Increases the allocated storage capacity of a database instance
+// @Tags databases
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Database ID"
+// @Param request body ResizeDatabaseRequest true "Resize request"
+// @Success 200 {object} httputil.Response
+// @Failure 400 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /databases/{id}/resize [post]
+func (h *DatabaseHandler) Resize(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, invalidDatabaseIDMsg))
+		return
+	}
+	var req ResizeDatabaseRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid request body"))
+		return
+	}
+	if err := h.svc.ResizeDatabase(c.Request.Context(), id, req.AllocatedStorage); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, gin.H{"message": "database resized", "allocated_storage": req.AllocatedStorage})
+}
+
 // ModifyDatabaseRequest is the payload for updating a database.
 type ModifyDatabaseRequest struct {
 	Parameters       map[string]string `json:"parameters"`

--- a/internal/handlers/database_handler_test.go
+++ b/internal/handlers/database_handler_test.go
@@ -131,6 +131,10 @@ func (m *mockDatabaseService) StartDatabase(ctx context.Context, id uuid.UUID) e
 	return args.Error(0)
 }
 
+func (m *mockDatabaseService) ResizeDatabase(ctx context.Context, id uuid.UUID, newSizeGB int) error {
+	return m.Called(ctx, id, newSizeGB).Error(0)
+}
+
 func setupDatabaseHandlerTest(_ *testing.T) (*mockDatabaseService, *DatabaseHandler, *gin.Engine) {
 	gin.SetMode(gin.TestMode)
 	svc := new(mockDatabaseService)

--- a/internal/handlers/volume_handler.go
+++ b/internal/handlers/volume_handler.go
@@ -178,3 +178,36 @@ func (h *VolumeHandler) Detach(c *gin.Context) {
 
 	httputil.Success(c, http.StatusOK, gin.H{"message": "volume detached"})
 }
+
+// ResizeVolumeRequest is the payload for resizing a volume.
+type ResizeVolumeRequest struct {
+	NewSizeGB int `json:"new_size_gb" binding:"required,min=1"`
+}
+
+// Resize resizes a volume to a larger capacity
+// @Summary Resize a volume
+// @Description Increases the capacity of an existing block storage volume
+// @Tags volumes
+// @Accept json
+// @Produce json
+// @Security APIKeyAuth
+// @Param id path string true "Volume ID"
+// @Param request body ResizeVolumeRequest true "Resize request"
+// @Success 200 {object} httputil.Response
+// @Failure 400 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Failure 500 {object} httputil.Response
+// @Router /volumes/{id}/resize [post]
+func (h *VolumeHandler) Resize(c *gin.Context) {
+	idStr := c.Param("id")
+	var req ResizeVolumeRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid request body"))
+		return
+	}
+	if err := h.svc.ResizeVolume(c.Request.Context(), idStr, req.NewSizeGB); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, gin.H{"message": "volume resized", "new_size_gb": req.NewSizeGB})
+}

--- a/pkg/sdk/cache.go
+++ b/pkg/sdk/cache.go
@@ -1,7 +1,11 @@
 // Package sdk provides the official Go SDK for the platform.
 package sdk
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
 
 // Cache describes a cache instance.
 type Cache struct {
@@ -90,4 +94,23 @@ func (c *Client) GetCacheStats(id string) (*CacheStats, error) {
 		return nil, err
 	}
 	return &resp.Data, nil
+}
+
+func (c *Client) ResizeCache(idOrName string, newMemoryMB int) error {
+	// Resolve name to ID if needed
+	id := idOrName
+	if _, err := uuid.Parse(idOrName); err != nil {
+		caches, err := c.ListCaches()
+		if err != nil {
+			return err
+		}
+		for _, cache := range caches {
+			if cache.Name == idOrName {
+				id = cache.ID
+				break
+			}
+		}
+	}
+	body := map[string]int{"memory_mb": newMemoryMB}
+	return c.post(cachesPath+id+"/resize", body, nil)
 }

--- a/pkg/sdk/database.go
+++ b/pkg/sdk/database.go
@@ -77,3 +77,8 @@ func (c *Client) GetDatabaseConnectionString(id string) (string, error) {
 func (c *Client) RotateDatabaseCredentials(id string) error {
 	return c.post(databasesPath+id+"/rotate-credentials", nil, nil)
 }
+
+func (c *Client) ResizeDatabase(id string, newSizeGB int) error {
+	body := map[string]int{"allocated_storage": newSizeGB}
+	return c.post(databasesPath+id+"/resize", body, nil)
+}

--- a/pkg/sdk/volume.go
+++ b/pkg/sdk/volume.go
@@ -90,3 +90,16 @@ func (c *Client) AttachVolume(volumeID, instanceID, mountPath string) (string, e
 func (c *Client) DetachVolume(volumeID string) error {
 	return c.post(fmt.Sprintf("/volumes/%s/detach", volumeID), nil, nil)
 }
+
+// ResizeVolume increases the capacity of a volume.
+func (c *Client) ResizeVolume(idOrName string, newSizeGB int) error {
+	id, err := c.resolveID("volume", func() ([]interface{}, error) {
+		vols, err := c.ListVolumes()
+		return interfaceSlice(vols), err
+	}, func(v interface{}) string { return v.(Volume).ID.String() }, func(v interface{}) string { return v.(Volume).Name }, idOrName)
+	if err != nil {
+		return err
+	}
+	body := map[string]int{"new_size_gb": newSizeGB}
+	return c.post(fmt.Sprintf("/volumes/%s/resize", id), body, nil)
+}


### PR DESCRIPTION
## Summary

Add `cloud resize` commands for volume, database, and cache resources.

**Commands:**
- `cloud volume resize [id/name] [sizeGB]` — resize a block storage volume
- `cloud db resize [id] [sizeGB]` — resize database allocated storage  
- `cloud cache resize [id] [memoryMB]` — resize cache memory allocation

**Full stack implementation:**

| Resource | Interface | Service | Handler | SDK | CLI |
|----------|-----------|---------|---------|-----|-----|
| volume | existing | existing | new | new | new |
| db | new | new | new | new | new |
| cache | new | new | new | new | new |

**Files changed:** 18 files across all layers

**Note:** Cache resize requires container restart (docker backend only).

Fixes #442