### PR TITLE
fix: guard nil/empty/oob accesses across services and handlers (#684 …

### DIFF
--- a/internal/core/services/cluster.go
+++ b/internal/core/services/cluster.go
@@ -145,6 +145,9 @@ func (s *ClusterService) CreateCluster(ctx context.Context, params ports.CreateC
 	}
 
 	// Persist Node Group
+	if len(cluster.NodeGroups) == 0 {
+		return nil, errors.New(errors.Internal, "cluster has no node groups to persist")
+	}
 	if err := s.repo.AddNodeGroup(ctx, &cluster.NodeGroups[0]); err != nil {
 		// Rollback: delete the orphan cluster to avoid leaving a cluster
 		// without its required default nodegroup

--- a/internal/csi/driver.go
+++ b/internal/csi/driver.go
@@ -145,7 +145,7 @@ func (d *Driver) Stop() {
 func parseEndpoint(ep string) (string, string, error) {
 	if strings.HasPrefix(ep, "unix://") || strings.HasPrefix(ep, "tcp://") {
 		parts := strings.SplitN(ep, "://", 2)
-		if parts[1] != "" {
+		if len(parts) == 2 && parts[1] != "" {
 			return parts[0], parts[1], nil
 		}
 	}

--- a/internal/csi/driver_test.go
+++ b/internal/csi/driver_test.go
@@ -545,6 +545,21 @@ func TestDriver_Utils(t *testing.T) {
 		_, _, err = parseEndpoint("invalid")
 		require.Error(t, err)
 	})
+
+	t.Run("parseEndpoint bad inputs do not panic", func(t *testing.T) {
+		// Regression for #651: previously read parts[1] without bounds check.
+		// All of these inputs that previously could panic must now return
+		// an error instead.
+		for _, in := range []string{"", "unix", "tcp", "unix://", "tcp://", "http://x"} {
+			_, _, err := parseEndpoint(in)
+			require.Errorf(t, err, "expected error for %q", in)
+		}
+
+		s, a, err := parseEndpoint("tcp://127.0.0.1:9000")
+		require.NoError(t, err)
+		assert.Equal(t, "tcp", s)
+		assert.Equal(t, "127.0.0.1:9000", a)
+	})
 }
 
 func TestLinuxMounter_Implementation(t *testing.T) {

--- a/internal/handlers/instance_handler.go
+++ b/internal/handlers/instance_handler.go
@@ -183,9 +183,10 @@ func (h *InstanceHandler) mapLaunchRequest(req LaunchRequest) (*uuid.UUID, *uuid
 
 	if req.SubnetID != "" {
 		id, err := uuid.Parse(req.SubnetID)
-		if err == nil {
-			subnetUUID = &id
+		if err != nil {
+			return nil, nil, nil, errors.New(errors.InvalidInput, "invalid subnet_id format")
 		}
+		subnetUUID = &id
 	}
 
 	volumes := make([]domain.VolumeAttachment, 0, len(req.Volumes))

--- a/internal/handlers/storage_handler.go
+++ b/internal/handlers/storage_handler.go
@@ -184,6 +184,10 @@ func (h *StorageHandler) Download(c *gin.Context) {
 		httputil.Error(c, err)
 		return
 	}
+	if obj == nil || reader == nil {
+		httputil.Error(c, errors.New(errors.NotFound, "object not found"))
+		return
+	}
 	defer func() { _ = reader.Close() }()
 
 	// Set headers

--- a/internal/storage/coordinator/service.go
+++ b/internal/storage/coordinator/service.go
@@ -82,6 +82,9 @@ func (c *Coordinator) SyncClusterState(ctx context.Context) {
 	for _, cl := range c.clients {
 		clients = append(clients, cl)
 	}
+	if len(clients) == 0 {
+		return
+	}
 
 	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(clients))))
 	if err != nil {


### PR DESCRIPTION
Guards nil/empty/out-of-bounds accesses across services and handlers:

- cluster: bounds-check NodeGroups before AddNodeGroup (Fixes #684)
- storage_handler.Download: nil-check obj and reader before header writes (Fixes #668)
- instance_handler: surface invalid subnet_id parse errors (Fixes #669)
- coordinator.SyncClusterState: return early when clients slice is empty (Fixes #648)
- csi parseEndpoint: require SplitN to return 2 parts, add regression tests (Fixes #651)