### PR TITLE
fix #220: remove redundant ctx check in healing_worker

### DIFF
--- a/internal/workers/healing_worker.go
+++ b/internal/workers/healing_worker.go
@@ -109,13 +109,6 @@ func (w *HealingWorker) healERRORInstances(ctx context.Context) {
 			case <-timer.C:
 			}
 
-			// Check context cancellation again after delay
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-
 			w.logger.Info("initiating healing restart", "instance_id", id)
 			if err := w.instSvc.StopInstance(hCtx, id); err != nil {
 				w.logger.Warn("healing: stop failed", "instance_id", id, "error", err)


### PR DESCRIPTION
## Summary
- Remove redundant post-timer context cancellation check in healing worker
- The goroutine now proceeds with healing after the delay unless the parent Run() loop explicitly stops it via reconcileWG.Wait()
- The defer timer.Stop() ensures timer cleanup on all return paths

## Test plan
- [x] Unit tests pass (TestHealingWorker)
- [x] Build succeeds

Fixes #220