### PR TITLE
fix(instance): rollback DB record when provision enqueue fails (#686)

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           go-version: '1.25.0'
 
-<<<<<<< HEAD
       - name: Generate TLS test certs
         run: |
           mkdir -p cmd/storage-node/testdata/tls internal/api/setup/testdata/tls

--- a/internal/core/services/instance.go
+++ b/internal/core/services/instance.go
@@ -243,6 +243,12 @@ func (s *InstanceService) LaunchInstance(ctx context.Context, params ports.Launc
 	s.logger.Info("enqueueing provision job", "instance_id", inst.ID, "queue", "provision_queue", "tenant_id", inst.TenantID)
 	if err := s.taskQueue.Enqueue(ctx, "provision_queue", job); err != nil {
 		s.logger.Error("failed to enqueue provision job", "instance_id", inst.ID, "error", err)
+		// Rollback the DB record so we do not leave an orphan STARTING instance
+		// that no worker will ever advance.
+		if delErr := s.repo.Delete(ctx, inst.ID); delErr != nil {
+			s.logger.Error("failed to rollback orphaned instance record",
+				"instance_id", inst.ID, "error", delErr)
+		}
 		// Rollback quota reservation on enqueue failure
 		_ = s.tenantSvc.DecrementUsage(ctx, tenantID, "vcpus", it.VCPUs)
 		_ = s.tenantSvc.DecrementUsage(ctx, tenantID, "memory", it.MemoryMB/1024)
@@ -313,6 +319,12 @@ func (s *InstanceService) LaunchInstanceWithOptions(ctx context.Context, opts po
 
 	if err := s.taskQueue.Enqueue(ctx, "provision_queue", job); err != nil {
 		s.logger.Error("failed to enqueue provision job", "instance_id", inst.ID, "error", err)
+		// Rollback the DB record so we do not leave an orphan STARTING instance
+		// that no worker will ever advance.
+		if delErr := s.repo.Delete(ctx, inst.ID); delErr != nil {
+			s.logger.Error("failed to rollback orphaned instance record",
+				"instance_id", inst.ID, "error", delErr)
+		}
 		return nil, errors.Wrap(errors.Internal, "failed to enqueue provisioning task", err)
 	}
 

--- a/internal/core/services/instance_unit_test.go
+++ b/internal/core/services/instance_unit_test.go
@@ -76,6 +76,7 @@ func (m *MockDNSService) UnregisterInstance(ctx context.Context, id uuid.UUID) e
 
 func TestInstanceService_Unit(t *testing.T) {
 	t.Run("LaunchInstance", testInstanceServiceLaunchInstanceUnit)
+	t.Run("LaunchInstanceWithOptions", testInstanceServiceLaunchInstanceWithOptionsUnit)
 	t.Run("Lifecycle", testInstanceServiceLifecycleUnit)
 	t.Run("Exec", testInstanceServiceExecUnit)
 	t.Run("ProvisionFinalize", testInstanceServiceProvisionFinalize)
@@ -219,6 +220,114 @@ func testInstanceServiceLaunchInstanceUnit(t *testing.T) {
 		_, err := svc.LaunchInstance(ctx, params)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "quota exceeded")
+	})
+
+	t.Run("EnqueueFails_RollbackDBRecord", func(t *testing.T) {
+		params := ports.LaunchParams{
+			Name:         "enqueue-fail",
+			Image:        "alpine",
+			InstanceType: "t2.micro",
+		}
+
+		rbacSvc.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+		typeRepo.On("GetByID", mock.Anything, "t2.micro").Return(&domain.InstanceType{
+			ID: "t2.micro", VCPUs: 1, MemoryMB: 1024,
+		}, nil).Once()
+		tenantSvc.On("CheckQuota", mock.Anything, tenantID, "instances", 1).Return(nil).Once()
+		tenantSvc.On("CheckQuota", mock.Anything, tenantID, "vcpus", 1).Return(nil).Once()
+		tenantSvc.On("CheckQuota", mock.Anything, tenantID, "memory", 1).Return(nil).Once()
+		tenantSvc.On("IncrementUsage", mock.Anything, tenantID, "vcpus", 1).Return(nil).Once()
+		tenantSvc.On("IncrementUsage", mock.Anything, tenantID, "memory", 1).Return(nil).Once()
+
+		instID := uuid.New()
+		repo.On("Create", mock.Anything, mock.MatchedBy(func(i *domain.Instance) bool {
+			return i.Name == params.Name && i.UserID == userID
+		})).Run(func(args mock.Arguments) {
+			inst := args.Get(1).(*domain.Instance)
+			inst.ID = instID
+		}).Return(nil).Once()
+
+		taskQueue.On("Enqueue", mock.Anything, "provision_queue", mock.Anything).Return(errors.New("queue unavailable")).Once()
+		repo.On("Delete", mock.Anything, mock.MatchedBy(func(id uuid.UUID) bool {
+			return id == instID
+		})).Return(nil).Once()
+		tenantSvc.On("DecrementUsage", mock.Anything, tenantID, "vcpus", 1).Return(nil).Once()
+		tenantSvc.On("DecrementUsage", mock.Anything, tenantID, "memory", 1).Return(nil).Once()
+
+		_, err := svc.LaunchInstance(ctx, params)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "enqueue")
+		repo.AssertExpectations(t)
+	})
+}
+
+func testInstanceServiceLaunchInstanceWithOptionsUnit(t *testing.T) {
+	repo := new(MockInstanceRepo)
+	vpcRepo := new(MockVpcRepo)
+	subnetRepo := new(MockSubnetRepo)
+	volRepo := new(MockVolumeRepo)
+	typeRepo := new(MockInstanceTypeRepo)
+	compute := new(MockComputeBackend)
+	network := new(MockNetworkBackend)
+	rbacSvc := new(MockRBACService)
+	eventSvc := new(MockEventService)
+	auditSvc := new(MockAuditService)
+	dnsSvc := new(MockDNSService)
+	taskQueue := new(MockTaskQueue)
+	tenantSvc := new(MockTenantService)
+	sshKeySvc := new(MockSSHKeyService)
+
+	svc := services.NewInstanceService(services.InstanceServiceParams{
+		Repo:             repo,
+		VpcRepo:          vpcRepo,
+		SubnetRepo:       subnetRepo,
+		VolumeRepo:       volRepo,
+		InstanceTypeRepo: typeRepo,
+		Compute:          compute,
+		Network:          network,
+		RBAC:             rbacSvc,
+		EventSvc:         eventSvc,
+		AuditSvc:         auditSvc,
+		DNSSvc:           dnsSvc,
+		TaskQueue:        taskQueue,
+		TenantSvc:        tenantSvc,
+		SSHKeySvc:        sshKeySvc,
+		DockerNetwork:    "bridge",
+		Logger:           slog.Default(),
+	})
+
+	ctx := context.Background()
+	userID := uuid.New()
+	tenantID := uuid.New()
+	ctx = appcontext.WithUserID(ctx, userID)
+	ctx = appcontext.WithTenantID(ctx, tenantID)
+
+	t.Run("EnqueueFails_RollbackDBRecord", func(t *testing.T) {
+		opts := ports.CreateInstanceOptions{
+			Name:      "opts-rollback",
+			ImageName: "alpine",
+			Ports:     []string{"8080:80"},
+		}
+
+		rbacSvc.On("Authorize", mock.Anything, userID, tenantID, domain.PermissionInstanceLaunch, "*").Return(nil).Once()
+
+		instID := uuid.New()
+		repo.On("Create", mock.Anything, mock.MatchedBy(func(i *domain.Instance) bool {
+			return i.Name == opts.Name
+		})).Run(func(args mock.Arguments) {
+			inst := args.Get(1).(*domain.Instance)
+			inst.ID = instID
+		}).Return(nil).Once()
+
+		taskQueue.On("Enqueue", mock.Anything, "provision_queue", mock.Anything).Return(errors.New("queue unavailable")).Once()
+		repo.On("Delete", mock.Anything, mock.MatchedBy(func(id uuid.UUID) bool {
+			return id == instID
+		})).Return(nil).Once()
+
+		_, err := svc.LaunchInstanceWithOptions(ctx, opts)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "enqueue")
+		repo.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
If taskQueue.Enqueue fails after repo.Create, the instance row stayed in STARTING forever with no worker to advance it. Both LaunchInstance and LaunchInstanceWithOptions now delete the row before returning the enqueue error (logging the rollback error if the delete itself fails).\n\nCloses #686.\n\n## Changes\n- Added rollback Delete on Enqueue failure in LaunchInstance and LaunchInstanceWithOptions\n- Added unit tests for both rollback paths