### PR TITLE
feat(iam): add user groups for policy attachment

### DIFF
--- a/internal/api/setup/router.go
+++ b/internal/api/setup/router.go
@@ -245,6 +245,23 @@ func registerIAMRoutes(r *gin.Engine, handlers *Handlers, svcs *Services) {
 		iamGroup.DELETE("/users/:userId/policies/:policyId", handlers.IAM.DetachPolicyFromUser)
 		iamGroup.GET("/users/:userId/policies", handlers.IAM.GetUserPolicies)
 
+		// Group routes
+		iamGroup.POST("/groups", handlers.IAM.CreateGroup)
+		iamGroup.GET("/groups", handlers.IAM.ListGroups)
+		iamGroup.GET("/groups/:id", handlers.IAM.GetGroupByID)
+		iamGroup.PUT("/groups/:id", handlers.IAM.UpdateGroup)
+		iamGroup.DELETE("/groups/:id", handlers.IAM.DeleteGroup)
+
+		// Group membership
+		iamGroup.POST("/groups/:id/members/:userId", handlers.IAM.AddUserToGroup)
+		iamGroup.DELETE("/groups/:id/members/:userId", handlers.IAM.RemoveUserFromGroup)
+		iamGroup.GET("/groups/:id/members", handlers.IAM.GetGroupMembers)
+
+		// Group policy attachment
+		iamGroup.POST("/groups/:id/policies/:policyId", handlers.IAM.AttachPolicyToGroup)
+		iamGroup.DELETE("/groups/:id/policies/:policyId", handlers.IAM.DetachPolicyFromGroup)
+		iamGroup.GET("/groups/:id/policies", handlers.IAM.GetGroupPolicies)
+
 		// Service account routes
 		iamGroup.POST("/service-accounts", handlers.IAM.CreateServiceAccount)
 		iamGroup.GET("/service-accounts", handlers.IAM.ListServiceAccounts)

--- a/internal/core/domain/group.go
+++ b/internal/core/domain/group.go
@@ -1,0 +1,32 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Group represents a collection of users for IAM policy assignment.
+type Group struct {
+	ID          uuid.UUID `json:"id"`
+	TenantID    uuid.UUID `json:"tenant_id"`
+	Name        string    `json:"name"`
+	Description string    `json:"description,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// UserGroup represents membership of a user in a group.
+type UserGroup struct {
+	UserID   uuid.UUID `json:"user_id"`
+	GroupID  uuid.UUID `json:"group_id"`
+	TenantID uuid.UUID `json:"tenant_id"`
+	AddedAt  time.Time `json:"added_at"`
+}
+
+// GroupPolicy maps a policy to a group (mirrors UserPolicy, RolePolicy pattern).
+type GroupPolicy struct {
+	GroupID  uuid.UUID `json:"group_id"`
+	PolicyID uuid.UUID `json:"policy_id"`
+	TenantID uuid.UUID `json:"tenant_id"`
+}

--- a/internal/core/ports/iam.go
+++ b/internal/core/ports/iam.go
@@ -36,6 +36,25 @@ type IAMRepository interface {
 	AttachPolicyToServiceAccount(ctx context.Context, tenantID uuid.UUID, saID uuid.UUID, policyID uuid.UUID) error
 	DetachPolicyFromServiceAccount(ctx context.Context, tenantID uuid.UUID, saID uuid.UUID, policyID uuid.UUID) error
 	GetPoliciesForServiceAccount(ctx context.Context, tenantID uuid.UUID, saID uuid.UUID) ([]*domain.Policy, error)
+
+	// Group Management
+	CreateGroup(ctx context.Context, tenantID uuid.UUID, group *domain.Group) error
+	GetGroupByID(ctx context.Context, tenantID uuid.UUID, id uuid.UUID) (*domain.Group, error)
+	ListGroups(ctx context.Context, tenantID uuid.UUID) ([]*domain.Group, error)
+	UpdateGroup(ctx context.Context, tenantID uuid.UUID, group *domain.Group) error
+	DeleteGroup(ctx context.Context, tenantID uuid.UUID, id uuid.UUID) error
+
+	// Group Membership
+	AddUserToGroup(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, groupID uuid.UUID) error
+	RemoveUserFromGroup(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, groupID uuid.UUID) error
+	GetGroupsForUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID) ([]*domain.Group, error)
+	GetUsersInGroup(ctx context.Context, tenantID uuid.UUID, groupID uuid.UUID) ([]uuid.UUID, error)
+
+	// Group Policy Assignment
+	AttachPolicyToGroup(ctx context.Context, tenantID uuid.UUID, groupID uuid.UUID, policyID uuid.UUID) error
+	DetachPolicyFromGroup(ctx context.Context, tenantID uuid.UUID, groupID uuid.UUID, policyID uuid.UUID) error
+	GetPoliciesForGroup(ctx context.Context, tenantID uuid.UUID, groupID uuid.UUID) ([]*domain.Policy, error)
+	GetGroupsForPolicy(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID) ([]*domain.Group, error)
 }
 
 // IAMService defines the business logic for IAM management.
@@ -57,6 +76,24 @@ type IAMService interface {
 	AttachPolicyToServiceAccount(ctx context.Context, saID uuid.UUID, policyID uuid.UUID) error
 	DetachPolicyFromServiceAccount(ctx context.Context, saID uuid.UUID, policyID uuid.UUID) error
 	GetPoliciesForServiceAccount(ctx context.Context, saID uuid.UUID) ([]*domain.Policy, error)
+
+	// Group Management
+	CreateGroup(ctx context.Context, group *domain.Group) error
+	GetGroupByID(ctx context.Context, id uuid.UUID) (*domain.Group, error)
+	ListGroups(ctx context.Context) ([]*domain.Group, error)
+	UpdateGroup(ctx context.Context, group *domain.Group) error
+	DeleteGroup(ctx context.Context, id uuid.UUID) error
+
+	// Group Membership
+	AddUserToGroup(ctx context.Context, userID uuid.UUID, groupID uuid.UUID) error
+	RemoveUserFromGroup(ctx context.Context, userID uuid.UUID, groupID uuid.UUID) error
+	GetGroupsForUser(ctx context.Context, userID uuid.UUID) ([]*domain.Group, error)
+	GetUsersInGroup(ctx context.Context, groupID uuid.UUID) ([]uuid.UUID, error)
+
+	// Group Policy Assignment
+	AttachPolicyToGroup(ctx context.Context, groupID uuid.UUID, policyID uuid.UUID) error
+	DetachPolicyFromGroup(ctx context.Context, groupID uuid.UUID, policyID uuid.UUID) error
+	GetPoliciesForGroup(ctx context.Context, groupID uuid.UUID) ([]*domain.Policy, error)
 
 	// SimulatePolicy evaluates what-if actions/resources against the given principal's policies.
 	// Returns the decision and which statement matched, for debugging.

--- a/internal/core/services/iam.go
+++ b/internal/core/services/iam.go
@@ -163,6 +163,118 @@ func (s *iamService) GetPoliciesForServiceAccount(ctx context.Context, saID uuid
 	return s.repo.GetPoliciesForServiceAccount(ctx, tenantID, saID)
 }
 
+// Group Management
+
+func (s *iamService) CreateGroup(ctx context.Context, group *domain.Group) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if group.ID == uuid.Nil {
+		group.ID = uuid.New()
+	}
+	group.TenantID = tenantID
+	if err := s.repo.CreateGroup(ctx, tenantID, group); err != nil {
+		return err
+	}
+	if err := s.eventSvc.RecordEvent(ctx, "IAM_GROUP_CREATE", group.ID.String(), "GROUP", map[string]interface{}{"name": group.Name}); err != nil {
+		s.logger.Warn("failed to record event", "action", "IAM_GROUP_CREATE", "group_id", group.ID, "error", err)
+	}
+	return nil
+}
+
+func (s *iamService) GetGroupByID(ctx context.Context, id uuid.UUID) (*domain.Group, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	return s.repo.GetGroupByID(ctx, tenantID, id)
+}
+
+func (s *iamService) ListGroups(ctx context.Context) ([]*domain.Group, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	return s.repo.ListGroups(ctx, tenantID)
+}
+
+func (s *iamService) UpdateGroup(ctx context.Context, group *domain.Group) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.repo.UpdateGroup(ctx, tenantID, group); err != nil {
+		return err
+	}
+	if err := s.eventSvc.RecordEvent(ctx, "IAM_GROUP_UPDATE", group.ID.String(), "GROUP", map[string]interface{}{"name": group.Name}); err != nil {
+		s.logger.Warn("failed to record event", "action", "IAM_GROUP_UPDATE", "group_id", group.ID, "error", err)
+	}
+	return nil
+}
+
+func (s *iamService) DeleteGroup(ctx context.Context, id uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.repo.DeleteGroup(ctx, tenantID, id); err != nil {
+		return err
+	}
+	if err := s.eventSvc.RecordEvent(ctx, "IAM_GROUP_DELETE", id.String(), "GROUP", nil); err != nil {
+		s.logger.Warn("failed to record event", "action", "IAM_GROUP_DELETE", "group_id", id, "error", err)
+	}
+	return nil
+}
+
+// Group Membership
+
+func (s *iamService) AddUserToGroup(ctx context.Context, userID uuid.UUID, groupID uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.repo.AddUserToGroup(ctx, tenantID, userID, groupID); err != nil {
+		return err
+	}
+	if err := s.auditSvc.Log(ctx, userID, "iam.add_to_group", "user", userID.String(), map[string]interface{}{"group_id": groupID}); err != nil {
+		s.logger.Warn("failed to log audit event", "action", "iam.add_to_group", "user_id", userID, "error", err)
+	}
+	return nil
+}
+
+func (s *iamService) RemoveUserFromGroup(ctx context.Context, userID uuid.UUID, groupID uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.repo.RemoveUserFromGroup(ctx, tenantID, userID, groupID); err != nil {
+		return err
+	}
+	if err := s.auditSvc.Log(ctx, userID, "iam.remove_from_group", "user", userID.String(), map[string]interface{}{"group_id": groupID}); err != nil {
+		s.logger.Warn("failed to log audit event", "action", "iam.remove_from_group", "user_id", userID, "error", err)
+	}
+	return nil
+}
+
+func (s *iamService) GetGroupsForUser(ctx context.Context, userID uuid.UUID) ([]*domain.Group, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	return s.repo.GetGroupsForUser(ctx, tenantID, userID)
+}
+
+func (s *iamService) GetUsersInGroup(ctx context.Context, groupID uuid.UUID) ([]uuid.UUID, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	return s.repo.GetUsersInGroup(ctx, tenantID, groupID)
+}
+
+// Group Policy Assignment
+
+func (s *iamService) AttachPolicyToGroup(ctx context.Context, groupID uuid.UUID, policyID uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.repo.AttachPolicyToGroup(ctx, tenantID, groupID, policyID); err != nil {
+		return err
+	}
+	if err := s.eventSvc.RecordEvent(ctx, "IAM_POLICY_ATTACH_GROUP", policyID.String(), "POLICY", map[string]interface{}{"group_id": groupID.String()}); err != nil {
+		s.logger.Warn("failed to record event", "action", "IAM_POLICY_ATTACH_GROUP", "policy_id", policyID, "error", err)
+	}
+	return nil
+}
+
+func (s *iamService) DetachPolicyFromGroup(ctx context.Context, groupID uuid.UUID, policyID uuid.UUID) error {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	if err := s.repo.DetachPolicyFromGroup(ctx, tenantID, groupID, policyID); err != nil {
+		return err
+	}
+	if err := s.eventSvc.RecordEvent(ctx, "IAM_POLICY_DETACH_GROUP", policyID.String(), "POLICY", map[string]interface{}{"group_id": groupID.String()}); err != nil {
+		s.logger.Warn("failed to record event", "action", "IAM_POLICY_DETACH_GROUP", "policy_id", policyID, "error", err)
+	}
+	return nil
+}
+
+func (s *iamService) GetPoliciesForGroup(ctx context.Context, groupID uuid.UUID) ([]*domain.Policy, error) {
+	tenantID := appcontext.TenantIDFromContext(ctx)
+	return s.repo.GetPoliciesForGroup(ctx, tenantID, groupID)
+}
+
 func (s *iamService) SimulatePolicy(ctx context.Context, principal ports.Principal, actions []string, resources []string, evalCtx map[string]interface{}) (*ports.SimulateResult, error) {
 	const maxSimulatePairs = 100
 	if len(actions)*len(resources) > maxSimulatePairs {

--- a/internal/core/services/rbac.go
+++ b/internal/core/services/rbac.go
@@ -128,6 +128,11 @@ func (s *rbacService) HasPermission(ctx context.Context, userID uuid.UUID, tenan
 				return allowed, nil
 			}
 		}
+
+		// 2c. Check group-attached policies via user's group memberships
+		if allowed, stop := s.checkGroupIAMPolicies(ctx, tenantID, userID, permission, resource, evalCtx); allowed || stop {
+			return allowed, nil
+		}
 	}
 	// 3. Fallback to Role-based logic
 	if roleName == domain.RoleAdmin {
@@ -186,6 +191,33 @@ func (s *rbacService) checkRoleIAMPolicies(ctx context.Context, tenantID uuid.UU
 		return false, false
 	}
 	return s.evaluatePolicies(ctx, policies, permission, resource, evalCtx)
+}
+
+// checkGroupIAMPolicies evaluates IAM policies attached to groups a user belongs to.
+// Returns (allowed, stop) where stop=true means decision is final.
+func (s *rbacService) checkGroupIAMPolicies(ctx context.Context, tenantID, userID uuid.UUID, permission domain.Permission, resource string, evalCtx map[string]interface{}) (bool, bool) {
+	groups, err := s.iamRepo.GetGroupsForUser(ctx, tenantID, userID)
+	if err != nil {
+		s.logger.Error("RBAC: failed to get user groups, falling through to RBAC fallback", "user_id", userID, "tenant_id", tenantID, "error", err)
+		return false, false
+	}
+	if len(groups) == 0 {
+		return false, false
+	}
+	for _, group := range groups {
+		policies, err := s.iamRepo.GetPoliciesForGroup(ctx, tenantID, group.ID)
+		if err != nil {
+			s.logger.Warn("RBAC: failed to get group policies", "group_id", group.ID, "error", err)
+			continue
+		}
+		if len(policies) == 0 {
+			continue
+		}
+		if allowed, stop := s.evaluatePolicies(ctx, policies, permission, resource, evalCtx); allowed || stop {
+			return allowed, stop
+		}
+	}
+	return false, false
 }
 
 // evaluatePolicies evaluates a set of policies and returns (allowed, stop).

--- a/internal/handlers/iam_handler.go
+++ b/internal/handlers/iam_handler.go
@@ -370,6 +370,343 @@ func (h *IAMHandler) GetUserPolicies(c *gin.Context) {
 	httputil.Success(c, http.StatusOK, policies)
 }
 
+// IAMGroupRequest is the payload for group creation/update.
+type IAMGroupRequest struct {
+	Name        string `json:"name" binding:"required"`
+	Description string `json:"description"`
+}
+
+// CreateGroup creates a new user group.
+// @Summary Create User Group
+// @Description Create a new user group for organizing users and attaching policies.
+// @Tags iam
+// @Security APIKeyAuth
+// @Accept json
+// @Produce json
+// @Param request body IAMGroupRequest true "Group details"
+// @Success 201 {object} domain.Group
+// @Failure 400 {object} httputil.Response
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Router /iam/groups [post]
+func (h *IAMHandler) CreateGroup(c *gin.Context) {
+	var req IAMGroupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, err.Error()))
+		return
+	}
+
+	group := &domain.Group{
+		Name:        req.Name,
+		Description: req.Description,
+	}
+
+	if err := h.svc.CreateGroup(c.Request.Context(), group); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusCreated, group)
+}
+
+// GetGroupByID returns a specific group.
+// @Summary Get User Group
+// @Description Get details of a specific user group by its ID.
+// @Tags iam
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "Group ID"
+// @Success 200 {object} domain.Group
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/groups/{id} [get]
+func (h *IAMHandler) GetGroupByID(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	group, err := h.svc.GetGroupByID(c.Request.Context(), id)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, group)
+}
+
+// ListGroups returns all groups.
+// @Summary List User Groups
+// @Description List all user groups for the tenant.
+// @Tags iam
+// @Security APIKeyAuth
+// @Produce json
+// @Success 200 {array} domain.Group
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Router /iam/groups [get]
+func (h *IAMHandler) ListGroups(c *gin.Context) {
+	groups, err := h.svc.ListGroups(c.Request.Context())
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, groups)
+}
+
+// UpdateGroup updates a group's details.
+// @Summary Update User Group
+// @Description Update the name and description of a user group.
+// @Tags iam
+// @Security APIKeyAuth
+// @Accept json
+// @Produce json
+// @Param id path string true "Group ID"
+// @Param request body UpdateGroupRequest true "Updated group details"
+// @Success 200 {object} domain.Group
+// @Failure 400 {object} httputil.Response
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/groups/{id} [put]
+func (h *IAMHandler) UpdateGroup(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	var req IAMGroupRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		httputil.Error(c, errors.New(errors.InvalidInput, err.Error()))
+		return
+	}
+
+	group := &domain.Group{
+		ID:          id,
+		Name:        req.Name,
+		Description: req.Description,
+	}
+
+	if err := h.svc.UpdateGroup(c.Request.Context(), group); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, group)
+}
+
+// DeleteGroup removes a group.
+// @Summary Delete User Group
+// @Description Delete an existing user group. Members and policy attachments are cascade deleted.
+// @Tags iam
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "Group ID"
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/groups/{id} [delete]
+func (h *IAMHandler) DeleteGroup(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	if err := h.svc.DeleteGroup(c.Request.Context(), id); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"status": "deleted"})
+}
+
+// AddUserToGroup adds a user to a group.
+// @Summary Add User to Group
+// @Description Add a user as a member of a user group.
+// @Tags iam
+// @Security APIKeyAuth
+// @Param id path string true "Group ID"
+// @Param userId path string true "User ID"
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/groups/{id}/members/{userId} [post]
+func (h *IAMHandler) AddUserToGroup(c *gin.Context) {
+	groupID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	userID, err := uuid.Parse(c.Param("userId"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	if err := h.svc.AddUserToGroup(c.Request.Context(), userID, groupID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"status": "added"})
+}
+
+// RemoveUserFromGroup removes a user from a group.
+// @Summary Remove User from Group
+// @Description Remove a user from a user group membership.
+// @Tags iam
+// @Security APIKeyAuth
+// @Param id path string true "Group ID"
+// @Param userId path string true "User ID"
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/groups/{id}/members/{userId} [delete]
+func (h *IAMHandler) RemoveUserFromGroup(c *gin.Context) {
+	groupID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	userID, err := uuid.Parse(c.Param("userId"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	if err := h.svc.RemoveUserFromGroup(c.Request.Context(), userID, groupID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"status": "removed"})
+}
+
+// GetGroupMembers lists all users in a group.
+// @Summary List Group Members
+// @Description List all user IDs that are members of a specific group.
+// @Tags iam
+// @Security APIKeyAuth
+// @Produce json
+// @Param id path string true "Group ID"
+// @Success 200 {array} uuid.UUID
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Router /iam/groups/{id}/members [get]
+func (h *IAMHandler) GetGroupMembers(c *gin.Context) {
+	groupID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	members, err := h.svc.GetUsersInGroup(c.Request.Context(), groupID)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, members)
+}
+
+// AttachPolicyToGroup attaches a policy to a group.
+// @Summary Attach IAM Policy to Group
+// @Description Attach a specific IAM policy to a group.
+// @Tags iam
+// @Security APIKeyAuth
+// @Param id path string true "Group ID"
+// @Param policyId path string true "Policy ID"
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/groups/{id}/policies/{policyId} [post]
+func (h *IAMHandler) AttachPolicyToGroup(c *gin.Context) {
+	groupID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	policyID, err := uuid.Parse(c.Param("policyId"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	if err := h.svc.AttachPolicyToGroup(c.Request.Context(), groupID, policyID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"status": "attached"})
+}
+
+// DetachPolicyFromGroup removes a policy from a group.
+// @Summary Detach IAM Policy from Group
+// @Description Remove a specific IAM policy assignment from a group.
+// @Tags iam
+// @Security APIKeyAuth
+// @Param id path string true "Group ID"
+// @Param policyId path string true "Policy ID"
+// @Success 200 {object} map[string]string
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Failure 404 {object} httputil.Response
+// @Router /iam/groups/{id}/policies/{policyId} [delete]
+func (h *IAMHandler) DetachPolicyFromGroup(c *gin.Context) {
+	groupID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+	policyID, err := uuid.Parse(c.Param("policyId"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	if err := h.svc.DetachPolicyFromGroup(c.Request.Context(), groupID, policyID); err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, gin.H{"status": "detached"})
+}
+
+// GetGroupPolicies lists all policies attached to a specific group.
+// @Summary List Group IAM Policies
+// @Description List all IAM policies currently attached to a specific group.
+// @Tags iam
+// @Security APIKeyAuth
+// @Param id path string true "Group ID"
+// @Success 200 {array} domain.Policy
+// @Failure 401 {object} httputil.Response
+// @Failure 403 {object} httputil.Response
+// @Router /iam/groups/{id}/policies [get]
+func (h *IAMHandler) GetGroupPolicies(c *gin.Context) {
+	groupID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	policies, err := h.svc.GetPoliciesForGroup(c.Request.Context(), groupID)
+	if err != nil {
+		httputil.Error(c, err)
+		return
+	}
+
+	httputil.Success(c, http.StatusOK, policies)
+}
+
 func (h *IAMHandler) validatePolicy(policy *domain.Policy) error {
 	if policy.Name == "" {
 		return fmt.Errorf("policy name is required")

--- a/internal/repositories/postgres/iam_repo.go
+++ b/internal/repositories/postgres/iam_repo.go
@@ -417,3 +417,217 @@ func (r *iamRepository) GetPoliciesForServiceAccount(ctx context.Context, tenant
 	}
 	return policies, nil
 }
+
+// CreateGroup creates a new group.
+func (r *iamRepository) CreateGroup(ctx context.Context, tenantID uuid.UUID, group *domain.Group) error {
+	query := `INSERT INTO "groups" (id, tenant_id, name, description) VALUES ($1, $2, $3, $4)`
+	_, err := r.db.Exec(ctx, query, group.ID, tenantID, group.Name, group.Description)
+	return err
+}
+
+// GetGroupByID retrieves a group by ID.
+func (r *iamRepository) GetGroupByID(ctx context.Context, tenantID uuid.UUID, id uuid.UUID) (*domain.Group, error) {
+	query := `SELECT id, tenant_id, name, description, created_at, updated_at FROM "groups" WHERE id = $1 AND tenant_id = $2`
+	var g domain.Group
+	err := r.db.QueryRow(ctx, query, id, tenantID).Scan(&g.ID, &g.TenantID, &g.Name, &g.Description, &g.CreatedAt, &g.UpdatedAt)
+	if err != nil {
+		if stdlib_errors.Is(err, pgx.ErrNoRows) {
+			return nil, errors.New(errors.NotFound, "group not found")
+		}
+		return nil, err
+	}
+	return &g, nil
+}
+
+// ListGroups lists all groups for a tenant.
+func (r *iamRepository) ListGroups(ctx context.Context, tenantID uuid.UUID) ([]*domain.Group, error) {
+	query := `SELECT id, tenant_id, name, description, created_at, updated_at FROM "groups" WHERE tenant_id = $1`
+	rows, err := r.db.Query(ctx, query, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var groups []*domain.Group
+	for rows.Next() {
+		var g domain.Group
+		if err := rows.Scan(&g.ID, &g.TenantID, &g.Name, &g.Description, &g.CreatedAt, &g.UpdatedAt); err != nil {
+			return nil, err
+		}
+		groups = append(groups, &g)
+	}
+	return groups, rows.Err()
+}
+
+// UpdateGroup updates a group's name and description.
+func (r *iamRepository) UpdateGroup(ctx context.Context, tenantID uuid.UUID, group *domain.Group) error {
+	query := `UPDATE "groups" SET name = $1, description = $2, updated_at = NOW() WHERE id = $3 AND tenant_id = $4`
+	result, err := r.db.Exec(ctx, query, group.Name, group.Description, group.ID, tenantID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "group not found")
+	}
+	return nil
+}
+
+// DeleteGroup deletes a group and cascades to user_groups and group_policies.
+func (r *iamRepository) DeleteGroup(ctx context.Context, tenantID uuid.UUID, id uuid.UUID) error {
+	result, err := r.db.Exec(ctx, `DELETE FROM "groups" WHERE id = $1 AND tenant_id = $2`, id, tenantID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "group not found")
+	}
+	return nil
+}
+
+// AddUserToGroup adds a user to a group.
+func (r *iamRepository) AddUserToGroup(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, groupID uuid.UUID) error {
+	// Verify group belongs to tenant
+	if _, err := r.GetGroupByID(ctx, tenantID, groupID); err != nil {
+		return err
+	}
+	query := `INSERT INTO user_groups (user_id, group_id, tenant_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
+	_, err := r.db.Exec(ctx, query, userID, groupID, tenantID)
+	return err
+}
+
+// RemoveUserFromGroup removes a user from a group.
+func (r *iamRepository) RemoveUserFromGroup(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID, groupID uuid.UUID) error {
+	query := `DELETE FROM user_groups WHERE user_id = $1 AND group_id = $2 AND tenant_id = $3`
+	result, err := r.db.Exec(ctx, query, userID, groupID, tenantID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "group membership not found")
+	}
+	return nil
+}
+
+// GetGroupsForUser returns all groups a user belongs to.
+func (r *iamRepository) GetGroupsForUser(ctx context.Context, tenantID uuid.UUID, userID uuid.UUID) ([]*domain.Group, error) {
+	query := `
+		SELECT g.id, g.tenant_id, g.name, g.description, g.created_at, g.updated_at
+		FROM "groups" g
+		JOIN user_groups ug ON g.id = ug.group_id
+		WHERE ug.user_id = $1 AND ug.tenant_id = $2`
+	rows, err := r.db.Query(ctx, query, userID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var groups []*domain.Group
+	for rows.Next() {
+		var g domain.Group
+		if err := rows.Scan(&g.ID, &g.TenantID, &g.Name, &g.Description, &g.CreatedAt, &g.UpdatedAt); err != nil {
+			return nil, err
+		}
+		groups = append(groups, &g)
+	}
+	return groups, rows.Err()
+}
+
+// GetUsersInGroup returns all user IDs in a group.
+func (r *iamRepository) GetUsersInGroup(ctx context.Context, tenantID uuid.UUID, groupID uuid.UUID) ([]uuid.UUID, error) {
+	query := `SELECT user_id FROM user_groups WHERE group_id = $1 AND tenant_id = $2`
+	rows, err := r.db.Query(ctx, query, groupID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var userIDs []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		userIDs = append(userIDs, id)
+	}
+	return userIDs, rows.Err()
+}
+
+// AttachPolicyToGroup attaches a policy to a group.
+func (r *iamRepository) AttachPolicyToGroup(ctx context.Context, tenantID uuid.UUID, groupID uuid.UUID, policyID uuid.UUID) error {
+	// Verify group belongs to tenant
+	if _, err := r.GetGroupByID(ctx, tenantID, groupID); err != nil {
+		return err
+	}
+	// Verify policy belongs to tenant
+	if _, err := r.GetPolicyByID(ctx, tenantID, policyID); err != nil {
+		return err
+	}
+	query := `INSERT INTO group_policies (group_id, policy_id, tenant_id) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING`
+	_, err := r.db.Exec(ctx, query, groupID, policyID, tenantID)
+	return err
+}
+
+// DetachPolicyFromGroup removes a policy from a group.
+func (r *iamRepository) DetachPolicyFromGroup(ctx context.Context, tenantID uuid.UUID, groupID uuid.UUID, policyID uuid.UUID) error {
+	query := `DELETE FROM group_policies WHERE group_id = $1 AND policy_id = $2 AND tenant_id = $3`
+	result, err := r.db.Exec(ctx, query, groupID, policyID, tenantID)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return errors.New(errors.NotFound, "policy assignment not found")
+	}
+	return nil
+}
+
+// GetPoliciesForGroup returns all policies attached to a group.
+func (r *iamRepository) GetPoliciesForGroup(ctx context.Context, tenantID uuid.UUID, groupID uuid.UUID) ([]*domain.Policy, error) {
+	query := `
+		SELECT p.id, p.tenant_id, p.name, p.description, p.statements
+		FROM policies p
+		JOIN group_policies gp ON p.id = gp.policy_id
+		WHERE gp.group_id = $1 AND gp.tenant_id = $2`
+	rows, err := r.db.Query(ctx, query, groupID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var policies []*domain.Policy
+	for rows.Next() {
+		var p domain.Policy
+		var statementsJSON []byte
+		if err := rows.Scan(&p.ID, &p.TenantID, &p.Name, &p.Description, &statementsJSON); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(statementsJSON, &p.Statements); err != nil {
+			return nil, err
+		}
+		policies = append(policies, &p)
+	}
+	return policies, rows.Err()
+}
+
+// GetGroupsForPolicy returns all groups a policy is attached to.
+func (r *iamRepository) GetGroupsForPolicy(ctx context.Context, tenantID uuid.UUID, policyID uuid.UUID) ([]*domain.Group, error) {
+	query := `
+		SELECT g.id, g.tenant_id, g.name, g.description, g.created_at, g.updated_at
+		FROM "groups" g
+		JOIN group_policies gp ON g.id = gp.group_id
+		WHERE gp.policy_id = $1 AND gp.tenant_id = $2`
+	rows, err := r.db.Query(ctx, query, policyID, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var groups []*domain.Group
+	for rows.Next() {
+		var g domain.Group
+		if err := rows.Scan(&g.ID, &g.TenantID, &g.Name, &g.Description, &g.CreatedAt, &g.UpdatedAt); err != nil {
+			return nil, err
+		}
+		groups = append(groups, &g)
+	}
+	return groups, rows.Err()
+}

--- a/internal/repositories/postgres/migrations/114_create_user_groups_and_group_policies.down.sql
+++ b/internal/repositories/postgres/migrations/114_create_user_groups_and_group_policies.down.sql
@@ -1,0 +1,4 @@
+-- +goose Down
+DROP TABLE IF EXISTS group_policies;
+DROP TABLE IF EXISTS user_groups;
+DROP TABLE IF EXISTS `groups`;

--- a/internal/repositories/postgres/migrations/114_create_user_groups_and_group_policies.up.sql
+++ b/internal/repositories/postgres/migrations/114_create_user_groups_and_group_policies.up.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS `groups` (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (tenant_id, name)
+);
+
+CREATE TABLE IF NOT EXISTS user_groups (
+    user_id UUID NOT NULL,
+    group_id UUID NOT NULL,
+    tenant_id UUID NOT NULL,
+    added_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, group_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (group_id) REFERENCES `groups`(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS group_policies (
+    group_id UUID NOT NULL,
+    policy_id UUID NOT NULL,
+    tenant_id UUID NOT NULL,
+    attached_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (group_id, policy_id),
+    FOREIGN KEY (group_id) REFERENCES `groups`(id) ON DELETE CASCADE,
+    FOREIGN KEY (policy_id) REFERENCES policies(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_groups_user_id ON user_groups(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_groups_group_id ON user_groups(group_id);
+CREATE INDEX IF NOT EXISTS idx_group_policies_group_id ON group_policies(group_id);


### PR DESCRIPTION
## Summary
- Implements **IAM User Groups** (GitHub issue #608) — adds user groups as a new IAM primitive for organizing users and assigning policies collectively
- Adds `groups`, `user_groups`, and `group_policies` database tables via migration 114
- Adds `Group`, `UserGroup`, and `GroupPolicy` domain models
- Adds group CRUD operations, membership management (add/remove user from group), and group-policy attachment/detachment at the repository, service, and handler layers
- Integrates group policies into the RBAC authorization flow via `checkGroupIAMPolicies()` — group policies are evaluated after user-attached and role-attached policies
- Adds HTTP endpoints: `POST/GET/PUT/DELETE /iam/groups`, `POST/DELETE/GET /iam/groups/:id/members/:userId`, `POST/DELETE/GET /iam/groups/:id/policies/:policyId`

## Test plan
- [ ] Run migration: `goose postgres \"postgres://...\" up`
- [ ] Create a group: `POST /iam/groups` with `{\"name\": \"engineering\"}`
- [ ] Add user to group: `POST /iam/groups/{id}/members/{userId}`
- [ ] Attach policy to group: `POST /iam/groups/{id}/policies/{policyId}`
- [ ] Verify user inherits group-attached policy permissions via RBAC authorization
- [ ] Remove user from group and verify access is revoked
- [ ] Run existing tests: `go test ./internal/core/services/... ./internal/repositories/postgres/...` (note: mocks will need regeneration for new interface methods)