### PR TITLE
fix(iam): implement mid-string wildcard pattern matching (#512)

### DIFF
--- a/internal/core/services/iam_evaluator.go
+++ b/internal/core/services/iam_evaluator.go
@@ -260,8 +260,13 @@ func (e *iamEvaluator) matchPattern(pattern, target string) bool {
 // - * matches any sequence of characters (including empty)
 // - ? matches any single character
 // - * can appear at any position in the pattern
+//
+// Note: Uses recursion with max depth bounded by min(len(pattern), len(target)).
+// For typical IAM patterns (<100 chars), stack depth is not a concern.
+// If patterns could be maliciously long, consider iterative implementation.
 func matchGlob(pattern, target string) bool {
 	if pattern == "" {
+		// Empty pattern matches only empty target
 		return target == ""
 	}
 	if pattern == "*" {

--- a/internal/core/services/iam_evaluator.go
+++ b/internal/core/services/iam_evaluator.go
@@ -3,7 +3,6 @@ package services
 import (
 	"context"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/poyrazk/thecloud/internal/core/domain"
@@ -254,15 +253,73 @@ func (e *iamEvaluator) matches(statement domain.Statement, action string, resour
 }
 
 func (e *iamEvaluator) matchPattern(pattern, target string) bool {
+	return matchGlob(pattern, target)
+}
+
+// matchGlob implements glob-style pattern matching where:
+// - * matches any sequence of characters (including empty)
+// - ? matches any single character
+// - * can appear at any position in the pattern
+func matchGlob(pattern, target string) bool {
+	if pattern == "" {
+		return target == ""
+	}
 	if pattern == "*" {
 		return true
 	}
 
-	// Simple wildcard matching: "instance:*" matches "instance:launch"
-	if strings.HasSuffix(pattern, "*") {
-		prefix := strings.TrimSuffix(pattern, "*")
-		return strings.HasPrefix(target, prefix)
+	// Use recursive matching to handle wildcards at any position
+	return matchGlobRecursive(pattern, target)
+}
+
+func matchGlobRecursive(pattern, target string) bool {
+	// Both empty = match
+	if pattern == "" && target == "" {
+		return true
+	}
+	// Pattern empty, target not = no match
+	if pattern == "" {
+		return false
+	}
+	// Target empty - only * patterns can match empty target
+	if target == "" {
+		// Only trailing *s can match empty string
+		if pattern == "*" {
+			return true
+		}
+		if pattern[0] == '*' {
+			return matchGlobRecursive(pattern[1:], target)
+		}
+		return false
 	}
 
-	return pattern == target
+	// Handle * at any position
+	if pattern[0] == '*' {
+		// Try matching with * consuming zero characters
+		if matchGlobRecursive(pattern[1:], target) {
+			return true
+		}
+		// Try matching with * consuming one character
+		return matchGlobRecursive(pattern, target[1:])
+	}
+
+	// Handle ? matching any single character
+	if pattern[0] == '?' {
+		return matchGlobRecursive(pattern[1:], target[1:])
+	}
+
+	// Handle escaped characters (starting with \)
+	if len(pattern) >= 2 && pattern[0] == '\\' {
+		if pattern[1] == target[0] {
+			return matchGlobRecursive(pattern[2:], target[1:])
+		}
+		return false
+	}
+
+	// Handle single character literal match
+	if pattern[0] == target[0] {
+		return matchGlobRecursive(pattern[1:], target[1:])
+	}
+
+	return false
 }

--- a/internal/core/services/iam_evaluator.go
+++ b/internal/core/services/iam_evaluator.go
@@ -260,6 +260,7 @@ func (e *iamEvaluator) matchPattern(pattern, target string) bool {
 // - * matches any sequence of characters (including empty)
 // - ? matches any single character
 // - * can appear at any position in the pattern
+// - \ is the escape character: \*, \?, \: match literal *, ?, :
 //
 // Note: Uses recursion with max depth bounded by min(len(pattern), len(target)).
 // For typical IAM patterns (<100 chars), stack depth is not a concern.

--- a/internal/core/services/iam_evaluator_test.go
+++ b/internal/core/services/iam_evaluator_test.go
@@ -544,12 +544,32 @@ func TestIAMEvaluator_MatchPattern(t *testing.T) {
 		target  string
 		want    bool
 	}{
+		// Existing tests
 		{"*", "anything", true},
 		{"instance:*", "instance:launch", true},
 		{"instance:*", "instance:stop", true},
 		{"instance:*", "other:launch", false},
 		{"instance:launch", "instance:launch", true},
 		{"instance:launch", "instance:stop", false},
+		// Mid-string wildcard tests (Issue #512)
+		{"*:launch", "instance:launch", true},
+		{"*:launch", "func:launch", true},
+		{"*:launch", "instance:stop", false},
+		{"compute:*:instance", "compute:us-east-1:instance", true},
+		{"compute:*:instance", "compute:eu-west-2:instance", true},
+		{"compute:*:instance", "compute:instance", false},
+		{"compute:*:instance", "compute:region:other", false},
+		// Single character wildcard
+		{"instance:run-?", "instance:run-1", true},
+		{"instance:run-?", "instance:run-a", true},
+		{"instance:run-?", "instance:run-ab", false},
+		{"?:launch", "a:launch", true},
+		{"?:launch", "ab:launch", false},
+		// Complex patterns
+		{"*:instance:*", "compute:instance:us-east-1", true},
+		{"*:instance:*", "compute:instance", false},
+		{"*-*-*", "us-east-1", true},
+		{"*-*-*", "us-east", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/core/services/iam_evaluator_test.go
+++ b/internal/core/services/iam_evaluator_test.go
@@ -570,6 +570,13 @@ func TestIAMEvaluator_MatchPattern(t *testing.T) {
 		{"*:instance:*", "compute:instance", false},
 		{"*-*-*", "us-east-1", true},
 		{"*-*-*", "us-east", false},
+		// Escaped character tests
+		{`\*`, "*", true},
+		{`\*`, "x", false},
+		{`\?`, "?", true},
+		{`\?`, "x", false},
+		{`instance\:stop`, "instance:stop", true},
+		{`instance\:stop`, "instance:launch", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Implement glob-style pattern matching in `iam_evaluator.go` to support `*` and `?` wildcards at any position in patterns, not just at the end
- Fixes issue #512 where mid-string wildcards like `*:launch` or `compute:*:instance` were not being matched correctly

## Changes
- Replace simple suffix wildcard matching with recursive glob matching algorithm
- Support patterns like `*:launch`, `compute:*:instance`, `instance:run-?`
- Add comprehensive tests for mid-string wildcards and complex patterns
- Handle empty target strings correctly

## Test plan
- [x] All IAMEvaluator tests pass including new mid-string wildcard tests
- [x] Build succeeds
- [x] Full test suite passes