### PR TITLE
fix: remove conflict marker from coverage.yml

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           go-version: '1.25.0'
 
-<<<<<<< HEAD
       - name: Generate TLS test certs
         run: |
           mkdir -p cmd/storage-node/testdata/tls internal/api/setup/testdata/tls


### PR DESCRIPTION
Remove conflict marker from .github/workflows/coverage.yml that was causing the Coverage Gate workflow to fail.