### PR TITLE
fix: call collectMetrics synchronously instead of as untracked goroutine (Issue #210)

### DIFF
--- a/internal/workers/metrics_worker.go
+++ b/internal/workers/metrics_worker.go
@@ -32,8 +32,8 @@ func (w *MetricsCollectorWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 	w.logger.Info("metrics collector worker started")
 
-	// Initial run
-	go w.collectMetrics(ctx)
+	// Initial run — call synchronously before the ticker loop
+	w.collectMetrics(ctx)
 
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()


### PR DESCRIPTION
## Summary
- Call `w.collectMetrics(ctx)` synchronously instead of as untracked goroutine at startup
- Removes the `go` keyword from line 36 of metrics_worker.go

## Test plan
- [x] `go build ./internal/workers/...` — compiles
- [x] `go test ./internal/workers/...` — all tests pass

Fixes #210