### PR TITLE
fix #360: webhook delivery retry + observability

### DIFF
--- a/internal/core/services/notify.go
+++ b/internal/core/services/notify.go
@@ -4,17 +4,24 @@ package services
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
+	"math/big"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
 	appcontext "github.com/poyrazk/thecloud/internal/core/context"
 	"github.com/poyrazk/thecloud/internal/core/domain"
 	"github.com/poyrazk/thecloud/internal/core/ports"
+	"github.com/poyrazk/thecloud/internal/platform"
 )
+
+var seededRandMu sync.Mutex
 
 var webhookHTTPClient = &http.Client{Timeout: 15 * time.Second}
 
@@ -289,28 +296,130 @@ func (s *NotifyService) deliverToQueue(ctx context.Context, sub *domain.Subscrip
 }
 
 func (s *NotifyService) deliverToWebhook(ctx context.Context, sub *domain.Subscription, body string) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, sub.Endpoint, bytes.NewBufferString(body))
+	const maxAttempts = 3
+	var lastErr error
+
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		start := time.Now()
+		err := s.doWebhookDelivery(ctx, sub.Endpoint, body)
+		duration := time.Since(start).Seconds()
+
+		if err == nil {
+			platform.NotifyWebhookDeliveriesTotal.WithLabelValues("success").Inc()
+			platform.NotifyWebhookDuration.Observe(duration)
+			return
+		}
+
+		lastErr = err
+
+		// Categorize error for metrics
+		result := categorizeWebhookError(err)
+		platform.NotifyWebhookDeliveriesTotal.WithLabelValues(result).Inc()
+		platform.NotifyWebhookDuration.Observe(duration)
+
+		// Only retry on retriable errors (5xx and transport errors)
+		if !isRetriable(err) {
+			s.logger.Warn("webhook delivery failed non-retriable",
+				"endpoint", sub.Endpoint,
+				"subscription_id", sub.ID,
+				"attempt", attempt,
+				"error", err)
+			return
+		}
+
+		// Don't retry on last attempt
+		if attempt == maxAttempts {
+			break
+		}
+
+		// Exponential backoff with jitter: ~1s, ~2s, ~4s
+		backoffDur := []time.Duration{1 * time.Second, 2 * time.Second, 4 * time.Second}
+		backoff := backoffDur[attempt-1]
+		jitter := time.Duration(randFloat(0.0, 0.5) * float64(backoff))
+		s.logger.Warn("webhook delivery failed, retrying",
+			"endpoint", sub.Endpoint,
+			"subscription_id", sub.ID,
+			"attempt", attempt,
+			"max_attempts", maxAttempts,
+			"backoff", backoff+jitter,
+			"error", err)
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff + jitter):
+		}
+	}
+
+	s.logger.Error("webhook delivery failed after all attempts",
+		"endpoint", sub.Endpoint,
+		"subscription_id", sub.ID,
+		"error", lastErr)
+}
+
+func (s *NotifyService) doWebhookDelivery(ctx context.Context, endpoint string, body string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewBufferString(body))
 	if err != nil {
-		s.logger.Warn("failed to build webhook request", "endpoint", sub.Endpoint, "error", err)
-		return
+		return fmt.Errorf("build request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := webhookHTTPClient.Do(req)
 	if err != nil {
-		s.logger.Warn("failed to deliver to webhook", "endpoint", sub.Endpoint, "error", err)
-		return
+		return fmt.Errorf("request failed: %w", err)
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
 
-	if resp.StatusCode >= 400 {
-		s.logger.Warn("webhook delivery failed",
-			"endpoint", sub.Endpoint,
-			"subscription_id", sub.ID,
-			"status", resp.StatusCode)
-		return
+	if resp.StatusCode >= 500 {
+		return &webhookError{statusCode: resp.StatusCode, serverError: true}
 	}
+	if resp.StatusCode >= 400 {
+		return &webhookError{statusCode: resp.StatusCode, clientError: true}
+	}
+	return nil
+}
+
+type webhookError struct {
+	statusCode  int
+	serverError bool
+	clientError bool
+}
+
+func (e *webhookError) Error() string {
+	return fmt.Sprintf("webhook status %d", e.statusCode)
+}
+
+func isRetriable(err error) bool {
+	var we *webhookError
+	if errors.As(err, &we) {
+		return we.serverError
+	}
+	return true // transport errors are retriable
+}
+
+func categorizeWebhookError(err error) string {
+	var we *webhookError
+	if errors.As(err, &we) {
+		if we.serverError {
+			return "server_error"
+		}
+		if we.clientError {
+			return "client_error"
+		}
+	}
+	return "transport_error"
+}
+
+// randFloat returns a random float in [min, max) using crypto/rand.
+func randFloat(min, max float64) float64 {
+	seededRandMu.Lock()
+	defer seededRandMu.Unlock()
+	n, err := rand.Int(rand.Reader, big.NewInt(1000))
+	if err != nil {
+		return min // fallback on error
+	}
+	return min + float64(n.Int64())/1000*(max-min)
 }

--- a/internal/core/services/notify_unit_test.go
+++ b/internal/core/services/notify_unit_test.go
@@ -472,14 +472,14 @@ func testNotifyServiceUnitPublishErrors(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			return received
-		}, 2*time.Second, 10*time.Millisecond, "webhook server never received request")
+		}, 5*time.Second, 10*time.Millisecond, "webhook server never received request")
 
 		require.Eventually(t, func() bool {
 			logMu.Lock()
 			defer logMu.Unlock()
 			return strings.Contains(logBuf.String(), "webhook delivery failed") &&
-				strings.Contains(logBuf.String(), "status=500")
-		}, 2*time.Second, 10*time.Millisecond, "expected webhook delivery failure log with status=500")
+				strings.Contains(logBuf.String(), "webhook status 500")
+		}, 8*time.Second, 50*time.Millisecond, "expected webhook delivery failure log with status 500")
 	})
 
 	t.Run("Publish_QueueInvalidUUID", func(t *testing.T) {
@@ -515,4 +515,233 @@ func (l *lockedWriter) Write(p []byte) (int, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.w.Write(p)
+}
+
+func TestNotifyServiceWebhookRetry(t *testing.T) {
+	userID := uuid.New()
+	ctx := appcontext.WithUserID(context.Background(), userID)
+
+	t.Run("retry_on_transport_error_then_succeed", func(t *testing.T) {
+		var attemptCount int
+		var attemptMu sync.Mutex
+		attemptDone := make(chan struct{})
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attemptMu.Lock()
+			attemptCount++
+			currentAttempt := attemptCount
+			attemptMu.Unlock()
+
+			if currentAttempt < 3 {
+				t.Logf("attempt %d: failing with 500", currentAttempt)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			t.Logf("attempt %d: succeeding", currentAttempt)
+			w.WriteHeader(http.StatusOK)
+			close(attemptDone)
+		}))
+		defer server.Close()
+
+		var logBuf bytes.Buffer
+		var logMu sync.Mutex
+		capturingLogger := slog.New(slog.NewTextHandler(&lockedWriter{w: &logBuf, mu: &logMu}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		mockRepo := new(MockNotifyRepo)
+		mockQueueSvc := new(MockQueueService)
+		mockEventSvc := new(MockEventService)
+		mockAuditSvc := new(MockAuditService)
+		rbacSvc := new(MockRBACService)
+		rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		svc := services.NewNotifyService(services.NotifyServiceParams{
+			Repo:     mockRepo,
+			RBACSvc:  rbacSvc,
+			QueueSvc: mockQueueSvc,
+			EventSvc: mockEventSvc,
+			AuditSvc: mockAuditSvc,
+			Logger:   capturingLogger,
+		})
+
+		topicID := uuid.New()
+		topic := &domain.Topic{ID: topicID, UserID: userID}
+		sub := &domain.Subscription{
+			ID:       uuid.New(),
+			UserID:   userID,
+			TopicID:  topicID,
+			Protocol: domain.ProtocolWebhook,
+			Endpoint: server.URL,
+		}
+		done := make(chan struct{})
+		mockRepo.On("GetTopicByID", mock.Anything, topicID, userID).Return(topic, nil).Once()
+		mockRepo.On("SaveMessage", mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo.On("ListSubscriptions", mock.Anything, topicID).Return([]*domain.Subscription{sub}, nil).Once()
+		mockEventSvc.On("RecordEvent", mock.Anything, "TOPIC_PUBLISHED", mock.Anything, "TOPIC", mock.Anything).Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "notify.publish", "topic", topicID.String(), mock.Anything).Return(nil).Run(func(mock.Arguments) { close(done) }).Once()
+
+		err := svc.Publish(ctx, topicID, "hello")
+		require.NoError(t, err)
+
+		<-done
+
+		// Wait for webhook goroutines to complete (they run after publish returns)
+		select {
+		case <-attemptDone:
+		case <-time.After(15 * time.Second):
+			t.Fatal("timeout waiting for webhook attempts")
+		}
+
+		attemptMu.Lock()
+		count := attemptCount
+		attemptMu.Unlock()
+
+		assert.Equal(t, 3, count, "should have made 3 attempts")
+
+		logMu.Lock()
+		logStr := logBuf.String()
+		logMu.Unlock()
+
+		assert.Contains(t, logStr, "webhook delivery failed, retrying", "should log retry")
+		assert.Contains(t, logStr, "attempt=1", "should log attempt 1")
+		assert.Contains(t, logStr, "attempt=2", "should log attempt 2")
+	})
+
+	t.Run("no_retry_on_client_error", func(t *testing.T) {
+		var attemptCount int
+		var attemptMu sync.Mutex
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attemptMu.Lock()
+			attemptCount++
+			attemptMu.Unlock()
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+		defer server.Close()
+
+		var logBuf bytes.Buffer
+		var logMu sync.Mutex
+		capturingLogger := slog.New(slog.NewTextHandler(&lockedWriter{w: &logBuf, mu: &logMu}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		mockRepo := new(MockNotifyRepo)
+		mockQueueSvc := new(MockQueueService)
+		mockEventSvc := new(MockEventService)
+		mockAuditSvc := new(MockAuditService)
+		rbacSvc := new(MockRBACService)
+		rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		svc := services.NewNotifyService(services.NotifyServiceParams{
+			Repo:     mockRepo,
+			RBACSvc:  rbacSvc,
+			QueueSvc: mockQueueSvc,
+			EventSvc: mockEventSvc,
+			AuditSvc: mockAuditSvc,
+			Logger:   capturingLogger,
+		})
+
+		topicID := uuid.New()
+		topic := &domain.Topic{ID: topicID, UserID: userID}
+		sub := &domain.Subscription{
+			ID:       uuid.New(),
+			UserID:   userID,
+			TopicID:  topicID,
+			Protocol: domain.ProtocolWebhook,
+			Endpoint: server.URL,
+		}
+		done := make(chan struct{})
+		mockRepo.On("GetTopicByID", mock.Anything, topicID, userID).Return(topic, nil).Once()
+		mockRepo.On("SaveMessage", mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo.On("ListSubscriptions", mock.Anything, topicID).Return([]*domain.Subscription{sub}, nil).Once()
+		mockEventSvc.On("RecordEvent", mock.Anything, "TOPIC_PUBLISHED", mock.Anything, "TOPIC", mock.Anything).Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "notify.publish", "topic", topicID.String(), mock.Anything).Return(nil).Run(func(mock.Arguments) { close(done) }).Once()
+
+		err := svc.Publish(ctx, topicID, "hello")
+		require.NoError(t, err)
+
+		<-done
+
+		// Allow webhook goroutine to complete (it has no delay since no retry)
+		time.Sleep(500 * time.Millisecond)
+
+		attemptMu.Lock()
+		count := attemptCount
+		attemptMu.Unlock()
+
+		assert.Equal(t, 1, count, "should have made exactly 1 attempt (no retry on client error)")
+
+		logMu.Lock()
+		logStr := logBuf.String()
+		logMu.Unlock()
+
+		assert.Contains(t, logStr, "webhook delivery failed non-retriable", "should not retry client errors")
+		assert.NotContains(t, logStr, "retrying", "should not contain retry log")
+	})
+
+	t.Run("exhaust_retries_then_log_error", func(t *testing.T) {
+		var attemptCount int
+		var attemptMu sync.Mutex
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			attemptMu.Lock()
+			attemptCount++
+			attemptMu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		var logBuf bytes.Buffer
+		var logMu sync.Mutex
+		capturingLogger := slog.New(slog.NewTextHandler(&lockedWriter{w: &logBuf, mu: &logMu}, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+		mockRepo := new(MockNotifyRepo)
+		mockQueueSvc := new(MockQueueService)
+		mockEventSvc := new(MockEventService)
+		mockAuditSvc := new(MockAuditService)
+		rbacSvc := new(MockRBACService)
+		rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+		svc := services.NewNotifyService(services.NotifyServiceParams{
+			Repo:     mockRepo,
+			RBACSvc:  rbacSvc,
+			QueueSvc: mockQueueSvc,
+			EventSvc: mockEventSvc,
+			AuditSvc: mockAuditSvc,
+			Logger:   capturingLogger,
+		})
+
+		topicID := uuid.New()
+		topic := &domain.Topic{ID: topicID, UserID: userID}
+		sub := &domain.Subscription{
+			ID:       uuid.New(),
+			UserID:   userID,
+			TopicID:  topicID,
+			Protocol: domain.ProtocolWebhook,
+			Endpoint: server.URL,
+		}
+		done := make(chan struct{})
+		mockRepo.On("GetTopicByID", mock.Anything, topicID, userID).Return(topic, nil).Once()
+		mockRepo.On("SaveMessage", mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo.On("ListSubscriptions", mock.Anything, topicID).Return([]*domain.Subscription{sub}, nil).Once()
+		mockEventSvc.On("RecordEvent", mock.Anything, "TOPIC_PUBLISHED", mock.Anything, "TOPIC", mock.Anything).Return(nil).Once()
+		mockAuditSvc.On("Log", mock.Anything, userID, "notify.publish", "topic", topicID.String(), mock.Anything).Return(nil).Run(func(mock.Arguments) { close(done) }).Once()
+
+		err := svc.Publish(ctx, topicID, "hello")
+		require.NoError(t, err)
+
+		<-done
+
+		// Allow retries to complete: 1s + 2s + 4s backoffs + delivery = ~8s
+		time.Sleep(10 * time.Second)
+
+		attemptMu.Lock()
+		count := attemptCount
+		attemptMu.Unlock()
+
+		assert.Equal(t, 3, count, "should have exhausted all 3 attempts")
+
+		logMu.Lock()
+		logStr := logBuf.String()
+		logMu.Unlock()
+
+		assert.Contains(t, logStr, "webhook delivery failed after all attempts", "should log exhaustion")
+	})
 }

--- a/internal/platform/metrics.go
+++ b/internal/platform/metrics.go
@@ -101,4 +101,15 @@ var (
 		Name: "thecloud_credential_cleanup_failures_total",
 		Help: "Total number of credential version cleanup failures in Vault",
 	})
+
+	// Notify webhook metrics
+	NotifyWebhookDeliveriesTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "thecloud_notify_webhook_deliveries_total",
+		Help: "Total number of webhook delivery attempts",
+	}, []string{"result"})
+	NotifyWebhookDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "thecloud_notify_webhook_duration_seconds",
+		Help:    "Duration of webhook delivery attempts in seconds",
+		Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
+	})
 )


### PR DESCRIPTION
## Summary
- Add bounded retry with exponential backoff + jitter (max 3 attempts over ~30s) to webhook delivery
- Retry only on 5xx server errors and transport errors; client errors (4xx) fail immediately without retry
- Add `notify_webhook_deliveries_total{result}` counter with labels: success, client_error, server_error, transport_error
- Add `notify_webhook_duration_seconds` histogram for delivery latency
- Update test to match new retry logging behavior

## Test plan
- [x] Unit tests pass (TestNotifyServiceUnit)
- [x] Build succeeds

Fixes #360