### PR TITLE
fix: add graceful shutdown to rate limiter cleanup loop (Issue #184)

### DIFF
--- a/pkg/ratelimit/limiter.go
+++ b/pkg/ratelimit/limiter.go
@@ -14,12 +14,14 @@ import (
 
 // IPRateLimiter manages rate limiters for different IPs/clients
 type IPRateLimiter struct {
-	ips    map[string]*rate.Limiter
-	routes map[uuid.UUID]map[string]*rate.Limiter // per-route limiters
-	mu     sync.RWMutex
-	rate   rate.Limit
-	burst  int
-	logger *slog.Logger
+	ips      map[string]*rate.Limiter
+	routes   map[uuid.UUID]map[string]*rate.Limiter // per-route limiters
+	mu       sync.RWMutex
+	rate     rate.Limit
+	burst    int
+	logger   *slog.Logger
+	stopCh   chan struct{}
+	stopOnce sync.Once
 }
 
 // NewIPRateLimiter creates a new rate limiter manager
@@ -30,6 +32,7 @@ func NewIPRateLimiter(r rate.Limit, b int, logger *slog.Logger) *IPRateLimiter {
 		rate:   r,
 		burst:  b,
 		logger: logger,
+		stopCh: make(chan struct{}),
 	}
 
 	// Periodic cleanup of old entries
@@ -84,14 +87,24 @@ func (i *IPRateLimiter) GetRouteLimiter(routeID uuid.UUID, key string, r rate.Li
 // timestamps for high-traffic production deployments.
 func (i *IPRateLimiter) cleanupLoop() {
 	for {
-		time.Sleep(10 * time.Minute)
-		i.mu.Lock()
-		// Start fresh every cleanup cycle for simplicity
-		// A production robust implementation would track last access time
-		i.ips = make(map[string]*rate.Limiter)
-		i.routes = make(map[uuid.UUID]map[string]*rate.Limiter)
-		i.mu.Unlock()
+		select {
+		case <-time.After(10 * time.Minute):
+			i.mu.Lock()
+			// Start fresh every cleanup cycle for simplicity
+			// A production robust implementation would track last access time
+			i.ips = make(map[string]*rate.Limiter)
+			i.routes = make(map[uuid.UUID]map[string]*rate.Limiter)
+			i.mu.Unlock()
+		case <-i.stopCh:
+			i.logger.Info("rate limiter cleanup loop stopping")
+			return
+		}
 	}
+}
+
+// Shutdown signals the cleanup loop to stop gracefully
+func (i *IPRateLimiter) Shutdown() {
+	i.stopOnce.Do(func() { close(i.stopCh) })
 }
 
 // Middleware creates a Gin middleware for rate limiting


### PR DESCRIPTION
## Summary
- Add `stopCh` channel to `IPRateLimiter` struct
- Modify `cleanupLoop()` to listen on `stopCh` for graceful shutdown
- Add `Shutdown()` method to signal the cleanup loop to stop

## Test plan
- [x] `go build ./pkg/ratelimit/...` — compiles
- [x] `go test ./pkg/ratelimit/...` — tests pass
- [x] `go build ./internal/api/setup/...` — compiles

Fixes #184