### PR TITLE
fix(k8s): add CLOUD_API_KEY to env files (closes #408)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,6 @@ STORAGE_SECRET=your-secure-storage-secret
 # For local development, use http://host.docker.internal:8080
 # For production, use https://api.yourdomain.com
 CLOUD_API_URL=http://host.docker.internal:8080
+# CLOUD_API_KEY is the API key used by k8s cluster components to authenticate
+# Generate with: openssl rand -hex 32
+CLOUD_API_KEY=your-api-key-here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,7 @@ services:
       - STORAGE_SECRET=${STORAGE_SECRET}
       - DOCKER_DEFAULT_NETWORK=${DOCKER_DEFAULT_NETWORK:-cloud-network}
       - CLOUD_API_URL=${CLOUD_API_URL:-http://host.docker.internal:8080}
+      - CLOUD_API_KEY=${CLOUD_API_KEY}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/openvswitch:/var/run/openvswitch


### PR DESCRIPTION
## Summary
- Add `CLOUD_API_KEY` to `.env.example` with documentation
- Add `CLOUD_API_KEY` environment variable to `docker-compose.yml` API service
- Fixes #408: K8s cluster creation fails because CLOUD_API_KEY not documented

## Test plan
- [ ] Verify: `grep CLOUD_API_KEY .env.example docker-compose.yml`