### PR TITLE
feat: implement push-pull gossip for faster convergence (#505)

### DIFF
--- a/internal/storage/node/gossip.go
+++ b/internal/storage/node/gossip.go
@@ -41,6 +41,7 @@ type peerClient struct {
 type GossipConfig struct {
 	FailureTimeout    time.Duration // default 5s
 	SuspectMultiplier int           // multiplies timeout to get dead threshold, default 3
+	WantPull          bool          // request peer's state on each gossip tick; default true
 }
 
 // GossipProtocol manages membership and health gossip between nodes.
@@ -56,6 +57,7 @@ type GossipProtocol struct {
 	peers          map[string]*peerClient
 	failureTimeout time.Duration
 	deadTimeout    time.Duration
+	wantPull       bool // whether to request peer's state on each gossip tick
 }
 
 // NewGossipProtocol constructs a GossipProtocol for a node.
@@ -65,6 +67,7 @@ type GossipProtocol struct {
 func NewGossipProtocol(nodeID, address string, dialOpts []grpc.DialOption, logger *slog.Logger, cfg *GossipConfig) *GossipProtocol {
 	failureTimeout := 5 * time.Second
 	suspectMultiplier := 3
+	wantPull := true
 	if cfg != nil {
 		if cfg.FailureTimeout > 0 {
 			failureTimeout = cfg.FailureTimeout
@@ -72,6 +75,7 @@ func NewGossipProtocol(nodeID, address string, dialOpts []grpc.DialOption, logge
 		if cfg.SuspectMultiplier > 0 {
 			suspectMultiplier = cfg.SuspectMultiplier
 		}
+		wantPull = cfg.WantPull
 	}
 	g := &GossipProtocol{
 		nodeID:         nodeID,
@@ -83,6 +87,7 @@ func NewGossipProtocol(nodeID, address string, dialOpts []grpc.DialOption, logge
 		dialOpts:       dialOpts,
 		failureTimeout: failureTimeout,
 		deadTimeout:    failureTimeout * time.Duration(suspectMultiplier),
+		wantPull:       wantPull,
 	}
 	if g.dialOpts == nil {
 		g.dialOpts = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
@@ -298,11 +303,23 @@ func (g *GossipProtocol) sendGossip(targetID string, msg *pb.GossipMessage) {
 		peerToUse = newPeer
 	}
 
+	msg.WantState = g.wantPull
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	if _, err := peerToUse.client.Gossip(ctx, msg); err != nil {
+	resp, err := peerToUse.client.Gossip(ctx, msg)
+	if err != nil {
 		g.logger.Warn("gossip failed", "target", targetID, "error", err)
+		return
+	}
+	if resp != nil && resp.Success && len(resp.Members) > 0 {
+		g.OnGossip(&pb.GossipMessage{
+			SenderId:   targetID,
+			SenderAddr: member.Address,
+			Timestamp:  time.Now().Unix(),
+			Members:    resp.Members,
+		})
 	}
 }
 

--- a/internal/storage/node/gossip_test.go
+++ b/internal/storage/node/gossip_test.go
@@ -397,6 +397,25 @@ func TestGossipProtocolNegativeMultiplierTreatedAsDefault(t *testing.T) {
 	assert.Equal(t, 6*time.Second, g.deadTimeout)
 }
 
+func TestGossipProtocolWantPullConfigurable(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	cfg := &GossipConfig{
+		FailureTimeout:    100 * time.Millisecond,
+		SuspectMultiplier: 2,
+		WantPull:         false,
+	}
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, cfg)
+
+	assert.Equal(t, false, g.wantPull)
+}
+
+func TestGossipProtocolWantPullDefaultsTrue(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
+
+	assert.True(t, g.wantPull, "WantPull should default to true")
+}
+
 func TestGossipProtocolAddPeerIdempotent(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
 	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
@@ -421,4 +440,42 @@ func TestGossipProtocolStopAndStart(t *testing.T) {
 
 	// Stop is idempotent — calling again must not panic
 	g.Stop()
+}
+
+func TestGossipProtocolOnGossipWantState(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	g := NewGossipProtocol("node1", testNode1Addr, nil, logger, nil)
+
+	// Simulate a pull response from a peer about a third node
+	msg := &pb.GossipMessage{
+		SenderId:   "node2",
+		SenderAddr: testNode2Addr,
+		Timestamp:  time.Now().Unix(),
+		Members: map[string]*pb.MemberState{
+			"node2": {
+				Addr:      testNode2Addr,
+				Status:    "alive",
+				Heartbeat: 10,
+			},
+			"node3": {
+				Addr:      testNode3Addr,
+				Status:    "alive",
+				Heartbeat: 5,
+			},
+		},
+	}
+
+	g.OnGossip(msg)
+
+	g.mu.RLock()
+	node2, exists2 := g.members["node2"]
+	node3, exists3 := g.members["node3"]
+	g.mu.RUnlock()
+
+	assert.True(t, exists2, "node2 should be discovered")
+	assert.Equal(t, testNode2Addr, node2.Address)
+	assert.Equal(t, uint64(10), node2.Heartbeat)
+	assert.True(t, exists3, "node3 should be discovered via pull gossip")
+	assert.Equal(t, testNode3Addr, node3.Address)
+	assert.Equal(t, uint64(5), node3.Heartbeat)
 }

--- a/internal/storage/node/rpc.go
+++ b/internal/storage/node/rpc.go
@@ -147,6 +147,25 @@ func (s *RPCServer) Gossip(ctx context.Context, req *pb.GossipMessage) (*pb.Goss
 	if s.gossiper != nil {
 		s.gossiper.OnGossip(req)
 	}
+
+	if req.WantState {
+		if s.gossiper == nil {
+			return &pb.GossipResponse{Success: true}, nil
+		}
+		s.gossiper.mu.RLock()
+		defer s.gossiper.mu.RUnlock()
+		members := make(map[string]*pb.MemberState)
+		for id, m := range s.gossiper.members {
+			members[id] = &pb.MemberState{
+				Addr:      m.Address,
+				Status:    m.Status,
+				LastSeen:  m.LastSeen.Unix(),
+				Heartbeat: m.Heartbeat,
+			}
+		}
+		return &pb.GossipResponse{Success: true, Members: members}, nil
+	}
+
 	return &pb.GossipResponse{Success: true}, nil
 }
 

--- a/internal/storage/protocol/storage.pb.go
+++ b/internal/storage/protocol/storage.pb.go
@@ -107,6 +107,7 @@ type GossipMessage struct {
 	SenderAddr    string                  `protobuf:"bytes,2,opt,name=sender_addr,json=senderAddr,proto3" json:"sender_addr,omitempty"`
 	Members       map[string]*MemberState `protobuf:"bytes,3,rep,name=members,proto3" json:"members,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // Key is node_id
 	Timestamp     int64                   `protobuf:"varint,4,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	WantState     bool                    `protobuf:"varint,5,opt,name=want_state,json=wantState,proto3" json:"want_state,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -167,6 +168,13 @@ func (x *GossipMessage) GetTimestamp() int64 {
 		return x.Timestamp
 	}
 	return 0
+}
+
+func (x *GossipMessage) GetWantState() bool {
+	if x != nil {
+		return x.WantState
+	}
+	return false
 }
 
 type MemberState struct {
@@ -240,6 +248,7 @@ func (x *MemberState) GetHeartbeat() uint64 {
 type GossipResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Members       map[string]*MemberState `protobuf:"bytes,2,rep,name=members,proto3" json:"members,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -279,6 +288,13 @@ func (x *GossipResponse) GetSuccess() bool {
 		return x.Success
 	}
 	return false
+}
+
+func (x *GossipResponse) GetMembers() map[string]*MemberState {
+	if x != nil {
+		return x.Members
+	}
+	return nil
 }
 
 type StoreRequest struct {

--- a/internal/storage/protocol/storage.proto
+++ b/internal/storage/protocol/storage.proto
@@ -24,6 +24,7 @@ message GossipMessage {
   string sender_addr = 2;
   map<string, MemberState> members = 3; // Key is node_id
   int64 timestamp = 4;
+  bool want_state = 5; // request peer's full member state
 }
 
 message MemberState {
@@ -35,6 +36,7 @@ message MemberState {
 
 message GossipResponse {
   bool success = 1;
+  map<string, MemberState> members = 2; // peer's member map for pull-based gossip
 }
 
 message StoreRequest {


### PR DESCRIPTION
## Summary

Implements push-pull gossip for faster cluster convergence (issue #505).

Currently the gossip protocol is push-only: each tick, a node picks one random peer and sends its state. With push-pull, after sending its own state, a node also requests the peer's state — enabling it to learn about members it doesn't directly know about faster.

## Changes

### Proto changes (`storage.proto`)
- Added `want_state` field to `GossipMessage` (field 5) — signals to the receiver that we want their state
- Added `members` field to `GossipResponse` (field 2) — carries the peer's full member map back

### Client-side (`gossip.go`)
- `sendGossip()` now sets `WantState: true` on every outgoing message
- After sending, parses the `GossipResponse` and if `Success` and `Members` are present, calls `OnGossip()` with the pulled state — allowing the node to discover peers-of-peers

### Server-side (`rpc.go`)
- `Gossip()` handler checks `req.WantState`
- If true, includes the full member map in the `GossipResponse`

### Test coverage
- Added `TestGossipProtocolOnGossipWantState` verifying that a node can discover a third node through pull gossip

## Test plan

- [x] `go build ./internal/storage/node/... ./internal/storage/protocol/...`
- [x] `go test ./internal/storage/node/... -count=1`
- [x] `go test -race ./internal/storage/node/... -count=1`
- [x] `go vet ./internal/storage/node/...`

Fixes #505