### PR TITLE
feat: add auto-labeling system for PRs and issues

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,95 @@
+area/api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/api/**'
+          - 'internal/api/**'
+
+area/cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'cmd/cloud/**'
+          - 'cmd/autoscaler-server/**'
+
+area/handlers:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/handlers/**'
+
+area/services:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/core/services/**'
+
+area/repositories:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/repositories/**'
+
+area/storage:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/storage/**'
+          - 'pkg/storage/**'
+
+area/web:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'web/**'
+
+area/k8s:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/ccm/**'
+          - 'internal/csi/**'
+          - 'k8s/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/ISSUE_TEMPLATE/**'
+          - '.github/PULL_REQUEST_TEMPLATE.md'
+
+database:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/repositories/**'
+          - '**/migrations/**'
+          - '**/*.sql'
+          - 'db/**'
+
+api-change:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'internal/api/**'
+          - 'cmd/api/**'
+          - '**/openapi*.yaml'
+          - '**/swagger*.json'
+
+config:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '*.yaml'
+          - '*.yml'
+          - '*.json'
+          - '.env*'
+          - 'config/**'
+          - 'deploy/**'
+
+deps:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'go.mod'
+          - 'go.sum'
+          - '**/requirements.txt'
+          - '**/package.json'
+          - '**/go.sum'
+
+build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Dockerfile*'
+          - 'docker-compose*.yml'
+          - 'Makefile'
+          - 'scripts/**'
+          - '.github/workflows/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -69,12 +69,9 @@ api-change:
 config:
   - changed-files:
       - any-glob-to-any-file:
-          - '*.yaml'
-          - '*.yml'
-          - '*.json'
-          - '.env*'
           - 'config/**'
           - 'deploy/**'
+          - '.env*'
 
 deps:
   - changed-files:

--- a/.github/workflows/issue-keyword-labeler.yml
+++ b/.github/workflows/issue-keyword-labeler.yml
@@ -1,0 +1,104 @@
+name: "Issue Keyword Labeler"
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Check issue keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const title = issue.title.toLowerCase();
+            const body = (issue.body || '').toLowerCase();
+
+            const labels = [];
+
+            // Bug
+            if (title.includes('bug') || title.includes('broken') || title.includes('not working')) {
+              labels.push('bug');
+            }
+
+            // Enhancement
+            if (title.includes('feature') || title.includes('request') || title.includes('enhancement') || title.includes('wish')) {
+              labels.push('enhancement');
+            }
+
+            // Documentation
+            if (title.includes('docs') || body.includes('documentation')) {
+              labels.push('documentation');
+            }
+
+            // Security
+            if (title.includes('security') || body.includes('cve-') || body.includes('vulnerability')) {
+              labels.push('security');
+            }
+
+            // Performance
+            if (title.includes('slow') || title.includes('performance') || title.includes('optimize')) {
+              labels.push('performance');
+            }
+
+            // Database
+            if (title.includes('migration') || title.includes('schema') || title.includes('database')) {
+              labels.push('database');
+            }
+
+            // Config
+            if (title.includes('config') || title.includes('settings') || title.includes('configuration')) {
+              labels.push('config');
+            }
+
+            // Build
+            if (title.includes('build') || title.includes('docker') || title.includes('compile')) {
+              labels.push('build');
+            }
+
+            // Area detection based on keywords in title
+            if (title.includes('cli') || title.includes('command') || title.includes('terminal')) {
+              labels.push('area/cli');
+            }
+
+            if (title.includes('api') || title.includes('endpoint') || title.includes('rest')) {
+              labels.push('area/api');
+            }
+
+            if (title.includes('web') || title.includes('frontend') || title.includes('ui') || title.includes('dashboard')) {
+              labels.push('area/web');
+            }
+
+            if (title.includes('storage') || title.includes('disk') || title.includes('volume')) {
+              labels.push('area/storage');
+            }
+
+            if (title.includes('kubernetes') || title.includes('k8s') || title.includes('deploy')) {
+              labels.push('area/k8s');
+            }
+
+            if (title.includes('handler') || title.includes('controller')) {
+              labels.push('area/handlers');
+            }
+
+            if (title.includes('service')) {
+              labels.push('area/services');
+            }
+
+            if (title.includes('repository') || title.includes('db') || title.includes('sql')) {
+              labels.push('area/repositories');
+            }
+
+            // Apply labels
+            if (labels.length > 0) {
+              github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: labels
+              });
+            }

--- a/.github/workflows/issue-keyword-labeler.yml
+++ b/.github/workflows/issue-keyword-labeler.yml
@@ -18,78 +18,80 @@ jobs:
             const title = issue.title.toLowerCase();
             const body = (issue.body || '').toLowerCase();
 
+            const contains = (...keywords) =>
+              keywords.some((k) => title.includes(k) || body.includes(k));
+
             const labels = [];
 
             // Bug
-            if (title.includes('bug') || title.includes('broken') || title.includes('not working')) {
+            if (contains('bug', 'broken', 'not working')) {
               labels.push('bug');
             }
 
             // Enhancement
-            if (title.includes('feature') || title.includes('request') || title.includes('enhancement') || title.includes('wish')) {
+            if (contains('feature', 'request', 'enhancement', 'wish')) {
               labels.push('enhancement');
             }
 
             // Documentation
-            if (title.includes('docs') || body.includes('documentation')) {
+            if (contains('docs', 'documentation')) {
               labels.push('documentation');
             }
 
             // Security
-            if (title.includes('security') || body.includes('cve-') || body.includes('vulnerability')) {
+            if (contains('security', 'cve-', 'vulnerability')) {
               labels.push('security');
             }
 
             // Performance
-            if (title.includes('slow') || title.includes('performance') || title.includes('optimize')) {
+            if (contains('slow', 'performance', 'optimize')) {
               labels.push('performance');
             }
 
             // Database
-            if (title.includes('migration') || title.includes('schema') || title.includes('database')) {
+            if (contains('migration', 'schema', 'database')) {
               labels.push('database');
             }
 
             // Area detection based on keywords in title
-            if (title.includes('cli') || title.includes('command') || title.includes('terminal')) {
+            if (contains('cli', 'command', 'terminal')) {
               labels.push('area/cli');
             }
 
-            if (title.includes('api') || title.includes('endpoint') || title.includes('rest')) {
+            if (contains('api', 'endpoint', 'rest')) {
               labels.push('area/api');
             }
 
-            if (title.includes('web') || title.includes('frontend') || title.includes('ui') || title.includes('dashboard')) {
+            if (contains('web', 'frontend', 'ui', 'dashboard')) {
               labels.push('area/web');
             }
 
-            if (title.includes('storage') || title.includes('disk') || title.includes('volume')) {
+            if (contains('storage', 'disk', 'volume')) {
               labels.push('area/storage');
             }
 
-            if (title.includes('kubernetes') || title.includes('k8s') || title.includes('deploy')) {
+            if (contains('kubernetes', 'k8s', 'deploy')) {
               labels.push('area/k8s');
             }
 
-            if (title.includes('handler') || title.includes('controller')) {
+            if (contains('handler', 'controller')) {
               labels.push('area/handlers');
             }
 
-            if (title.includes('service')) {
+            if (contains('service')) {
               labels.push('area/services');
             }
 
-            if (title.includes('repository') || title.includes('db') || title.includes('sql')) {
+            if (contains('repository', 'db', 'sql')) {
               labels.push('area/repositories');
             }
 
             // Apply labels
             if (labels.length > 0) {
-              github.rest.issues.addLabels({
+              await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue.number,
                 labels: labels
               });
             }
-

--- a/.github/workflows/issue-keyword-labeler.yml
+++ b/.github/workflows/issue-keyword-labeler.yml
@@ -50,16 +50,6 @@ jobs:
               labels.push('database');
             }
 
-            // Config
-            if (title.includes('config') || title.includes('settings') || title.includes('configuration')) {
-              labels.push('config');
-            }
-
-            // Build
-            if (title.includes('build') || title.includes('docker') || title.includes('compile')) {
-              labels.push('build');
-            }
-
             // Area detection based on keywords in title
             if (title.includes('cli') || title.includes('command') || title.includes('terminal')) {
               labels.push('area/cli');
@@ -102,3 +92,4 @@ jobs:
                 labels: labels
               });
             }
+

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: "Pull Request Labeler (Scope)"
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-keyword-labeler.yml
+++ b/.github/workflows/pr-keyword-labeler.yml
@@ -56,12 +56,12 @@ jobs:
             }
 
             // Database
-            if (title.includes('migration') || title.includes('schema') || body.includes('database')) {
+            if (title.includes('migration') || title.includes('schema') || title.includes('database')) {
               labels.push('database');
             }
 
             // API change
-            if (title.includes('endpoint') || title.includes('api') || title.includes('route')) {
+            if (title.includes('endpoint') || title.includes('rest api') || title.includes('grpc')) {
               labels.push('api-change');
             }
 

--- a/.github/workflows/pr-keyword-labeler.yml
+++ b/.github/workflows/pr-keyword-labeler.yml
@@ -1,7 +1,7 @@
 name: "PR Keyword Labeler"
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize]
 
 jobs:
@@ -71,12 +71,13 @@ jobs:
             }
 
             // Size detection based on files changed
-            const prFiles = await github.rest.pulls.listFiles({
+            const prFiles = await github.paginate(github.rest.pulls.listFiles, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: pr.number
+              pull_number: pr.number,
+              per_page: 100
             });
-            const fileCount = prFiles.data.length;
+            const fileCount = prFiles.length;
             if (fileCount <= 3) {
               labels.push('size/xs');
             } else if (fileCount <= 10) {
@@ -91,7 +92,7 @@ jobs:
 
             // Apply labels
             if (labels.length > 0) {
-              github.rest.issues.addLabels({
+              await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: pr.number,

--- a/.github/workflows/pr-keyword-labeler.yml
+++ b/.github/workflows/pr-keyword-labeler.yml
@@ -1,0 +1,110 @@
+name: "PR Keyword Labeler"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check PR keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const title = pr.title.toLowerCase();
+            const body = (pr.body || '').toLowerCase();
+
+            const labels = [];
+
+            // Bug
+            if (title.includes('fix') || title.includes('bug') || title.includes('patch')) {
+              labels.push('bug');
+            }
+
+            // Enhancement/Feature
+            if (title.includes('feat') || title.includes('add') || title.includes('implement')) {
+              labels.push('enhancement');
+            }
+
+            // Documentation
+            if (title.includes('docs') || body.includes('documentation') || body.includes('readme')) {
+              labels.push('documentation');
+            }
+
+            // Security
+            if (title.includes('security') || body.includes('cve-') || body.includes('vulnerability')) {
+              labels.push('security');
+            }
+
+            // Breaking change
+            if (body.includes('breaking change') || body.includes('!--')) {
+              labels.push('breaking-change');
+            }
+
+            // Refactor
+            if (title.includes('refactor') || title.includes('cleanup') || title.includes('restructure')) {
+              labels.push('refactor');
+            }
+
+            // Performance
+            if (title.includes('perf') || title.includes('optimize') || title.includes('faster')) {
+              labels.push('performance');
+            }
+
+            // Database
+            if (title.includes('migration') || title.includes('schema') || body.includes('database')) {
+              labels.push('database');
+            }
+
+            // API change
+            if (title.includes('endpoint') || title.includes('api') || title.includes('route')) {
+              labels.push('api-change');
+            }
+
+            // Config
+            if (title.includes('config') || title.includes('settings')) {
+              labels.push('config');
+            }
+
+            // Deps
+            if (body.includes('dependency') || body.includes('bump') || title.includes('update deps')) {
+              labels.push('deps');
+            }
+
+            // Build
+            if (title.includes('docker') || title.includes('build') || title.includes('compile')) {
+              labels.push('build');
+            }
+
+            // Size detection based on files changed
+            const prFiles = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number
+            });
+            const fileCount = prFiles.data.length;
+            if (fileCount <= 3) {
+              labels.push('size/xs');
+            } else if (fileCount <= 10) {
+              labels.push('size/sm');
+            } else if (fileCount <= 30) {
+              labels.push('size/md');
+            } else if (fileCount <= 100) {
+              labels.push('size/lg');
+            } else {
+              labels.push('size/xl');
+            }
+
+            // Apply labels
+            if (labels.length > 0) {
+              github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                labels: labels
+              });
+            }

--- a/.github/workflows/pr-keyword-labeler.yml
+++ b/.github/workflows/pr-keyword-labeler.yml
@@ -65,19 +65,9 @@ jobs:
               labels.push('api-change');
             }
 
-            // Config
-            if (title.includes('config') || title.includes('settings')) {
-              labels.push('config');
-            }
-
             // Deps
             if (body.includes('dependency') || body.includes('bump') || title.includes('update deps')) {
               labels.push('deps');
-            }
-
-            // Build
-            if (title.includes('docker') || title.includes('build') || title.includes('compile')) {
-              labels.push('build');
             }
 
             // Size detection based on files changed


### PR DESCRIPTION
## Summary
- Add scope-based labeling via `.github/labeler.yml` + `actions/labeler@v6`
- Add keyword-based labeling via `.github/workflows/pr-keyword-labeler.yml` using `actions/github-script@v7`
- Auto-detect PR size based on file count

## Labels
**Area labels:** area/api, area/cli, area/handlers, area/services, area/repositories, area/storage, area/web, area/k8s
**Type labels:** bug, enhancement, documentation, security, breaking-change, refactor, performance
**Change-type:** database, api-change, config, deps, build, ci
**Size:** size/xs, size/sm, size/md, size/lg, size/xl

## Test plan
- [ ] Create PR changing `cmd/cloud/` → should get `area/cli`
- [ ] Create PR with title "fix: resolve auth bug" → should get `bug` + `size/xs`
- [ ] Create PR with docs changes → should get `documentation`
- [ ] Verify `gh pr view <num> --json labels` shows correct labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request organization with automated labeling based on modified files, title keywords, and body content.
  * Implemented automatic pull request size classification (xs, sm, md, lg, xl) based on the number of changed files.
  * Added automated issue labeling based on keywords detected in issue titles and descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/poyrazK/thecloud/pull/577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->