### PR TITLE
fix: rollback cluster creation if AddNodeGroup fails (Issue #247)

### DIFF
--- a/internal/core/services/cluster.go
+++ b/internal/core/services/cluster.go
@@ -148,7 +148,9 @@ func (s *ClusterService) CreateCluster(ctx context.Context, params ports.CreateC
 	if err := s.repo.AddNodeGroup(ctx, &cluster.NodeGroups[0]); err != nil {
 		// Rollback: delete the orphan cluster to avoid leaving a cluster
 		// without its required default nodegroup
-		_ = s.repo.Delete(ctx, cluster.ID)
+		if deleteErr := s.repo.Delete(ctx, cluster.ID); deleteErr != nil {
+			s.logger.Error("rollback failed: could not delete orphan cluster", "cluster_id", cluster.ID, "error", deleteErr)
+		}
 		return nil, errors.Wrap(errors.Internal, "failed to create default node group", err)
 	}
 

--- a/internal/core/services/cluster.go
+++ b/internal/core/services/cluster.go
@@ -146,7 +146,9 @@ func (s *ClusterService) CreateCluster(ctx context.Context, params ports.CreateC
 
 	// Persist Node Group
 	if err := s.repo.AddNodeGroup(ctx, &cluster.NodeGroups[0]); err != nil {
-		// Ideally this should be in a transaction with repo.Create
+		// Rollback: delete the orphan cluster to avoid leaving a cluster
+		// without its required default nodegroup
+		_ = s.repo.Delete(ctx, cluster.ID)
 		return nil, errors.Wrap(errors.Internal, "failed to create default node group", err)
 	}
 

--- a/internal/core/services/cluster_unit_test.go
+++ b/internal/core/services/cluster_unit_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -72,6 +73,31 @@ func TestClusterService_Unit(t *testing.T) {
 		assert.NotNil(t, cluster)
 		assert.Equal(t, "test-cluster", cluster.Name)
 		assert.Equal(t, 3, cluster.WorkerCount)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("CreateCluster_AddNodeGroupFails_Rollback", func(t *testing.T) {
+		svc, mockRepo, _, mockVpcSvc, _, mockSecretSvc, _, _ := newTestClusterSvc()
+
+		vpcID := uuid.New()
+
+		mockVpcSvc.On("GetVPC", mock.Anything, vpcID.String()).Return(&domain.VPC{ID: vpcID}, nil).Once()
+		mockSecretSvc.On("Encrypt", mock.Anything, mock.Anything, mock.Anything).Return("encrypted-key", nil).Once()
+		mockRepo.On("Create", mock.Anything, mock.Anything).Return(nil).Once()
+		mockRepo.On("AddNodeGroup", mock.Anything, mock.Anything).Return(errors.New("database error")).Once()
+		mockRepo.On("Delete", mock.Anything, mock.Anything).Return(nil).Once()
+
+		params := ports.CreateClusterParams{
+			UserID:  uuid.New(),
+			Name:    "test-cluster-rollback",
+			VpcID:   vpcID,
+			Workers: 1,
+		}
+
+		cluster, err := svc.CreateCluster(ctx, params)
+		require.Error(t, err)
+		assert.Nil(t, cluster)
+		assert.Contains(t, err.Error(), "failed to create default node group")
 		mockRepo.AssertExpectations(t)
 	})
 


### PR DESCRIPTION
## Summary
- If `repo.AddNodeGroup` fails after `repo.Create` succeeds, delete the orphan cluster to avoid leaving a cluster without its required default nodegroup
- Updates the comment from "Ideally this should be in a transaction" to a rollback implementation

## Test plan
- [x] `go build ./internal/core/services/...` — compiles
- [x] `go test ./internal/core/services/... -run Cluster` — tests pass

Fixes #247