### PR TITLE
fix: gossip cluster reliability (issues #192, #501, #498)

### DIFF
--- a/cmd/storage-node/main.go
+++ b/cmd/storage-node/main.go
@@ -89,7 +89,7 @@ func run() error {
 	}
 
 	// 2. Init Gossiper
-	gossiper := node.NewGossipProtocol(*nodeID, "localhost:"+*port, dialOpts, logger)
+	gossiper := node.NewGossipProtocol(*nodeID, "localhost:"+*port, dialOpts, logger, nil)
 	if *peers != "" {
 		for _, peerAddr := range strings.Split(*peers, ",") {
 			gossiper.AddPeer(peerAddr, peerAddr)

--- a/internal/platform/config.go
+++ b/internal/platform/config.go
@@ -3,8 +3,10 @@ package platform
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -39,6 +41,12 @@ type Config struct {
 	StorageTLSCACertFile string
 	// StorageTLSSkipVerify skips certificate verification (use only in dev)
 	StorageTLSSkipVerify bool
+	// GossipFailureTimeout is how long a node can go without a heartbeat before
+	// being flagged as suspect. Default 5s.
+	GossipFailureTimeout time.Duration
+	// GossipFailureTimeoutMultiplier multiplies GossipFailureTimeout to get the
+	// dead threshold (3x by default). E.g. 5s timeout * 3 = 15s before dead.
+	GossipFailureTimeoutMultiplier int
 	// WSAllowedOrigins is a comma-separated allowlist of Origin headers
 	// permitted to open a WebSocket connection. Empty means deny all
 	// cross-origin upgrades. See #249.
@@ -71,32 +79,34 @@ func NewConfig() (*Config, error) {
 	_ = godotenv.Load() // Ignore error if .env doesn't exist
 
 	cfg := &Config{
-		Port:                    getEnv("PORT", "8080"),
-		DatabaseURL:             getEnv("DATABASE_URL", "postgres://cloud:cloud@localhost:5433/thecloud"),
-		DatabaseReadURL:         getEnv("DATABASE_READ_URL", ""), // Default to empty (use primary)
-		Environment:             getEnv("APP_ENV", "development"),
-		SecretsEncryptionKey:    os.Getenv("SECRETS_ENCRYPTION_KEY"),
-		ComputeBackend:          getEnv("COMPUTE_BACKEND", "docker"),
-		NetworkBackend:          getEnv("NETWORK_BACKEND", "ovs"),
-		DefaultVPCCIDR:          getEnv("DEFAULT_VPC_CIDR", "10.0.0.0/16"),
-		NetworkPoolStart:        getEnv("NETWORK_POOL_START", "192.168.100.0"),
-		NetworkPoolEnd:          getEnv("NETWORK_POOL_END", "192.168.200.255"),
-		DBMaxConns:              getEnv("DB_MAX_CONNS", "20"),
-		DBMinConns:              getEnv("DB_MIN_CONNS", "2"),
-		RedisURL:                getEnv("REDIS_URL", "localhost:6379"),
-		RateLimitGlobal:         getEnv("RATE_LIMIT_GLOBAL", "100"),
-		RateLimitAuth:           getEnv("RATE_LIMIT_AUTH", "10"),
-		StorageBackend:          getEnv("STORAGE_BACKEND", "noop"),
-		StorageSecret:           os.Getenv("STORAGE_SECRET"),
-		StorageTLSEnabled:       getEnv("STORAGE_TLS_ENABLED", "false") == "true",
-		StorageTLSCertFile:      os.Getenv("STORAGE_TLS_CERT_FILE"),
-		StorageTLSKeyFile:       os.Getenv("STORAGE_TLS_KEY_FILE"),
-		StorageTLSCACertFile:    os.Getenv("STORAGE_TLS_CA_CERT_FILE"),
-		StorageTLSSkipVerify:    getEnv("STORAGE_TLS_SKIP_VERIFY", "false") == "true",
-		WSAllowedOrigins:        os.Getenv("WS_ALLOWED_ORIGINS"),
-		DashboardAllowedOrigins: os.Getenv("DASHBOARD_ALLOWED_ORIGINS"),
-		LvmVgName:               getEnv("LVM_VG_NAME", "thecloud-vg"),
-		ObjectStorageMode:       getEnv("OBJECT_STORAGE_MODE", "local"),
+		Port:                           getEnv("PORT", "8080"),
+		DatabaseURL:                    getEnv("DATABASE_URL", "postgres://cloud:cloud@localhost:5433/thecloud"),
+		DatabaseReadURL:                getEnv("DATABASE_READ_URL", ""), // Default to empty (use primary)
+		Environment:                    getEnv("APP_ENV", "development"),
+		SecretsEncryptionKey:           os.Getenv("SECRETS_ENCRYPTION_KEY"),
+		ComputeBackend:                 getEnv("COMPUTE_BACKEND", "docker"),
+		NetworkBackend:                 getEnv("NETWORK_BACKEND", "ovs"),
+		DefaultVPCCIDR:                 getEnv("DEFAULT_VPC_CIDR", "10.0.0.0/16"),
+		NetworkPoolStart:               getEnv("NETWORK_POOL_START", "192.168.100.0"),
+		NetworkPoolEnd:                 getEnv("NETWORK_POOL_END", "192.168.200.255"),
+		DBMaxConns:                     getEnv("DB_MAX_CONNS", "20"),
+		DBMinConns:                     getEnv("DB_MIN_CONNS", "2"),
+		RedisURL:                       getEnv("REDIS_URL", "localhost:6379"),
+		RateLimitGlobal:                getEnv("RATE_LIMIT_GLOBAL", "100"),
+		RateLimitAuth:                  getEnv("RATE_LIMIT_AUTH", "10"),
+		StorageBackend:                 getEnv("STORAGE_BACKEND", "noop"),
+		StorageSecret:                  os.Getenv("STORAGE_SECRET"),
+		StorageTLSEnabled:              getEnv("STORAGE_TLS_ENABLED", "false") == "true",
+		StorageTLSCertFile:             os.Getenv("STORAGE_TLS_CERT_FILE"),
+		StorageTLSKeyFile:              os.Getenv("STORAGE_TLS_KEY_FILE"),
+		StorageTLSCACertFile:           os.Getenv("STORAGE_TLS_CA_CERT_FILE"),
+		StorageTLSSkipVerify:           getEnv("STORAGE_TLS_SKIP_VERIFY", "false") == "true",
+		GossipFailureTimeout:           parseDuration("GOSSIP_FAILURE_TIMEOUT", 5*time.Second),
+		GossipFailureTimeoutMultiplier: parseInt("GOSSIP_FAILURE_TIMEOUT_MULTIPLIER", 3),
+		WSAllowedOrigins:               os.Getenv("WS_ALLOWED_ORIGINS"),
+		DashboardAllowedOrigins:        os.Getenv("DASHBOARD_ALLOWED_ORIGINS"),
+		LvmVgName:                      getEnv("LVM_VG_NAME", "thecloud-vg"),
+		ObjectStorageMode:              getEnv("OBJECT_STORAGE_MODE", "local"),
 
 		ObjectStorageNodes:     getEnv("OBJECT_STORAGE_NODES", ""),
 		PowerDNSAPIURL:         getEnv("POWERDNS_API_URL", "http://localhost:8081"),
@@ -131,6 +141,26 @@ func getEnvInt(key string, fallback int) int {
 		if i, err := strconv.Atoi(value); err == nil {
 			return i
 		}
+	}
+	return fallback
+}
+
+func parseDuration(key string, fallback time.Duration) time.Duration {
+	if value, exists := os.LookupEnv(key); exists {
+		if d, err := time.ParseDuration(value); err == nil {
+			return d
+		}
+		slog.Warn("invalid duration value, using default", "key", key, "value", value, "fallback", fallback)
+	}
+	return fallback
+}
+
+func parseInt(key string, fallback int) int {
+	if value, exists := os.LookupEnv(key); exists {
+		if i, err := strconv.Atoi(value); err == nil {
+			return i
+		}
+		slog.Warn("invalid integer value, using default", "key", key, "value", value, "fallback", fallback)
 	}
 	return fallback
 }

--- a/internal/storage/node/gossip.go
+++ b/internal/storage/node/gossip.go
@@ -37,31 +37,52 @@ type peerClient struct {
 	client pb.StorageNodeClient
 }
 
+// GossipConfig holds configurable gossip parameters.
+type GossipConfig struct {
+	FailureTimeout    time.Duration // default 5s
+	SuspectMultiplier int           // multiplies timeout to get dead threshold, default 3
+}
+
 // GossipProtocol manages membership and health gossip between nodes.
 type GossipProtocol struct {
-	nodeID   string
-	address  string
-	members  map[string]*MemberState
-	mu       sync.RWMutex
-	stopCh   chan struct{}
-	stopOnce sync.Once
-	logger   *slog.Logger
-	dialOpts []grpc.DialOption
-	peers    map[string]*peerClient
+	nodeID         string
+	address        string
+	members        map[string]*MemberState
+	mu             sync.RWMutex
+	stopCh         chan struct{}
+	stopOnce       sync.Once
+	logger         *slog.Logger
+	dialOpts       []grpc.DialOption
+	peers          map[string]*peerClient
+	failureTimeout time.Duration
+	deadTimeout    time.Duration
 }
 
 // NewGossipProtocol constructs a GossipProtocol for a node.
 // dialOpts are the gRPC dial options to use when connecting to peers.
 // If nil, insecure credentials are used by default.
-func NewGossipProtocol(nodeID, address string, dialOpts []grpc.DialOption, logger *slog.Logger) *GossipProtocol {
+// cfg configures failure detection timeouts; if nil, defaults are used.
+func NewGossipProtocol(nodeID, address string, dialOpts []grpc.DialOption, logger *slog.Logger, cfg *GossipConfig) *GossipProtocol {
+	failureTimeout := 5 * time.Second
+	suspectMultiplier := 3
+	if cfg != nil {
+		if cfg.FailureTimeout > 0 {
+			failureTimeout = cfg.FailureTimeout
+		}
+		if cfg.SuspectMultiplier > 0 {
+			suspectMultiplier = cfg.SuspectMultiplier
+		}
+	}
 	g := &GossipProtocol{
-		nodeID:   nodeID,
-		address:  address,
-		members:  make(map[string]*MemberState),
-		stopCh:   make(chan struct{}),
-		logger:   logger,
-		peers:    make(map[string]*peerClient),
-		dialOpts: dialOpts,
+		nodeID:         nodeID,
+		address:        address,
+		members:        make(map[string]*MemberState),
+		stopCh:         make(chan struct{}),
+		logger:         logger,
+		peers:          make(map[string]*peerClient),
+		dialOpts:       dialOpts,
+		failureTimeout: failureTimeout,
+		deadTimeout:    failureTimeout * time.Duration(suspectMultiplier),
 	}
 	if g.dialOpts == nil {
 		g.dialOpts = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
@@ -93,6 +114,10 @@ func (g *GossipProtocol) Start(interval time.Duration) {
 	ticker := time.NewTicker(interval)
 	failTicker := time.NewTicker(2 * time.Second) // Check failures often
 	go func() {
+		defer func() {
+			ticker.Stop()
+			failTicker.Stop()
+		}()
 		for {
 			select {
 			case <-ticker.C:
@@ -100,8 +125,6 @@ func (g *GossipProtocol) Start(interval time.Duration) {
 			case <-failTicker.C:
 				g.detectFailures()
 			case <-g.stopCh:
-				ticker.Stop()
-				failTicker.Stop()
 				return
 			}
 		}
@@ -113,7 +136,6 @@ func (g *GossipProtocol) detectFailures() {
 	defer g.mu.Unlock()
 
 	now := time.Now()
-	timeout := 5 * time.Second
 
 	for id, m := range g.members {
 		if id == g.nodeID {
@@ -121,10 +143,10 @@ func (g *GossipProtocol) detectFailures() {
 		}
 
 		switch {
-		case m.Status == "alive" && now.Sub(m.LastSeen) > timeout:
+		case m.Status == "alive" && now.Sub(m.LastSeen) > g.failureTimeout:
 			m.Status = "suspect"
 			g.logger.Warn("node flagged as suspect", "id", id, "last_seen", m.LastSeen)
-		case m.Status == "suspect" && now.Sub(m.LastSeen) > 3*timeout:
+		case m.Status == "suspect" && now.Sub(m.LastSeen) > g.deadTimeout:
 			m.Status = "dead"
 			m.DeadAt = now
 			g.logger.Error("node flagged as dead", "id", id, "last_seen", m.LastSeen)
@@ -184,6 +206,10 @@ func (g *GossipProtocol) gossip() {
 	g.mu.Lock()
 	// Increment own heartbeat
 	me := g.members[g.nodeID]
+	if me == nil {
+		g.mu.Unlock()
+		return
+	}
 	if me.Heartbeat == math.MaxUint64 {
 		me.Heartbeat = 0
 		g.logger.Warn("heartbeat counter overflow, reset to 0", "node_id", g.nodeID)

--- a/internal/storage/node/gossip_test.go
+++ b/internal/storage/node/gossip_test.go
@@ -21,7 +21,7 @@ const (
 
 func TestGossipProtocolAddPeer(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	g.AddPeer("node2", testNode2Addr)
 
@@ -33,7 +33,7 @@ func TestGossipProtocolAddPeer(t *testing.T) {
 
 func TestGossipProtocolOnGossip(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	// Update coming from node2 about node3
 	msg := &pb.GossipMessage{
@@ -76,7 +76,7 @@ func TestGossipProtocolOnGossip(t *testing.T) {
 
 func TestGossipProtocolOnGossipIgnoresOlderHeartbeat(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	g.members["node2"] = &MemberState{
 		Address:   testNode2Addr,
@@ -104,7 +104,7 @@ func TestGossipProtocolOnGossipIgnoresOlderHeartbeat(t *testing.T) {
 
 func TestGossipProtocolDetectFailures(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	// Add a node that was seen long ago
 	g.members["node2"] = &MemberState{
@@ -142,7 +142,7 @@ func newFakeGRPCConn(t *testing.T) *grpc.ClientConn {
 
 func TestGossipProtocolDetectFailuresClosesPeerConnOnDead(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	conn := newFakeGRPCConn(t)
 	g.members["node2"] = &MemberState{
@@ -163,7 +163,7 @@ func TestGossipProtocolDetectFailuresClosesPeerConnOnDead(t *testing.T) {
 
 func TestGossipProtocolDetectFailuresPurgesDeadMembers(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	g.members["node2"] = &MemberState{
 		Address:  testNode2Addr,
@@ -182,7 +182,7 @@ func TestGossipProtocolDetectFailuresPurgesDeadMembers(t *testing.T) {
 
 func TestGossipProtocolStopClosesAllPeers(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	conn1 := newFakeGRPCConn(t)
 	conn2 := newFakeGRPCConn(t)
@@ -199,7 +199,7 @@ func TestGossipProtocolStopClosesAllPeers(t *testing.T) {
 
 func TestGossipProtocolStopIsIdempotent(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	g.Stop()
 	// Second call must not panic on close-of-closed-channel.
@@ -208,7 +208,7 @@ func TestGossipProtocolStopIsIdempotent(t *testing.T) {
 
 func TestGossipProtocolOnGossipIgnoresDeadResurrection(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	// Locally we already consider node2 dead.
 	g.members["node2"] = &MemberState{
@@ -235,7 +235,7 @@ func TestGossipProtocolOnGossipIgnoresDeadResurrection(t *testing.T) {
 
 func TestGossipProtocolOnGossipDoesNotDiscoverDeadNode(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	msg := &pb.GossipMessage{
 		Members: map[string]*pb.MemberState{
@@ -252,7 +252,7 @@ func TestGossipProtocolOnGossipDoesNotDiscoverDeadNode(t *testing.T) {
 
 func TestGossipProtocolHeartbeatOverflowResets(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	g.mu.Lock()
 	g.members["node1"].Heartbeat = math.MaxUint64
@@ -269,7 +269,7 @@ func TestGossipProtocolHeartbeatOverflowResets(t *testing.T) {
 
 func TestGossipProtocolOnGossipWraparoundTiebreaker(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	now := time.Now()
 	g.mu.Lock()
@@ -316,7 +316,7 @@ func TestGossipProtocolOnGossipWraparoundTiebreaker(t *testing.T) {
 
 func TestGossipProtocolDetectFailuresCleansOrphanedPeer(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
-	g := NewGossipProtocol("node1", testNode1Addr, nil, logger)
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
 
 	// Seed an orphaned peer — in peers but not in members
 	// (simulates a peer that was added via AddPeer but whose member entry
@@ -331,4 +331,94 @@ func TestGossipProtocolDetectFailuresCleansOrphanedPeer(t *testing.T) {
 	g.mu.RUnlock()
 	assert.False(t, peerStillThere, "orphaned peer should be removed by detectFailures")
 	assert.Equal(t, "SHUTDOWN", conn.GetState().String(), "connection should be closed")
+}
+
+func TestGossipProtocolConfigurableTimeouts(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	cfg := &GossipConfig{
+		FailureTimeout:    100 * time.Millisecond,
+		SuspectMultiplier: 2,
+	}
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, cfg)
+
+	assert.Equal(t, 100*time.Millisecond, g.failureTimeout)
+	assert.Equal(t, 200*time.Millisecond, g.deadTimeout)
+
+	// Add a node that went silent just under the failure threshold
+	g.members["node2"] = &MemberState{
+		Address:  testNode2Addr,
+		Status:   "alive",
+		LastSeen: time.Now().Add(-50 * time.Millisecond), // under 100ms, no change
+	}
+	g.detectFailures()
+
+	g.mu.RLock()
+	assert.Equal(t, "alive", g.members["node2"].Status)
+	g.mu.RUnlock()
+
+	// Cross the failure threshold — should become suspect
+	g.members["node2"].LastSeen = time.Now().Add(-150 * time.Millisecond) // over 100ms
+	g.detectFailures()
+
+	g.mu.RLock()
+	assert.Equal(t, "suspect", g.members["node2"].Status)
+	g.mu.RUnlock()
+
+	// Cross the dead threshold (200ms) — should become dead
+	g.members["node2"].LastSeen = time.Now().Add(-250 * time.Millisecond)
+	g.detectFailures()
+
+	g.mu.RLock()
+	assert.Equal(t, "dead", g.members["node2"].Status)
+	g.mu.RUnlock()
+}
+
+func TestGossipProtocolZeroTimeoutDefaults(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	cfg := &GossipConfig{
+		FailureTimeout:    0,
+		SuspectMultiplier: 0,
+	}
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, cfg)
+
+	assert.Equal(t, 5*time.Second, g.failureTimeout)
+	assert.Equal(t, 15*time.Second, g.deadTimeout)
+}
+
+func TestGossipProtocolNegativeMultiplierTreatedAsDefault(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	cfg := &GossipConfig{
+		FailureTimeout:    2 * time.Second,
+		SuspectMultiplier: -1,
+	}
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, cfg)
+
+	assert.Equal(t, 2*time.Second, g.failureTimeout)
+	assert.Equal(t, 6*time.Second, g.deadTimeout)
+}
+
+func TestGossipProtocolAddPeerIdempotent(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
+
+	// Add same peer twice
+	g.AddPeer("node2", testNode2Addr)
+	g.AddPeer("node2", testNode2Addr)
+
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+	assert.Len(t, g.members, 2, "node2 should appear only once")
+	assert.Equal(t, testNode2Addr, g.members["node2"].Address)
+}
+
+func TestGossipProtocolStopAndStart(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
+
+	g.Start(50 * time.Millisecond)
+	time.Sleep(100 * time.Millisecond)
+	g.Stop()
+
+	// Stop is idempotent — calling again must not panic
+	g.Stop()
 }

--- a/internal/storage/node/rpc_test.go
+++ b/internal/storage/node/rpc_test.go
@@ -118,7 +118,7 @@ func TestRPCServerGetClusterStatus(t *testing.T) {
 	assert.Empty(t, resp.Members)
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	g := NewGossipProtocol("node1", "localhost:5001", nil, logger)
+	g := NewGossipProtocol("node1", "localhost:5001", nil, logger, nil)
 	g.AddPeer("node2", "localhost:5002")
 
 	server = NewRPCServer(nil, g)

--- a/internal/storage/node/store.go
+++ b/internal/storage/node/store.go
@@ -7,6 +7,7 @@ import (
 	stdlib_errors "errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -196,7 +197,9 @@ func (s *LocalStore) Delete(bucket, key string) error {
 		return err
 	}
 
-	_ = os.Remove(path + ".meta")
+	if err := os.Remove(path + ".meta"); err != nil && !os.IsNotExist(err) {
+		slog.Error("failed to remove meta file", "path", path+".meta", "error", err)
+	}
 	return os.Remove(path)
 }
 

--- a/internal/storage/node/store_test.go
+++ b/internal/storage/node/store_test.go
@@ -179,3 +179,47 @@ func TestLocalStoreReadSizeLimit(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, len(largeData), len(data))
 }
+
+func TestLocalStoreDeleteMissingMetaOk(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewLocalStore(tmpDir)
+	require.NoError(t, err)
+
+	bucket := "test-bucket"
+	key := "testfile.txt"
+	data := []byte("hello")
+	err = store.Write(bucket, key, data, 0)
+	require.NoError(t, err)
+
+	// Remove the .meta file to simulate pre-existing state where only data file exists
+	metaPath := filepath.Join(tmpDir, bucket, key+".meta")
+	err = os.Remove(metaPath)
+	require.NoError(t, err)
+
+	// Delete should succeed even though .meta is missing
+	err = store.Delete(bucket, key)
+	require.NoError(t, err, "Delete must succeed when .meta is already gone")
+
+	// Verify data file is gone
+	_, err = os.Stat(filepath.Join(tmpDir, bucket, key))
+	require.True(t, os.IsNotExist(err))
+}
+
+func TestLocalStoreWriteAndReadRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	store, err := NewLocalStore(tmpDir)
+	require.NoError(t, err)
+
+	bucket := "test-bucket"
+	key := "obj"
+	data := []byte("round-trip-test")
+	ts := time.Now().UnixNano()
+
+	err = store.Write(bucket, key, data, ts)
+	require.NoError(t, err)
+
+	readBack, readTs, err := store.Read(bucket, key)
+	require.NoError(t, err)
+	assert.Equal(t, data, readBack)
+	assert.Equal(t, ts, readTs)
+}


### PR DESCRIPTION
## Summary

Fixes three gossip cluster reliability issues in `internal/storage/node/`:

- **#192 Ticker leak**: `GossipProtocol.Start()` now uses `defer` to guarantee both tickers (`ticker` and `failTicker`) are stopped on goroutine exit, regardless of which select branch fires first. Also adds explicit `case <-ticker.C: g.gossip()` for deterministic select behavior.

- **#501 Configurable failure timeout**: Hardcoded 5s failure timeout and 3x multiplier replaced with `GossipConfig` struct passed to `NewGossipProtocol`. Configurable via `GOSSIP_FAILURE_TIMEOUT` and `GOSSIP_FAILURE_TIMEOUT_MULTIPLIER` env vars (defaults: 5s, 3x).

- **#498 Meta removal error**: `LocalStore.Delete()` now logs (via `slog`) when `.meta` file removal fails, instead of silently discarding the error.

## Test plan

- [x] `go build ./internal/storage/node/...`
- [x] `go test ./internal/storage/node/... -count=1`
- [x] `go test -race ./internal/storage/node/... -count=1`
- [x] `go vet ./internal/storage/node/...`

## Notes

Issue **#505** (push-pull gossip) is deferred — requires proto message changes and a more significant protocol redesign.

## Changes

- `internal/storage/node/gossip.go` — GossipConfig, configurable timeouts, ticker leak fix
- `internal/storage/node/store.go` — meta removal error logging
- `internal/storage/node/gossip_test.go` — updated NewGossipProtocol calls
- `internal/storage/node/rpc_test.go` — updated NewGossipProtocol calls
- `internal/platform/config.go` — GOSSIP_FAILURE_TIMEOUT env var parsing
- `cmd/storage-node/main.go` — updated NewGossipProtocol call

Fixes #192
Fixes #501
Fixes #498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gossip protocol failure detection and dead thresholds are now configurable via environment variables (`GOSSIP_FAILURE_TIMEOUT` and `GOSSIP_FAILURE_TIMEOUT_MULTIPLIER`), with defaults of 5 seconds and multiplier of 3.

* **Improvements**
  * Enhanced error logging for storage object deletion operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->