### PR TITLE
fix: prevent path traversal in storage handler

### DIFF
--- a/internal/handlers/helper.go
+++ b/internal/handlers/helper.go
@@ -56,7 +56,7 @@ func getBucketAndKeyRequired(c *gin.Context) (bucket, key string, ok bool) {
 	}
 
 	// Prevent path traversal attacks (e.g., "../../../etc/passwd")
-	if strings.Contains(key, "..") {
+	if strings.Contains(key, "..") || strings.Contains(key, "/") || strings.Contains(key, "\\") {
 		httputil.Error(c, errors.New(errors.InvalidInput, "invalid key"))
 		return "", "", false
 	}

--- a/internal/handlers/helper.go
+++ b/internal/handlers/helper.go
@@ -2,6 +2,8 @@
 package httphandlers
 
 import (
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/poyrazk/thecloud/internal/errors"
@@ -50,6 +52,12 @@ func getBucketAndKeyRequired(c *gin.Context) (bucket, key string, ok bool) {
 	key = c.Param("key")
 	if key == "" {
 		httputil.Error(c, errors.New(errors.InvalidInput, "key is required"))
+		return "", "", false
+	}
+
+	// Prevent path traversal attacks (e.g., "../../../etc/passwd")
+	if strings.Contains(key, "..") {
+		httputil.Error(c, errors.New(errors.InvalidInput, "invalid key"))
 		return "", "", false
 	}
 

--- a/internal/handlers/helper.go
+++ b/internal/handlers/helper.go
@@ -56,7 +56,8 @@ func getBucketAndKeyRequired(c *gin.Context) (bucket, key string, ok bool) {
 	}
 
 	// Prevent path traversal attacks (e.g., "../../../etc/passwd")
-	if strings.Contains(key, "..") || strings.Contains(key, "/") || strings.Contains(key, "\\") {
+	// Note: Gin glob pattern *key captures the path with leading /, so we only check for ".."
+	if strings.Contains(key, "..") {
 		httputil.Error(c, errors.New(errors.InvalidInput, "invalid key"))
 		return "", "", false
 	}

--- a/internal/handlers/helper_test.go
+++ b/internal/handlers/helper_test.go
@@ -120,4 +120,28 @@ func TestGetBucketAndKeyRequired(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, w.Code)
 		assert.Contains(t, w.Body.String(), "key is required")
 	})
+
+	t.Run("path traversal rejected", func(t *testing.T) {
+		traversalKeys := []string{
+			"../etc/passwd",
+			"foo/../bar",
+			"foo\\..\\bar",
+			"foo/../../etc/passwd",
+		}
+		for _, key := range traversalKeys {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Params = []gin.Param{
+				{Key: "bucket", Value: testBucket},
+				{Key: "key", Value: key},
+			}
+
+			bucket, key, ok := getBucketAndKeyRequired(c)
+
+			assert.False(t, ok, "key %q should be rejected", key)
+			assert.Empty(t, bucket)
+			assert.Empty(t, key)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		}
+	})
 }


### PR DESCRIPTION
## Summary
- Add path traversal validation in `getBucketAndKeyRequired` helper
- Reject keys containing `..` pattern before reaching storage service
- Protects all handlers: Upload, Download, Delete, InitiateMultipartUpload, ServePresignedDownload, ServePresignedUpload

## Fixes
Fixes #683

## Test plan
- [x] go build ./internal/handlers/...
- [x] go test ./internal/handlers/... -v