### PR TITLE
fix: use context.WithoutCancel to prevent job cancellation on worker shutdown (Issue #187)

### DIFF
--- a/internal/workers/pipeline_worker.go
+++ b/internal/workers/pipeline_worker.go
@@ -108,7 +108,7 @@ func (w *PipelineWorker) Run(ctx context.Context, wg *sync.WaitGroup) {
 			sem <- struct{}{}
 			go func(m *ports.DurableMessage, j domain.BuildJob) {
 				defer func() { <-sem }()
-				w.processJob(ctx, m, j)
+				w.processJob(context.WithoutCancel(ctx), m, j)
 			}(msg, job)
 		}
 	}


### PR DESCRIPTION
## Summary
- Use `context.WithoutCancel(ctx)` in pipeline worker goroutine so in-flight jobs are not cancelled when `Run()` exits
- This preserves `ctx.Deadline()` and `ctx.Values()` while removing the parent's cancellation signal

## Test plan
- [x] `go build ./internal/workers/...` — compiles
- [x] `go test ./internal/workers/... -run Pipeline` — tests pass

Fixes #187