### PR TITLE
fix: add context cancellation check after healing delay (closes #217)

### DIFF
--- a/internal/workers/healing_worker.go
+++ b/internal/workers/healing_worker.go
@@ -109,6 +109,13 @@ func (w *HealingWorker) healERRORInstances(ctx context.Context) {
 			case <-timer.C:
 			}
 
+			// Check context cancellation again after delay
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
 			w.logger.Info("initiating healing restart", "instance_id", id)
 			if err := w.instSvc.StopInstance(hCtx, id); err != nil {
 				w.logger.Warn("healing: stop failed", "instance_id", id, "error", err)


### PR DESCRIPTION
## Summary
- Add context cancellation check after healing delay in `HealingWorker`
- Prevents healing operations on instances being deleted or with cancelled requests
- Fixes issue #217: HealingWorker continues operations after context cancellation

## Test plan
- [x] go build ./internal/workers/... — compiles
- [ ] CI passes