### PR TITLE
IAM: Policy versioning with audit trail and rollback

### DIFF
--- a/docs/swagger/docs.go
+++ b/docs/swagger/docs.go
@@ -3644,6 +3644,203 @@ const docTemplate = `{
                 }
             }
         },
+        "/iam/policies/{id}/rollback/{version}": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Restore a policy to a specific historical version by creating a new version with the old content.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "iam"
+                ],
+                "summary": "Rollback Policy Version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Version Number to Rollback To",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/iam/policies/{id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "List all historical versions of a specific IAM policy.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "iam"
+                ],
+                "summary": "List Policy Versions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httputil.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/domain.PolicyVersion"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/iam/policies/{id}/versions/{version}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Get a specific historical version of an IAM policy.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "iam"
+                ],
+                "summary": "Get Policy Version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Version Number",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httputil.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.PolicyVersion"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/iam/service-accounts": {
             "get": {
                 "security": [
@@ -10950,6 +11147,38 @@ const docTemplate = `{
                 "EffectAllow",
                 "EffectDeny"
             ]
+        },
+        "domain.PolicyVersion": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "policy_id": {
+                    "type": "string"
+                },
+                "statements": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Statement"
+                    }
+                },
+                "version_number": {
+                    "type": "integer"
+                }
+            }
         },
         "domain.RecordType": {
             "type": "string",

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -3636,6 +3636,203 @@
                 }
             }
         },
+        "/iam/policies/{id}/rollback/{version}": {
+            "post": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Restore a policy to a specific historical version by creating a new version with the old content.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "iam"
+                ],
+                "summary": "Rollback Policy Version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Version Number to Rollback To",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/iam/policies/{id}/versions": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "List all historical versions of a specific IAM policy.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "iam"
+                ],
+                "summary": "List Policy Versions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httputil.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/domain.PolicyVersion"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/iam/policies/{id}/versions/{version}": {
+            "get": {
+                "security": [
+                    {
+                        "APIKeyAuth": []
+                    }
+                ],
+                "description": "Get a specific historical version of an IAM policy.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "iam"
+                ],
+                "summary": "Get Policy Version",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Policy ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Version Number",
+                        "name": "version",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/httputil.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/domain.PolicyVersion"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/httputil.Response"
+                        }
+                    }
+                }
+            }
+        },
         "/iam/service-accounts": {
             "get": {
                 "security": [
@@ -10942,6 +11139,38 @@
                 "EffectAllow",
                 "EffectDeny"
             ]
+        },
+        "domain.PolicyVersion": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "created_by": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "policy_id": {
+                    "type": "string"
+                },
+                "statements": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.Statement"
+                    }
+                },
+                "version_number": {
+                    "type": "integer"
+                }
+            }
         },
         "domain.RecordType": {
             "type": "string",

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -1284,6 +1284,27 @@ definitions:
     x-enum-varnames:
     - EffectAllow
     - EffectDeny
+  domain.PolicyVersion:
+    properties:
+      created_at:
+        type: string
+      created_by:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      policy_id:
+        type: string
+      statements:
+        items:
+          $ref: '#/definitions/domain.Statement'
+        type: array
+      version_number:
+        type: integer
+    type: object
   domain.RecordType:
     enum:
     - A
@@ -5108,6 +5129,128 @@ paths:
       security:
       - APIKeyAuth: []
       summary: Update IAM Policy
+      tags:
+      - iam
+  /iam/policies/{id}/rollback/{version}:
+    post:
+      description: Restore a policy to a specific historical version by creating a
+        new version with the old content.
+      parameters:
+      - description: Policy ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Version Number to Rollback To
+        in: path
+        name: version
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Rollback Policy Version
+      tags:
+      - iam
+  /iam/policies/{id}/versions:
+    get:
+      description: List all historical versions of a specific IAM policy.
+      parameters:
+      - description: Policy ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httputil.Response'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/domain.PolicyVersion'
+                  type: array
+              type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: List Policy Versions
+      tags:
+      - iam
+  /iam/policies/{id}/versions/{version}:
+    get:
+      description: Get a specific historical version of an IAM policy.
+      parameters:
+      - description: Policy ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Version Number
+        in: path
+        name: version
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/httputil.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/domain.PolicyVersion'
+              type: object
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "403":
+          description: Forbidden
+          schema:
+            $ref: '#/definitions/httputil.Response'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/httputil.Response'
+      security:
+      - APIKeyAuth: []
+      summary: Get Policy Version
       tags:
       - iam
   /iam/service-accounts:

--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -233,6 +233,11 @@ func registerIAMRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		iamGroup.GET(policyIDRoute, handlers.IAM.GetPolicyByID)
 		iamGroup.DELETE(policyIDRoute, handlers.IAM.DeletePolicy)
 
+		// Policy versioning
+		iamGroup.GET("/policies/:id/versions", handlers.IAM.GetPolicyVersions)
+		iamGroup.GET("/policies/:id/versions/:version", handlers.IAM.GetPolicyVersion)
+		iamGroup.POST("/policies/:id/rollback/:version", handlers.IAM.RollbackPolicyVersion)
+
 		iamGroup.POST("/users/:userId/policies/:policyId", handlers.IAM.AttachPolicyToUser)
 		iamGroup.DELETE("/users/:userId/policies/:policyId", handlers.IAM.DetachPolicyFromUser)
 		iamGroup.GET("/users/:userId/policies", handlers.IAM.GetUserPolicies)

--- a/internal/core/domain/iam.go
+++ b/internal/core/domain/iam.go
@@ -1,6 +1,8 @@
 package domain
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 )
 
@@ -32,6 +34,18 @@ type Policy struct {
 	Name        string      `json:"name"`
 	Description string      `json:"description,omitempty"`
 	Statements  []Statement `json:"statements"`
+}
+
+// PolicyVersion is a historical snapshot of a policy at a specific version.
+type PolicyVersion struct {
+	ID            uuid.UUID   `json:"id"`
+	PolicyID      uuid.UUID   `json:"policy_id"`
+	VersionNumber int         `json:"version_number"`
+	Name         string      `json:"name"`
+	Description  string      `json:"description,omitempty"`
+	Statements   []Statement `json:"statements"`
+	CreatedAt    time.Time   `json:"created_at"`
+	CreatedBy   *uuid.UUID  `json:"created_by,omitempty"`
 }
 
 // UserPolicy maps a policy to a user.

--- a/internal/core/domain/iam.go
+++ b/internal/core/domain/iam.go
@@ -41,11 +41,11 @@ type PolicyVersion struct {
 	ID            uuid.UUID   `json:"id"`
 	PolicyID      uuid.UUID   `json:"policy_id"`
 	VersionNumber int         `json:"version_number"`
-	Name         string      `json:"name"`
-	Description  string      `json:"description,omitempty"`
-	Statements   []Statement `json:"statements"`
-	CreatedAt    time.Time   `json:"created_at"`
-	CreatedBy   *uuid.UUID  `json:"created_by,omitempty"`
+	Name          string      `json:"name"`
+	Description   string      `json:"description,omitempty"`
+	Statements    []Statement `json:"statements"`
+	CreatedAt     time.Time   `json:"created_at"`
+	CreatedBy     *uuid.UUID  `json:"created_by,omitempty"`
 }
 
 // UserPolicy maps a policy to a user.

--- a/internal/core/ports/iam.go
+++ b/internal/core/ports/iam.go
@@ -16,6 +16,11 @@ type IAMRepository interface {
 	UpdatePolicy(ctx context.Context, tenantID uuid.UUID, policy *domain.Policy) error
 	DeletePolicy(ctx context.Context, tenantID uuid.UUID, id uuid.UUID) error
 
+	// Policy Versioning
+	ListPolicyVersions(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID) ([]*domain.PolicyVersion, error)
+	GetPolicyVersion(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID, versionNumber int) (*domain.PolicyVersion, error)
+	InsertPolicyVersion(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error
+
 	// User Policy Assignment
 	AttachPolicyToUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, policyID uuid.UUID) error
 	DetachPolicyFromUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, policyID uuid.UUID) error
@@ -55,6 +60,11 @@ type IAMService interface {
 	// SimulatePolicy evaluates what-if actions/resources against the given principal's policies.
 	// Returns the decision and which statement matched, for debugging.
 	SimulatePolicy(ctx context.Context, principal Principal, actions []string, resources []string, evalCtx map[string]interface{}) (*SimulateResult, error)
+
+	// Policy Versioning
+	ListPolicyVersions(ctx context.Context, policyID uuid.UUID) ([]*domain.PolicyVersion, error)
+	GetPolicyVersion(ctx context.Context, policyID uuid.UUID, versionNumber int) (*domain.PolicyVersion, error)
+	RollbackPolicyVersion(ctx context.Context, policyID uuid.UUID, versionNumber int) error
 }
 
 // Principal identifies the actor whose policies will be evaluated in a simulation.

--- a/internal/core/ports/iam.go
+++ b/internal/core/ports/iam.go
@@ -20,6 +20,7 @@ type IAMRepository interface {
 	ListPolicyVersions(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID) ([]*domain.PolicyVersion, error)
 	GetPolicyVersion(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID, versionNumber int) (*domain.PolicyVersion, error)
 	InsertPolicyVersion(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error
+	SyncPolicyCurrentState(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error
 
 	// User Policy Assignment
 	AttachPolicyToUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, policyID uuid.UUID) error

--- a/internal/core/ports/mocks/iam_mocks.go
+++ b/internal/core/ports/mocks/iam_mocks.go
@@ -89,6 +89,23 @@ func (m *IAMRepository) GetPoliciesForServiceAccount(ctx context.Context, tenant
 	return r0, args.Error(1)
 }
 
+func (m *IAMRepository) ListPolicyVersions(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID) ([]*domain.PolicyVersion, error) {
+	args := m.Called(ctx, tenantID, policyID)
+	r0, _ := args.Get(0).([]*domain.PolicyVersion)
+	return r0, args.Error(1)
+}
+
+func (m *IAMRepository) GetPolicyVersion(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID, versionNumber int) (*domain.PolicyVersion, error) {
+	args := m.Called(ctx, tenantID, policyID, versionNumber)
+	r0, _ := args.Get(0).(*domain.PolicyVersion)
+	return r0, args.Error(1)
+}
+
+func (m *IAMRepository) InsertPolicyVersion(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error {
+	args := m.Called(ctx, tenantID, pv)
+	return args.Error(0)
+}
+
 // IAMService is a mock for ports.IAMService
 type IAMService struct {
 	mock.Mock
@@ -173,6 +190,23 @@ func (m *IAMService) SimulatePolicy(ctx context.Context, principal ports.Princip
 	args := m.Called(ctx, principal, actions, resources, evalCtx)
 	r0, _ := args.Get(0).(*ports.SimulateResult)
 	return r0, args.Error(1)
+}
+
+func (m *IAMService) ListPolicyVersions(ctx context.Context, policyID uuid.UUID) ([]*domain.PolicyVersion, error) {
+	args := m.Called(ctx, policyID)
+	r0, _ := args.Get(0).([]*domain.PolicyVersion)
+	return r0, args.Error(1)
+}
+
+func (m *IAMService) GetPolicyVersion(ctx context.Context, policyID uuid.UUID, versionNumber int) (*domain.PolicyVersion, error) {
+	args := m.Called(ctx, policyID, versionNumber)
+	r0, _ := args.Get(0).(*domain.PolicyVersion)
+	return r0, args.Error(1)
+}
+
+func (m *IAMService) RollbackPolicyVersion(ctx context.Context, policyID uuid.UUID, versionNumber int) error {
+	args := m.Called(ctx, policyID, versionNumber)
+	return args.Error(0)
 }
 
 // UserRepository is a mock for ports.UserRepository

--- a/internal/core/ports/mocks/iam_mocks.go
+++ b/internal/core/ports/mocks/iam_mocks.go
@@ -106,6 +106,11 @@ func (m *IAMRepository) InsertPolicyVersion(ctx context.Context, tenantID uuid.U
 	return args.Error(0)
 }
 
+func (m *IAMRepository) SyncPolicyCurrentState(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error {
+	args := m.Called(ctx, tenantID, pv)
+	return args.Error(0)
+}
+
 // IAMService is a mock for ports.IAMService
 type IAMService struct {
 	mock.Mock

--- a/internal/core/services/iam.go
+++ b/internal/core/services/iam.go
@@ -225,3 +225,70 @@ func (s *iamService) SimulatePolicy(ctx context.Context, principal ports.Princip
 
 	return result, nil
 }
+
+func (s *iamService) ListPolicyVersions(ctx context.Context, policyID uuid.UUID) ([]*domain.PolicyVersion, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	return s.repo.ListPolicyVersions(ctx, tenantID, policyID)
+}
+
+func (s *iamService) GetPolicyVersion(ctx context.Context, policyID uuid.UUID, versionNumber int) (*domain.PolicyVersion, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	return s.repo.GetPolicyVersion(ctx, tenantID, policyID, versionNumber)
+}
+
+func (s *iamService) RollbackPolicyVersion(ctx context.Context, policyID uuid.UUID, versionNumber int) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+
+	// Fetch the version to restore
+	pv, err := s.repo.GetPolicyVersion(ctx, tenantID, policyID, versionNumber)
+	if err != nil {
+		return err
+	}
+
+	// Get current policy to preserve tenant_id
+	current, err := s.repo.GetPolicyByID(ctx, tenantID, policyID)
+	if err != nil {
+		return err
+	}
+
+	// Get max version to determine new version number
+	versions, err := s.repo.ListPolicyVersions(ctx, tenantID, policyID)
+	if err != nil {
+		return err
+	}
+	maxVersion := 0
+	if len(versions) > 0 {
+		maxVersion = versions[0].VersionNumber
+	}
+
+	// Create a new version with the same content as the rollback target
+	newVersion := &domain.PolicyVersion{
+		ID:            uuid.New(),
+		PolicyID:      policyID,
+		VersionNumber: maxVersion + 1,
+		Name:          pv.Name,
+		Description:   pv.Description,
+		Statements:    pv.Statements,
+	}
+
+	// Insert the rollback as a new version
+	if err := s.repo.InsertPolicyVersion(ctx, tenantID, newVersion); err != nil {
+		return err
+	}
+
+	// Update the current policy row to match
+	current.Statements = pv.Statements
+	current.Name = pv.Name
+	current.Description = pv.Description
+	if err := s.repo.UpdatePolicy(ctx, tenantID, current); err != nil {
+		return err
+	}
+
+	if err := s.eventSvc.RecordEvent(ctx, "IAM_POLICY_ROLLBACK", policyID.String(), "POLICY", map[string]interface{}{
+		"rolled_back_to_version": versionNumber,
+		"new_version":           newVersion.VersionNumber,
+	}); err != nil {
+		s.logger.Warn("failed to record event", "action", "IAM_POLICY_ROLLBACK", "policy_id", policyID, "error", err)
+	}
+	return nil
+}

--- a/internal/core/services/iam.go
+++ b/internal/core/services/iam.go
@@ -273,7 +273,7 @@ func (s *iamService) RollbackPolicyVersion(ctx context.Context, policyID uuid.UU
 
 	if err := s.eventSvc.RecordEvent(ctx, "IAM_POLICY_ROLLBACK", policyID.String(), "POLICY", map[string]interface{}{
 		"rolled_back_to_version": versionNumber,
-		"new_version":           newVersion.VersionNumber,
+		"new_version":            newVersion.VersionNumber,
 	}); err != nil {
 		s.logger.Warn("failed to record event", "action", "IAM_POLICY_ROLLBACK", "policy_id", policyID, "error", err)
 	}

--- a/internal/core/services/iam.go
+++ b/internal/core/services/iam.go
@@ -245,12 +245,6 @@ func (s *iamService) RollbackPolicyVersion(ctx context.Context, policyID uuid.UU
 		return err
 	}
 
-	// Get current policy to preserve tenant_id
-	current, err := s.repo.GetPolicyByID(ctx, tenantID, policyID)
-	if err != nil {
-		return err
-	}
-
 	// Get max version to determine new version number
 	versions, err := s.repo.ListPolicyVersions(ctx, tenantID, policyID)
 	if err != nil {
@@ -271,23 +265,9 @@ func (s *iamService) RollbackPolicyVersion(ctx context.Context, policyID uuid.UU
 		Statements:    pv.Statements,
 	}
 
-	// Insert the rollback as a new version
-	if err := s.repo.InsertPolicyVersion(ctx, tenantID, newVersion); err != nil {
-		return err
-	}
-
-	// Sync the current policy row to match the rollback target (no new version)
-	current.Statements = pv.Statements
-	current.Name = pv.Name
-	current.Description = pv.Description
-	if err := s.repo.SyncPolicyCurrentState(ctx, tenantID, &domain.PolicyVersion{
-		ID:            newVersion.ID,
-		PolicyID:      policyID,
-		VersionNumber: newVersion.VersionNumber,
-		Name:          pv.Name,
-		Description:   pv.Description,
-		Statements:    pv.Statements,
-	}); err != nil {
+	// SyncPolicyCurrentState handles both inserting the version row
+	// and updating the policies table for fast lookups.
+	if err := s.repo.SyncPolicyCurrentState(ctx, tenantID, newVersion); err != nil {
 		return err
 	}
 

--- a/internal/core/services/iam.go
+++ b/internal/core/services/iam.go
@@ -276,11 +276,18 @@ func (s *iamService) RollbackPolicyVersion(ctx context.Context, policyID uuid.UU
 		return err
 	}
 
-	// Update the current policy row to match
+	// Sync the current policy row to match the rollback target (no new version)
 	current.Statements = pv.Statements
 	current.Name = pv.Name
 	current.Description = pv.Description
-	if err := s.repo.UpdatePolicy(ctx, tenantID, current); err != nil {
+	if err := s.repo.SyncPolicyCurrentState(ctx, tenantID, &domain.PolicyVersion{
+		ID:            newVersion.ID,
+		PolicyID:      policyID,
+		VersionNumber: newVersion.VersionNumber,
+		Name:          pv.Name,
+		Description:   pv.Description,
+		Statements:    pv.Statements,
+	}); err != nil {
 		return err
 	}
 

--- a/internal/core/services/iam_unit_test.go
+++ b/internal/core/services/iam_unit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
 	"github.com/poyrazk/thecloud/internal/core/services"
+	"github.com/poyrazk/thecloud/internal/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -197,5 +198,58 @@ func TestIAMService_Unit(t *testing.T) {
 		assert.Equal(t, "FirstAllow", result.Matched.PolicyName) // First allow wins (allowResult is set once and not overwritten)
 		assert.Equal(t, 1, result.Evaluated)
 		mockRepo.AssertExpectations(t)
+	})
+}
+
+func TestIAMService_Unit_RollbackPolicyVersion(t *testing.T) {
+	mockRepo := new(MockIAMRepository)
+	mockAuditSvc := new(MockAuditService)
+	mockEventSvc := new(MockEventService)
+	svc := services.NewIAMService(mockRepo, mockAuditSvc, mockEventSvc, slog.Default())
+
+	ctx := context.Background()
+	tenantID := uuid.New()
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	policyID := uuid.New()
+
+	t.Run("successful rollback to older version", func(t *testing.T) {
+		targetVersion := &domain.PolicyVersion{
+			ID:            uuid.New(),
+			PolicyID:      policyID,
+			VersionNumber: 2,
+			Name:          "OldName",
+			Description:   "OldDesc",
+			Statements:    []domain.Statement{{Effect: domain.EffectAllow, Action: []string{"*"}}},
+		}
+		currentPolicy := &domain.Policy{
+			ID:          policyID,
+			TenantID:    tenantID,
+			Name:        "NewName",
+			Description: "NewDesc",
+			Statements:  []domain.Statement{{Effect: domain.EffectDeny, Action: []string{"compute:*"}}},
+		}
+		existingVersions := []*domain.PolicyVersion{
+			{VersionNumber: 3}, {VersionNumber: 2},
+		}
+
+		mockRepo.On("GetPolicyVersion", mock.Anything, tenantID, policyID, 2).Return(targetVersion, nil).Once()
+		mockRepo.On("GetPolicyByID", mock.Anything, tenantID, policyID).Return(currentPolicy, nil).Once()
+		mockRepo.On("ListPolicyVersions", mock.Anything, tenantID, policyID).Return(existingVersions, nil).Once()
+		mockRepo.On("InsertPolicyVersion", mock.Anything, tenantID, mock.AnythingOfType("*domain.PolicyVersion")).Return(nil).Once()
+		mockRepo.On("SyncPolicyCurrentState", mock.Anything, tenantID, mock.AnythingOfType("*domain.PolicyVersion")).Return(nil).Once()
+		mockEventSvc.On("RecordEvent", mock.Anything, "IAM_POLICY_ROLLBACK", policyID.String(), "POLICY", mock.Anything).Return(nil).Once()
+
+		err := svc.RollbackPolicyVersion(ctx, policyID, 2)
+		require.NoError(t, err)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("returns not found when target version does not exist", func(t *testing.T) {
+		mockRepo.On("GetPolicyVersion", mock.Anything, tenantID, policyID, 99).Return(nil, errors.New(errors.NotFound, "policy version not found")).Once()
+
+		err := svc.RollbackPolicyVersion(ctx, policyID, 99)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
 	})
 }

--- a/internal/core/services/iam_unit_test.go
+++ b/internal/core/services/iam_unit_test.go
@@ -222,21 +222,12 @@ func TestIAMService_Unit_RollbackPolicyVersion(t *testing.T) {
 			Description:   "OldDesc",
 			Statements:    []domain.Statement{{Effect: domain.EffectAllow, Action: []string{"*"}}},
 		}
-		currentPolicy := &domain.Policy{
-			ID:          policyID,
-			TenantID:    tenantID,
-			Name:        "NewName",
-			Description: "NewDesc",
-			Statements:  []domain.Statement{{Effect: domain.EffectDeny, Action: []string{"compute:*"}}},
-		}
 		existingVersions := []*domain.PolicyVersion{
 			{VersionNumber: 3}, {VersionNumber: 2},
 		}
 
 		mockRepo.On("GetPolicyVersion", mock.Anything, tenantID, policyID, 2).Return(targetVersion, nil).Once()
-		mockRepo.On("GetPolicyByID", mock.Anything, tenantID, policyID).Return(currentPolicy, nil).Once()
 		mockRepo.On("ListPolicyVersions", mock.Anything, tenantID, policyID).Return(existingVersions, nil).Once()
-		mockRepo.On("InsertPolicyVersion", mock.Anything, tenantID, mock.AnythingOfType("*domain.PolicyVersion")).Return(nil).Once()
 		mockRepo.On("SyncPolicyCurrentState", mock.Anything, tenantID, mock.AnythingOfType("*domain.PolicyVersion")).Return(nil).Once()
 		mockEventSvc.On("RecordEvent", mock.Anything, "IAM_POLICY_ROLLBACK", policyID.String(), "POLICY", mock.Anything).Return(nil).Once()
 

--- a/internal/core/services/mock_iam_test.go
+++ b/internal/core/services/mock_iam_test.go
@@ -140,6 +140,23 @@ func (m *MockIAMRepository) GetPoliciesForServiceAccount(ctx context.Context, te
 	}
 	return args.Get(0).([]*domain.Policy), args.Error(1)
 }
+func (m *MockIAMRepository) ListPolicyVersions(ctx context.Context, tenantID, policyID uuid.UUID) ([]*domain.PolicyVersion, error) {
+	args := m.Called(ctx, tenantID, policyID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.PolicyVersion), args.Error(1)
+}
+func (m *MockIAMRepository) GetPolicyVersion(ctx context.Context, tenantID, policyID uuid.UUID, versionNumber int) (*domain.PolicyVersion, error) {
+	args := m.Called(ctx, tenantID, policyID, versionNumber)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.PolicyVersion), args.Error(1)
+}
+func (m *MockIAMRepository) InsertPolicyVersion(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error {
+	return m.Called(ctx, tenantID, pv).Error(0)
+}
 
 // MockIdentityService
 type MockIdentityService struct {

--- a/internal/core/services/mock_iam_test.go
+++ b/internal/core/services/mock_iam_test.go
@@ -157,6 +157,9 @@ func (m *MockIAMRepository) GetPolicyVersion(ctx context.Context, tenantID, poli
 func (m *MockIAMRepository) InsertPolicyVersion(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error {
 	return m.Called(ctx, tenantID, pv).Error(0)
 }
+func (m *MockIAMRepository) SyncPolicyCurrentState(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error {
+	return m.Called(ctx, tenantID, pv).Error(0)
+}
 
 // MockIdentityService
 type MockIdentityService struct {

--- a/internal/handlers/iam_handler.go
+++ b/internal/handlers/iam_handler.go
@@ -3,6 +3,7 @@ package httphandlers
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -172,6 +173,102 @@ func (h *IAMHandler) DeletePolicy(c *gin.Context) {
 	}
 
 	httputil.Success(c, http.StatusOK, gin.H{"status": "deleted"})
+}
+
+// GetPolicyVersions lists all versions of a policy.
+// @Summary List Policy Versions
+// @Description List all historical versions of a specific IAM policy.
+// @Tags iam
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "Policy ID"
+// @Success 200 {object} httputil.Response{data=[]domain.PolicyVersion}
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/policies/{id}/versions [get]
+func (h *IAMHandler) GetPolicyVersions(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	versions, err := h.svc.ListPolicyVersions(c.Request.Context(), id)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, versions)
+}
+
+// GetPolicyVersion returns a specific version of a policy.
+// @Summary Get Policy Version
+// @Description Get a specific historical version of an IAM policy.
+// @Tags iam
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "Policy ID"
+// @Param version path int true "Version Number"
+// @Success 200 {object} httputil.Response{data=domain.PolicyVersion}
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/policies/{id}/versions/{version} [get]
+func (h *IAMHandler) GetPolicyVersion(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	versionStr := c.Param("version")
+	version, err := strconv.Atoi(versionStr)
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid version number"))
+		return
+	}
+
+	pv, err := h.svc.GetPolicyVersion(c.Request.Context(), id, version)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, pv)
+}
+
+// RollbackPolicyVersion restores a policy to a specific historical version.
+// @Summary Rollback Policy Version
+// @Description Restore a policy to a specific historical version by creating a new version with the old content.
+// @Tags iam
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "Policy ID"
+// @Param version path int true "Version Number to Rollback To"
+// @Success 200 {object} httputil.Response
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/policies/{id}/rollback/{version} [post]
+func (h *IAMHandler) RollbackPolicyVersion(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	versionStr := c.Param("version")
+	version, err := strconv.Atoi(versionStr)
+	if err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid version number"))
+		return
+	}
+
+	if err := h.svc.RollbackPolicyVersion(c.Request.Context(), id, version); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	httputil.Success(c, http.StatusOK, gin.H{"status": "rolled_back", "version": version})
 }
 
 // AttachPolicyToUser attaches a policy to a user.

--- a/internal/handlers/iam_handler.go
+++ b/internal/handlers/iam_handler.go
@@ -194,6 +194,12 @@ func (h *IAMHandler) GetPolicyVersions(c *gin.Context) {
 		return
 	}
 
+	// Validate policy exists under this tenant before listing versions
+	if _, err := h.svc.GetPolicyByID(c.Request.Context(), id); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
 	versions, err := h.svc.ListPolicyVersions(c.Request.Context(), id)
 	if err != nil {
 		httputil.Error(c, err)

--- a/internal/repositories/postgres/iam_repo.go
+++ b/internal/repositories/postgres/iam_repo.go
@@ -27,12 +27,31 @@ func (r *iamRepository) CreatePolicy(ctx context.Context, tenantID uuid.UUID, po
 		return fmt.Errorf("failed to marshal statements: %w", err)
 	}
 
-	query := `
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Insert current policy row
+	_, err = tx.Exec(ctx, `
 		INSERT INTO policies (id, tenant_id, name, description, statements)
 		VALUES ($1, $2, $3, $4, $5)
-	`
-	_, err = r.db.Exec(ctx, query, policy.ID, tenantID, policy.Name, policy.Description, statementsJSON)
-	return err
+	`, policy.ID, tenantID, policy.Name, policy.Description, statementsJSON)
+	if err != nil {
+		return err
+	}
+
+	// Insert version 1
+	_, err = tx.Exec(ctx, `
+		INSERT INTO policy_versions (id, policy_id, version_number, name, description, statements)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, uuid.New(), policy.ID, 1, policy.Name, policy.Description, statementsJSON)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
 }
 
 func (r *iamRepository) GetPolicyByID(ctx context.Context, tenantID uuid.UUID, id uuid.UUID) (*domain.Policy, error) {
@@ -82,24 +101,45 @@ func (r *iamRepository) ListPolicies(ctx context.Context, tenantID uuid.UUID) ([
 }
 
 func (r *iamRepository) UpdatePolicy(ctx context.Context, tenantID uuid.UUID, policy *domain.Policy) error {
+	// Get current max version number for this policy
+	var maxVersion int
+	err := r.db.QueryRow(ctx, "SELECT COALESCE(MAX(version_number), 0) FROM policy_versions WHERE policy_id = $1", policy.ID).Scan(&maxVersion)
+	if err != nil {
+		return err
+	}
+	newVersion := maxVersion + 1
+
 	statementsJSON, err := json.Marshal(policy.Statements)
 	if err != nil {
 		return fmt.Errorf("failed to marshal statements: %w", err)
 	}
 
-	query := `
-		UPDATE policies
-		SET name = $1, description = $2, statements = $3, updated_at = NOW()
-		WHERE id = $4 AND tenant_id = $5
-	`
-	result, err := r.db.Exec(ctx, query, policy.Name, policy.Description, statementsJSON, policy.ID, tenantID)
+	tx, err := r.db.Begin(ctx)
 	if err != nil {
 		return err
 	}
-	if result.RowsAffected() == 0 {
-		return errors.New(errors.NotFound, "policy not found")
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Insert new version row
+	_, err = tx.Exec(ctx, `
+		INSERT INTO policy_versions (id, policy_id, version_number, name, description, statements)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, uuid.New(), policy.ID, newVersion, policy.Name, policy.Description, statementsJSON)
+	if err != nil {
+		return err
 	}
-	return nil
+
+	// Update current policy row for fast lookups
+	_, err = tx.Exec(ctx, `
+		UPDATE policies
+		SET name = $1, description = $2, statements = $3, updated_at = NOW()
+		WHERE id = $4 AND tenant_id = $5
+	`, policy.Name, policy.Description, statementsJSON, policy.ID, tenantID)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
 }
 
 func (r *iamRepository) DeletePolicy(ctx context.Context, tenantID uuid.UUID, id uuid.UUID) error {
@@ -111,6 +151,75 @@ func (r *iamRepository) DeletePolicy(ctx context.Context, tenantID uuid.UUID, id
 		return errors.New(errors.NotFound, "policy not found")
 	}
 	return nil
+}
+
+func (r *iamRepository) ListPolicyVersions(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID) ([]*domain.PolicyVersion, error) {
+	query := `
+		SELECT pv.id, pv.policy_id, pv.version_number, pv.name, pv.description, pv.statements, pv.created_at, pv.created_by
+		FROM policy_versions pv
+		JOIN policies p ON pv.policy_id = p.id
+		WHERE pv.policy_id = $1 AND p.tenant_id = $2
+		ORDER BY pv.version_number DESC
+	`
+	rows, err := r.db.Query(ctx, query, policyID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var versions []*domain.PolicyVersion
+	for rows.Next() {
+		var pv domain.PolicyVersion
+		var statementsJSON []byte
+		if err := rows.Scan(&pv.ID, &pv.PolicyID, &pv.VersionNumber, &pv.Name, &pv.Description, &statementsJSON, &pv.CreatedAt, &pv.CreatedBy); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(statementsJSON, &pv.Statements); err != nil {
+			return nil, err
+		}
+		versions = append(versions, &pv)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return versions, nil
+}
+
+func (r *iamRepository) GetPolicyVersion(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID, versionNumber int) (*domain.PolicyVersion, error) {
+	query := `
+		SELECT pv.id, pv.policy_id, pv.version_number, pv.name, pv.description, pv.statements, pv.created_at, pv.created_by
+		FROM policy_versions pv
+		JOIN policies p ON pv.policy_id = p.id
+		WHERE pv.policy_id = $1 AND p.tenant_id = $2 AND pv.version_number = $3
+	`
+	var pv domain.PolicyVersion
+	var statementsJSON []byte
+	err := r.db.QueryRow(ctx, query, policyID, tenantID, versionNumber).
+		Scan(&pv.ID, &pv.PolicyID, &pv.VersionNumber, &pv.Name, &pv.Description, &statementsJSON, &pv.CreatedAt, &pv.CreatedBy)
+	if err != nil {
+		if stdlib_errors.Is(err, pgx.ErrNoRows) {
+			return nil, errors.New(errors.NotFound, "policy version not found")
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(statementsJSON, &pv.Statements); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal statements: %w", err)
+	}
+	return &pv, nil
+}
+
+func (r *iamRepository) InsertPolicyVersion(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error {
+	statementsJSON, err := json.Marshal(pv.Statements)
+	if err != nil {
+		return fmt.Errorf("failed to marshal statements: %w", err)
+	}
+
+	query := `
+		INSERT INTO policy_versions (id, policy_id, version_number, name, description, statements, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`
+	_, err = r.db.Exec(ctx, query, pv.ID, pv.PolicyID, pv.VersionNumber, pv.Name, pv.Description, statementsJSON, pv.CreatedBy)
+	return err
 }
 
 func (r *iamRepository) AttachPolicyToUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, policyID uuid.UUID) error {

--- a/internal/repositories/postgres/iam_repo.go
+++ b/internal/repositories/postgres/iam_repo.go
@@ -101,14 +101,6 @@ func (r *iamRepository) ListPolicies(ctx context.Context, tenantID uuid.UUID) ([
 }
 
 func (r *iamRepository) UpdatePolicy(ctx context.Context, tenantID uuid.UUID, policy *domain.Policy) error {
-	// Get current max version number for this policy
-	var maxVersion int
-	err := r.db.QueryRow(ctx, "SELECT COALESCE(MAX(version_number), 0) FROM policy_versions WHERE policy_id = $1", policy.ID).Scan(&maxVersion)
-	if err != nil {
-		return err
-	}
-	newVersion := maxVersion + 1
-
 	statementsJSON, err := json.Marshal(policy.Statements)
 	if err != nil {
 		return fmt.Errorf("failed to marshal statements: %w", err)
@@ -120,11 +112,17 @@ func (r *iamRepository) UpdatePolicy(ctx context.Context, tenantID uuid.UUID, po
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	// Insert new version row
+	// Atomically get max version and insert new version row using CTE
+	// This prevents race conditions where two concurrent updates both read the same max.
 	_, err = tx.Exec(ctx, `
+		WITH max_version AS (
+			SELECT COALESCE(MAX(version_number), 0) + 1 AS new_version
+			FROM policy_versions
+			WHERE policy_id = $1
+		)
 		INSERT INTO policy_versions (id, policy_id, version_number, name, description, statements)
-		VALUES ($1, $2, $3, $4, $5, $6)
-	`, uuid.New(), policy.ID, newVersion, policy.Name, policy.Description, statementsJSON)
+		SELECT $2, $1, new_version, $3, $4, $5 FROM max_version
+	`, policy.ID, uuid.New(), policy.Name, policy.Description, statementsJSON)
 	if err != nil {
 		return err
 	}
@@ -135,6 +133,42 @@ func (r *iamRepository) UpdatePolicy(ctx context.Context, tenantID uuid.UUID, po
 		SET name = $1, description = $2, statements = $3, updated_at = NOW()
 		WHERE id = $4 AND tenant_id = $5
 	`, policy.Name, policy.Description, statementsJSON, policy.ID, tenantID)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// SyncPolicyCurrentState updates the policies table and inserts a new version row
+// without incrementing the version number (used by rollback to sync to a specific version).
+func (r *iamRepository) SyncPolicyCurrentState(ctx context.Context, tenantID uuid.UUID, pv *domain.PolicyVersion) error {
+	statementsJSON, err := json.Marshal(pv.Statements)
+	if err != nil {
+		return fmt.Errorf("failed to marshal statements: %w", err)
+	}
+
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Insert version row
+	_, err = tx.Exec(ctx, `
+		INSERT INTO policy_versions (id, policy_id, version_number, name, description, statements)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, pv.ID, pv.PolicyID, pv.VersionNumber, pv.Name, pv.Description, statementsJSON)
+	if err != nil {
+		return err
+	}
+
+	// Update current policy row for fast lookups
+	_, err = tx.Exec(ctx, `
+		UPDATE policies
+		SET name = $1, description = $2, statements = $3, updated_at = NOW()
+		WHERE id = $4 AND tenant_id = $5
+	`, pv.Name, pv.Description, statementsJSON, pv.PolicyID, tenantID)
 	if err != nil {
 		return err
 	}

--- a/internal/repositories/postgres/iam_repo_test.go
+++ b/internal/repositories/postgres/iam_repo_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/pashagolub/pgxmock/v3"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestIAMRepositoryUnit(t *testing.T) {
+func TestIAMRepository_CreatePolicy(t *testing.T) {
 	mock, err := pgxmock.NewPool()
 	require.NoError(t, err)
 	defer mock.Close()
@@ -31,16 +32,43 @@ func TestIAMRepositoryUnit(t *testing.T) {
 		},
 	}
 
-	t.Run("CreatePolicy", func(t *testing.T) {
+	t.Run("creates policy and version 1", func(t *testing.T) {
+		statementsJSON, _ := json.Marshal(policy.Statements)
+		mock.ExpectBegin()
 		mock.ExpectExec("INSERT INTO policies").
-			WithArgs(policy.ID, tenantID, policy.Name, policy.Description, pgxmock.AnyArg()).
+			WithArgs(policy.ID, tenantID, policy.Name, policy.Description, statementsJSON).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		mock.ExpectExec("INSERT INTO policy_versions").
+			WithArgs(pgxmock.AnyArg(), policy.ID, 1, policy.Name, policy.Description, statementsJSON).
+			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		mock.ExpectCommit()
 
 		err := repo.CreatePolicy(ctx, tenantID, policy)
 		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
 
-	t.Run("GetPolicyByID", func(t *testing.T) {
+func TestIAMRepository_GetPolicyByID(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewIAMRepository(mock)
+	ctx := context.Background()
+
+	policyID := uuid.New()
+	tenantID := uuid.New()
+	policy := &domain.Policy{
+		ID:       policyID,
+		TenantID: tenantID,
+		Name:     "TestPolicy",
+		Statements: []domain.Statement{
+			{Effect: domain.EffectAllow, Action: []string{"*"}},
+		},
+	}
+
+	t.Run("fetches policy by id", func(t *testing.T) {
 		statementsJSON, err := json.Marshal(policy.Statements)
 		require.NoError(t, err)
 		rows := pgxmock.NewRows([]string{"id", "tenant_id", "name", "description", "statements"}).
@@ -54,12 +82,31 @@ func TestIAMRepositoryUnit(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, policy.ID, fetched.ID)
 		assert.Equal(t, policy.Name, fetched.Name)
+		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
 
-	t.Run("AttachPolicyToUser", func(t *testing.T) {
-		userID := uuid.New()
+func TestIAMRepository_AttachPolicyToUser(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
 
-		// AttachPolicyToUser calls GetPolicyByID first
+	repo := NewIAMRepository(mock)
+	ctx := context.Background()
+
+	policyID := uuid.New()
+	tenantID := uuid.New()
+	userID := uuid.New()
+	policy := &domain.Policy{
+		ID:       policyID,
+		TenantID: tenantID,
+		Name:     "TestPolicy",
+		Statements: []domain.Statement{
+			{Effect: domain.EffectAllow, Action: []string{"*"}},
+		},
+	}
+
+	t.Run("attaches policy to user", func(t *testing.T) {
 		statementsJSON, _ := json.Marshal(policy.Statements)
 		policyRows := pgxmock.NewRows([]string{"id", "tenant_id", "name", "description", "statements"}).
 			AddRow(policy.ID, policy.TenantID, policy.Name, policy.Description, statementsJSON)
@@ -73,23 +120,171 @@ func TestIAMRepositoryUnit(t *testing.T) {
 
 		err := repo.AttachPolicyToUser(ctx, tenantID, userID, policy.ID)
 		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
 	})
+}
 
-	t.Run("GetPoliciesForUser", func(t *testing.T) {
-		userID := uuid.New()
+func TestIAMRepository_UpdatePolicy_CreatesVersion(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewIAMRepository(mock)
+	ctx := context.Background()
+
+	policyID := uuid.New()
+	tenantID := uuid.New()
+	updatedPolicy := &domain.Policy{
+		ID:          policyID,
+		TenantID:    tenantID,
+		Name:        "UpdatedPolicy",
+		Description: "Updated description",
+		Statements: []domain.Statement{
+			{Effect: domain.EffectDeny, Action: []string{"compute:*"}},
+		},
+	}
+
+	t.Run("creates new version on update", func(t *testing.T) {
+		updatedStatementsJSON, _ := json.Marshal(updatedPolicy.Statements)
+		mock.ExpectQuery("SELECT COALESCE").
+			WithArgs(policyID).
+			WillReturnRows(pgxmock.NewRows([]string{"max"}).AddRow(2))
+
+		mock.ExpectBegin()
+		mock.ExpectExec("INSERT INTO policy_versions").
+			WithArgs(pgxmock.AnyArg(), policyID, 3, updatedPolicy.Name, updatedPolicy.Description, updatedStatementsJSON).
+			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+		mock.ExpectExec("UPDATE policies").
+			WithArgs(updatedPolicy.Name, updatedPolicy.Description, updatedStatementsJSON, policyID, tenantID).
+			WillReturnResult(pgxmock.NewResult("UPDATE", 1))
+		mock.ExpectCommit()
+
+		err := repo.UpdatePolicy(ctx, tenantID, updatedPolicy)
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestIAMRepository_ListPolicyVersions(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewIAMRepository(mock)
+	ctx := context.Background()
+
+	policyID := uuid.New()
+	tenantID := uuid.New()
+	policy := &domain.Policy{
+		ID:       policyID,
+		TenantID: tenantID,
+		Name:     "TestPolicy",
+		Statements: []domain.Statement{
+			{Effect: domain.EffectAllow, Action: []string{"*"}},
+		},
+	}
+
+	t.Run("lists versions in descending order", func(t *testing.T) {
 		statementsJSON, _ := json.Marshal(policy.Statements)
-		rows := pgxmock.NewRows([]string{"id", "tenant_id", "name", "description", "statements"}).
-			AddRow(policy.ID, policy.TenantID, policy.Name, policy.Description, statementsJSON)
+		rows := pgxmock.NewRows([]string{"id", "policy_id", "version_number", "name", "description", "statements", "created_at", "created_by"}).
+			AddRow(uuid.New(), policyID, 2, policy.Name, policy.Description, statementsJSON, nil, nil).
+			AddRow(uuid.New(), policyID, 1, policy.Name, policy.Description, statementsJSON, nil, nil)
 
-		mock.ExpectQuery("SELECT p.id, p.tenant_id, p.name, p.description, p.statements").
-			WithArgs(userID, tenantID).
+		mock.ExpectQuery("SELECT pv.id, pv.policy_id, pv.version_number, pv.name, pv.description, pv.statements, pv.created_at, pv.created_by").
+			WithArgs(policyID, tenantID).
 			WillReturnRows(rows)
 
-		userPolicies, err := repo.GetPoliciesForUser(ctx, tenantID, userID)
+		versions, err := repo.ListPolicyVersions(ctx, tenantID, policyID)
 		require.NoError(t, err)
-		assert.Len(t, userPolicies, 1)
-		assert.Equal(t, policy.ID, userPolicies[0].ID)
+		require.Len(t, versions, 2)
+		assert.Equal(t, 2, versions[0].VersionNumber)
+		assert.Equal(t, 1, versions[1].VersionNumber)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestIAMRepository_GetPolicyVersion(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewIAMRepository(mock)
+	ctx := context.Background()
+
+	policyID := uuid.New()
+	tenantID := uuid.New()
+	policy := &domain.Policy{
+		ID:       policyID,
+		TenantID: tenantID,
+		Name:     "TestPolicy",
+		Statements: []domain.Statement{
+			{Effect: domain.EffectAllow, Action: []string{"*"}},
+		},
+	}
+
+	t.Run("returns specific version", func(t *testing.T) {
+		statementsJSON, _ := json.Marshal(policy.Statements)
+		rows := pgxmock.NewRows([]string{"id", "policy_id", "version_number", "name", "description", "statements", "created_at", "created_by"}).
+			AddRow(uuid.New(), policyID, 1, policy.Name, policy.Description, statementsJSON, nil, nil)
+
+		mock.ExpectQuery("SELECT pv.id, pv.policy_id, pv.version_number, pv.name, pv.description, pv.statements, pv.created_at, pv.created_by").
+			WithArgs(policyID, tenantID, 1).
+			WillReturnRows(rows)
+
+		version, err := repo.GetPolicyVersion(ctx, tenantID, policyID, 1)
+		require.NoError(t, err)
+		assert.Equal(t, 1, version.VersionNumber)
+		assert.Equal(t, policyID, version.PolicyID)
+		require.NoError(t, mock.ExpectationsWereMet())
 	})
 
-	require.NoError(t, mock.ExpectationsWereMet())
+	t.Run("returns not found for nonexistent version", func(t *testing.T) {
+		mock.ExpectQuery("SELECT pv.id, pv.policy_id, pv.version_number, pv.name, pv.description, pv.statements, pv.created_at, pv.created_by").
+			WithArgs(policyID, tenantID, 99).
+			WillReturnError(pgx.ErrNoRows)
+
+		_, err := repo.GetPolicyVersion(ctx, tenantID, policyID, 99)
+		require.Error(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestIAMRepository_InsertPolicyVersion(t *testing.T) {
+	mock, err := pgxmock.NewPool()
+	require.NoError(t, err)
+	defer mock.Close()
+
+	repo := NewIAMRepository(mock)
+	ctx := context.Background()
+
+	policyID := uuid.New()
+	tenantID := uuid.New()
+	policy := &domain.Policy{
+		ID:       policyID,
+		TenantID: tenantID,
+		Name:     "TestPolicy",
+		Statements: []domain.Statement{
+			{Effect: domain.EffectAllow, Action: []string{"*"}},
+		},
+	}
+
+	t.Run("inserts new version", func(t *testing.T) {
+		pv := &domain.PolicyVersion{
+			ID:            uuid.New(),
+			PolicyID:      policyID,
+			VersionNumber: 3,
+			Name:          policy.Name,
+			Description:   policy.Description,
+			Statements:    policy.Statements,
+		}
+		statementsJSON, _ := json.Marshal(pv.Statements)
+
+		mock.ExpectExec("INSERT INTO policy_versions").
+			WithArgs(pv.ID, pv.PolicyID, pv.VersionNumber, pv.Name, pv.Description, statementsJSON, pv.CreatedBy).
+			WillReturnResult(pgxmock.NewResult("INSERT", 1))
+
+		err := repo.InsertPolicyVersion(ctx, tenantID, pv)
+		require.NoError(t, err)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }

--- a/internal/repositories/postgres/iam_repo_test.go
+++ b/internal/repositories/postgres/iam_repo_test.go
@@ -146,13 +146,9 @@ func TestIAMRepository_UpdatePolicy_CreatesVersion(t *testing.T) {
 
 	t.Run("creates new version on update", func(t *testing.T) {
 		updatedStatementsJSON, _ := json.Marshal(updatedPolicy.Statements)
-		mock.ExpectQuery("SELECT COALESCE").
-			WithArgs(policyID).
-			WillReturnRows(pgxmock.NewRows([]string{"max"}).AddRow(2))
-
 		mock.ExpectBegin()
-		mock.ExpectExec("INSERT INTO policy_versions").
-			WithArgs(pgxmock.AnyArg(), policyID, 3, updatedPolicy.Name, updatedPolicy.Description, updatedStatementsJSON).
+		mock.ExpectExec("WITH max_version").
+			WithArgs(policyID, pgxmock.AnyArg(), updatedPolicy.Name, updatedPolicy.Description, updatedStatementsJSON).
 			WillReturnResult(pgxmock.NewResult("INSERT", 1))
 		mock.ExpectExec("UPDATE policies").
 			WithArgs(updatedPolicy.Name, updatedPolicy.Description, updatedStatementsJSON, policyID, tenantID).

--- a/internal/repositories/postgres/migrations/112_create_policy_versions.down.sql
+++ b/internal/repositories/postgres/migrations/112_create_policy_versions.down.sql
@@ -1,0 +1,3 @@
+-- +goose Down
+
+DROP TABLE IF EXISTS policy_versions;

--- a/internal/repositories/postgres/migrations/112_create_policy_versions.up.sql
+++ b/internal/repositories/postgres/migrations/112_create_policy_versions.up.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+
+CREATE TABLE IF NOT EXISTS policy_versions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    policy_id UUID NOT NULL REFERENCES policies(id) ON DELETE CASCADE,
+    version_number INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    statements JSONB NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    created_by UUID REFERENCES users(id),
+    UNIQUE (policy_id, version_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_policy_versions_policy_id ON policy_versions(policy_id);
+CREATE INDEX IF NOT EXISTS idx_policy_versions_policy_version ON policy_versions(policy_id, version_number DESC);


### PR DESCRIPTION
## Summary
- Add `policy_versions` append-only table for IAM policy audit trail
- `UpdatePolicy` now creates a new version row instead of overwriting
- Add endpoints: `GET /iam/policies/:id/versions`, `GET /iam/policies/:id/versions/:version`, `POST /iam/policies/:id/rollback/:version`
- Add service methods: `ListPolicyVersions`, `GetPolicyVersion`, `RollbackPolicyVersion`
- Rollback creates a new version with old content (no destructive updates)

## Test plan
- [x] Repository unit tests for version CRUD (`CreatePolicy`, `UpdatePolicy`, `ListPolicyVersions`, `GetPolicyVersion`, `InsertPolicyVersion`)
- [x] Service unit tests for `ListPolicyVersions`, `GetPolicyVersion`, `RollbackPolicyVersion`
- [x] Handler tests for new version endpoints