### PR TITLE
fix: propagate error when quota creation fails in CreateTenant (closes #407)

### DIFF
--- a/internal/core/services/tenant.go
+++ b/internal/core/services/tenant.go
@@ -95,8 +95,7 @@ func (s *TenantService) CreateTenant(ctx context.Context, name, slug string, own
 		MaxVCPUs:     8,
 	}
 	if err := s.repo.UpdateQuota(ctx, quota); err != nil {
-		// Log but don't fail tenant creation
-		s.logger.Error("failed to set default quota", "tenant_id", tenant.ID, "err", err)
+		return nil, errors.Wrap(errors.Internal, "failed to set default quota", err)
 	}
 
 	// 5. Update user's default tenant if not set


### PR DESCRIPTION
## Summary
- Propagate error from  in  instead of silently logging
- This ensures tenant creation fails atomically if quota creation fails
- Fixes #407: Container deployments fail with 'quota not found'

## Test plan
- [ ] Build passes: `go build ./...`
- [ ] Run tenant service tests: `go test ./internal/core/services/... -run TestTenant`